### PR TITLE
Fix #422: Enable PARTY_INFO attribute for mobile API

### DIFF
--- a/powerauth-mtoken-model/src/main/java/io/getlime/security/powerauth/lib/mtoken/model/entity/PartyInfo.java
+++ b/powerauth-mtoken-model/src/main/java/io/getlime/security/powerauth/lib/mtoken/model/entity/PartyInfo.java
@@ -1,0 +1,99 @@
+package io.getlime.security.powerauth.lib.mtoken.model.entity;
+
+/**
+ * Class representing party information.
+ *
+ * @author Roman Strobl, roman.strobl@lime-company.eu
+ */
+public class PartyInfo {
+
+    private String logoUrl;
+    private String name;
+    private String description;
+    private String websiteUrl;
+
+    /**
+     * Default constructor.
+     */
+    public PartyInfo() {
+    }
+
+    /**
+     * Constructor with party details.
+     * @param logoUrl URL with party logo.
+     * @param name Party name.
+     * @param description Party description.
+     * @param websiteUrl Party website URL.
+     */
+    public PartyInfo(String logoUrl, String name, String description, String websiteUrl) {
+        this.logoUrl = logoUrl;
+        this.name = name;
+        this.description = description;
+        this.websiteUrl = websiteUrl;
+    }
+
+    /**
+     * Get URL with party logo.
+     * @return URL with party logo.
+     */
+    public String getLogoUrl() {
+        return logoUrl;
+    }
+
+    /**
+     * Set URL with party logo.
+     * @param logoUrl URL with party logo.
+     */
+    public void setLogoUrl(String logoUrl) {
+        this.logoUrl = logoUrl;
+    }
+
+    /**
+     * Get party name.
+     * @return Party name.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Set party name.
+     * @param name Party name.
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Get party description.
+     * @return Party description.
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Set party description.
+     * @param description Party description.
+     */
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+     * Get party website URL.
+     * @return Party website URL.
+     */
+    public String getWebsiteUrl() {
+        return websiteUrl;
+    }
+
+    /**
+     * Set party website URL.
+     * @param websiteUrl Party website URL.
+     */
+    public void setWebsiteUrl(String websiteUrl) {
+        this.websiteUrl = websiteUrl;
+    }
+
+}

--- a/powerauth-mtoken-model/src/main/java/io/getlime/security/powerauth/lib/mtoken/model/entity/attributes/Attribute.java
+++ b/powerauth-mtoken-model/src/main/java/io/getlime/security/powerauth/lib/mtoken/model/entity/attributes/Attribute.java
@@ -30,7 +30,7 @@ public class Attribute {
         KEY_VALUE,
         NOTE,
         HEADING,
-        PARTY
+        PARTY_INFO
     }
 
     protected Type type;

--- a/powerauth-mtoken-model/src/main/java/io/getlime/security/powerauth/lib/mtoken/model/entity/attributes/PartyAttribute.java
+++ b/powerauth-mtoken-model/src/main/java/io/getlime/security/powerauth/lib/mtoken/model/entity/attributes/PartyAttribute.java
@@ -15,30 +15,52 @@
  */
 package io.getlime.security.powerauth.lib.mtoken.model.entity.attributes;
 
+import io.getlime.security.powerauth.lib.mtoken.model.entity.PartyInfo;
+
 /**
  * Attribute representing a party.
  *
  * @author Roman Strobl, roman.strobl@lime-company.eu
  */
-public class PartyAttribute extends KeyValueAttribute {
+public class PartyAttribute extends Attribute {
+
+    private PartyInfo partyInfo;
 
     /**
      * Default constructor.
      */
     public PartyAttribute() {
         super();
-        this.setType(Type.PARTY);
+        this.setType(Type.PARTY_INFO);
     }
 
     /**
      * Constructor with all details.
      * @param id Attribute ID.
      * @param label Heading text.
+     * @param partyInfo Party information.
      */
-    public PartyAttribute(String id, String label) {
+    public PartyAttribute(String id, String label, PartyInfo partyInfo) {
         this();
         this.id = id;
         this.label = label;
+        this.partyInfo = partyInfo;
+    }
+
+    /**
+     * Get party info.
+     * @return Party info.
+     */
+    public PartyInfo getPartyInfo() {
+        return partyInfo;
+    }
+
+    /**
+     * Set party info.
+     * @param partyInfo Party info.
+     */
+    public void setPartyInfo(PartyInfo partyInfo) {
+        this.partyInfo = partyInfo;
     }
 
 }

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/model/converter/AttributeConverter.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/model/converter/AttributeConverter.java
@@ -15,6 +15,7 @@
  */
 package io.getlime.security.powerauth.lib.webflow.authentication.mtoken.model.converter;
 
+import io.getlime.security.powerauth.lib.mtoken.model.entity.PartyInfo;
 import io.getlime.security.powerauth.lib.mtoken.model.entity.attributes.*;
 import io.getlime.security.powerauth.lib.nextstep.model.entity.attribute.*;
 
@@ -48,16 +49,29 @@ public class AttributeConverter {
             }
             case PARTY_INFO: {
                 OperationPartyInfoFieldAttribute attr = (OperationPartyInfoFieldAttribute) input;
-                // TODO - we use KeyValueAttribute until mobile token supports PartyInfo
-                if (attr.getPartyInfo() != null) {
-                    return new KeyValueAttribute(attr.getId(), attr.getLabel(), attr.getPartyInfo().getName());
-                }
-                return new KeyValueAttribute(input.getId(), input.getLabel(), null);
+                return new PartyAttribute(attr.getId(), attr.getLabel(), fromPartyInfo(attr.getPartyInfo()));
             }
             default: {
                 return new KeyValueAttribute(input.getId(), input.getLabel(), null);
             }
         }
+    }
+
+    /**
+     * Convert PartyInfo from Next Step model to mToken model.
+     * @param input Input PartyInfo.
+     * @return Converted PartyInfo.
+     */
+    private PartyInfo fromPartyInfo(io.getlime.security.powerauth.lib.nextstep.model.entity.PartyInfo input) {
+        if (input == null) {
+            return null;
+        }
+        PartyInfo partyInfo = new PartyInfo();
+        partyInfo.setLogoUrl(input.getLogoUrl());
+        partyInfo.setName(input.getName());
+        partyInfo.setDescription(input.getDescription());
+        partyInfo.setWebsiteUrl(input.getWebsiteUrl());
+        return partyInfo;
     }
 
 }


### PR DESCRIPTION
I switch the PARTY_INFO attribute in mobile API from KEY_VALUE.

Remarks:
- The attribute name is PARTY_INFO, not PARTY to keep the enums synced accross different models.
- I don't see value in extending KeyValueAttribute for this attribute, because this would mean partial duplication of value and furthemore old version of mToken does not display PARTY_INFO attribute (the attribute is completely ignored and not displayed, so the value from KeyValueAttribute would be ignored). @petrdvorak if you feel we should extend KeyValueAttribute even under these circumstances let me know, I realize you wanted to do this for all new form data attributes.

New attribute in JSON response:
```
          {
            "type": "PARTY_INFO",
            "id": "operation.partyInfo",
            "label": "Application",
            "partyInfo": {
              "logoUrl": "https://.../logo.svg",
              "name": "XYZ",
              "description": "XYZ description",
              "websiteUrl": "https://..."
            }
          }
```