### PR TITLE
Fix #450: Invalid language in frontend vs. backend

### DIFF
--- a/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/controller/HomeController.java
+++ b/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/controller/HomeController.java
@@ -121,7 +121,7 @@ public class HomeController {
 
         model.put("title", webFlowConfig.getPageTitle());
         model.put("stylesheet", webFlowConfig.getCustomStyleSheetUrl());
-        model.put("lang", LocaleContextHolder.getLocale().toString());
+        model.put("lang", LocaleContextHolder.getLocale().getLanguage());
         // JSON objects with i18n messages are inserted into the model to provide localization for the frontend
         model.put("i18n_CS", i18nService.generateMessages(new Locale("cs")));
         model.put("i18n_EN", i18nService.generateMessages(Locale.ENGLISH));


### PR DESCRIPTION
Language is now set correctly without country suffix.