### PR TITLE
Fix #439: Do not log invalid device as error for mobile token

### DIFF
--- a/powerauth-mtoken-model/src/main/java/io/getlime/security/powerauth/lib/mtoken/model/enumeration/ErrorCode.java
+++ b/powerauth-mtoken-model/src/main/java/io/getlime/security/powerauth/lib/mtoken/model/enumeration/ErrorCode.java
@@ -36,6 +36,16 @@ public class ErrorCode {
     public static final String INVALID_REQUEST              = "INVALID_REQUEST";
 
     /**
+     * Error code for situation when an activation is not active.
+     */
+    public static final String ACTIVATION_NOT_ACTIVE        = "ACTIVATION_NOT_ACTIVE";
+
+    /**
+     * Error code for situation when an activation is not configured.
+     */
+    public static final String ACTIVATION_NOT_CONFIGURED    = "ACTIVATION_NOT_CONFIGURED";
+
+    /**
      * Error code for situation when an invalid activation / device is
      * attempted for operation manipulation.
      */

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileAppApiController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileAppApiController.java
@@ -134,7 +134,7 @@ public class MobileAppApiController extends AuthMethodController<MobileTokenAuth
 
             // Verify that the activation ID from context matches configured activation ID for given user.
             if (!verifyActivationId(activationId, userId)) {
-                throw new InvalidActivationException();
+                throw new InvalidActivationException(activationId);
             }
 
             // Get the list of operations for given user
@@ -204,7 +204,7 @@ public class MobileAppApiController extends AuthMethodController<MobileTokenAuth
 
             // Verify that the activation ID from context matches configured activation ID for given user.
             if (!verifyActivationId(activationId, userId)) {
-                throw new InvalidActivationException();
+                throw new InvalidActivationException(activationId);
             }
 
             final GetOperationDetailResponse operation = getOperation(operationId);
@@ -253,7 +253,7 @@ public class MobileAppApiController extends AuthMethodController<MobileTokenAuth
 
             // Verify that the activation ID from context matches configured activation ID for given user.
             if (!verifyActivationId(activationId, userId)) {
-                throw new InvalidActivationException();
+                throw new InvalidActivationException(activationId);
             }
 
             final UpdateOperationResponse updateOperationResponse = cancelAuthorization(operationId, userId, OperationCancelReason.fromString(request.getRequestObject().getReason()), null);

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOfflineController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOfflineController.java
@@ -115,7 +115,7 @@ public class MobileTokenOfflineController extends AuthMethodController<QRCodeAut
         final GetOperationDetailResponse operation = getOperation();
         Logger.getLogger(this.getClass().getName()).log(Level.INFO, "Step authentication started, operation ID: {0}, authentication method: {1}", new String[] {operation.getOperationId(), getAuthMethodName().toString()});
         checkOperationExpiration(operation);
-        // nonce and dataHash are received from UI - they were stored together with the QR code
+        // nonce is received from the UI - it was stored together with the QR code
         String nonce = request.getNonce();
         // data for signature is {OPERATION_ID}&{OPERATION_DATA}
         String data = operation.getOperationId() + '&' + operation.getOperationData();

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/PushRegistrationController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/PushRegistrationController.java
@@ -22,7 +22,6 @@ import io.getlime.push.client.PushServerClient;
 import io.getlime.push.client.PushServerClientException;
 import io.getlime.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
 import io.getlime.security.powerauth.lib.mtoken.model.request.PushRegisterRequest;
-import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.errorhandling.exception.InvalidActivationException;
 import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.errorhandling.exception.InvalidRequestObjectException;
 import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.errorhandling.exception.MobileAppApiException;
 import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.errorhandling.exception.PushRegistrationFailedException;
@@ -149,7 +148,7 @@ public class PushRegistrationController {
         // Verify that applicationId and activationId are set
         if (applicationId == null || activationId == null) {
             Logger.getLogger(this.getClass().getName()).log(Level.SEVERE, "Invalid activation in push registration, user ID: {0}", apiAuthentication.getUserId());
-            throw new InvalidActivationException();
+            throw new PushRegistrationFailedException();
         }
 
         // Register the device and return response

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/errorhandling/MobileApiExceptionResolver.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/errorhandling/MobileApiExceptionResolver.java
@@ -22,9 +22,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.exception.OperationAlrea
 import io.getlime.security.powerauth.lib.nextstep.model.exception.OperationAlreadyFailedException;
 import io.getlime.security.powerauth.lib.nextstep.model.exception.OperationAlreadyFinishedException;
 import io.getlime.security.powerauth.lib.webflow.authentication.exception.OperationTimeoutException;
-import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.errorhandling.exception.InvalidActivationException;
-import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.errorhandling.exception.InvalidRequestObjectException;
-import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.errorhandling.exception.PushRegistrationFailedException;
+import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.errorhandling.exception.*;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
@@ -76,6 +74,29 @@ public class MobileApiExceptionResolver {
     }
 
     /**
+     * Exception handler for activation not active exception.
+     * @param t Throwable.
+     * @return Response with error details.
+     */
+    @ExceptionHandler(ActivationNotActiveException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public @ResponseBody ErrorResponse handleActivationNotActiveException(Throwable t) {
+        return error(ErrorCode.ACTIVATION_NOT_ACTIVE, t);
+    }
+
+
+    /**
+     * Exception handler for activation not configured exception.
+     * @param t Throwable.
+     * @return Response with error details.
+     */
+    @ExceptionHandler(ActivationNotConfiguredException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public @ResponseBody ErrorResponse handleActivationNotConfiguredException(Throwable t) {
+        return error(ErrorCode.ACTIVATION_NOT_CONFIGURED, t);
+    }
+
+    /**
      * Exception handler for invalid activation exception.
      * @param t Throwable.
      * @return Response with error details.
@@ -83,7 +104,9 @@ public class MobileApiExceptionResolver {
     @ExceptionHandler(InvalidActivationException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public @ResponseBody ErrorResponse handleInvalidActivationException(Throwable t) {
-        return error(ErrorCode.INVALID_ACTIVATION, t);
+        // Special handling of invalid activation exception because this is a very common error
+        Logger.getLogger(this.getClass().getName()).log(Level.INFO, t.getMessage());
+        return new ErrorResponse(new Error(ErrorCode.INVALID_ACTIVATION, t.getMessage()));
     }
 
     /**

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/errorhandling/exception/ActivationNotActiveException.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/errorhandling/exception/ActivationNotActiveException.java
@@ -22,7 +22,7 @@ package io.getlime.security.powerauth.lib.webflow.authentication.mtoken.errorhan
  */
 public class ActivationNotActiveException extends MobileAppApiException {
 
-    public ActivationNotActiveException() {
-        super("Activation is not active in Mobile Token API component.");
+    public ActivationNotActiveException(String activationId) {
+        super("Activation is not active in Mobile Token API component: "+activationId);
     }
 }

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/errorhandling/exception/ActivationNotConfiguredException.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/errorhandling/exception/ActivationNotConfiguredException.java
@@ -20,9 +20,9 @@ package io.getlime.security.powerauth.lib.webflow.authentication.mtoken.errorhan
  *
  * @author Roman Strobl, roman.strobl@lime-company.eu
  */
-public class ActivationNotAvailableException extends MobileAppApiException {
+public class ActivationNotConfiguredException extends MobileAppApiException {
 
-    public ActivationNotAvailableException() {
+    public ActivationNotConfiguredException() {
         super("Activation is not configured in Mobile Token API component.");
     }
 }

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/errorhandling/exception/InvalidActivationException.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/errorhandling/exception/InvalidActivationException.java
@@ -22,7 +22,7 @@ package io.getlime.security.powerauth.lib.webflow.authentication.mtoken.errorhan
  */
 public class InvalidActivationException extends MobileAppApiException {
 
-    public InvalidActivationException() {
-        super("Invalid activation found in Mobile Token API component.");
+    public InvalidActivationException(String activationId) {
+        super("Invalid activation configured in Mobile Token API component: "+activationId);
     }
 }


### PR DESCRIPTION
This PR fixes:
- Fix #439: Do not log invalid device as error for mobile token
- Added missing error handling (for various activation states)
- Better error messages (included activation ID in messages)
- Fixed obsolete comment for offline signature verification