### PR TITLE
Fix #471: Cancel redirect does not work on Wildfly

### DIFF
--- a/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/controller/HomeController.java
+++ b/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/controller/HomeController.java
@@ -196,7 +196,7 @@ public class HomeController {
         // append error and error_description based on https://www.oauth.com/oauth2-servers/authorization/the-authorization-response
         final String redirectWithError = UriComponentsBuilder.fromUriString(redirectUri)
                 .queryParam("error", "access_denied")
-                .queryParam("error_description", "User canceled authentication request")
+                .queryParam("error_description", "User%20canceled%20authentication%20request")
                 .build()
                 .toUriString();
         logger.info("The /authenticate/cancel request succeeded");


### PR DESCRIPTION
The cancel redirect issue on Wildfly was caused by spaces in the redirect URL.