### PR TITLE
Fix #486: Do not expose service details when REST client fails

### DIFF
--- a/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/entity/DataAdapterError.java
+++ b/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/entity/DataAdapterError.java
@@ -38,6 +38,7 @@ public class DataAdapterError extends Error {
         public static final String INPUT_INVALID = "INPUT_INVALID";
         public static final String OPERATION_CONTEXT_INVALID = "OPERATION_CONTEXT_INVALID";
         public static final String REMOTE_ERROR = "REMOTE_ERROR";
+        public static final String COMMUNICATION_ERROR = "COMMUNICATION_ERROR";
     }
 
     /**

--- a/powerauth-nextstep-client/src/main/java/io/getlime/security/powerauth/lib/nextstep/client/NextStepClient.java
+++ b/powerauth-nextstep-client/src/main/java/io/getlime/security/powerauth/lib/nextstep/client/NextStepClient.java
@@ -470,7 +470,7 @@ public class NextStepClient {
      * @param ex Exception to handle.
      */
     private NextStepServiceException handleResourceAccessError(ResourceAccessException ex) {
-        Error error = new Error(NextStepServiceException.ERROR_COMMUNICATION, ex.getMessage());
+        Error error = new Error(NextStepServiceException.COMMUNICATION_ERROR, ex.getMessage());
         return new NextStepServiceException(ex, error);
     }
 
@@ -505,7 +505,7 @@ public class NextStepClient {
         } catch (IOException ex2) {
             Error error;
             if (ex.getStatusCode() != HttpStatus.OK) {
-                error = new Error(NextStepServiceException.ERROR_COMMUNICATION, "HTTP error occurred: " + ex.getMessage());
+                error = new Error(NextStepServiceException.COMMUNICATION_ERROR, "HTTP error occurred: " + ex.getMessage());
                 return new NextStepServiceException(ex, error);
             } else {
                 error = new Error(Error.Code.ERROR_GENERIC, "IO error occurred: " + ex2.getMessage());

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/exception/NextStepServiceException.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/exception/NextStepServiceException.java
@@ -25,7 +25,7 @@ import io.getlime.core.rest.model.base.entity.Error;
  */
 public class NextStepServiceException extends Exception {
 
-    public static final String ERROR_COMMUNICATION = "ERROR_COMMUNICATION";
+    public static final String COMMUNICATION_ERROR = "COMMUNICATION_ERROR";
 
     private Error error;
 

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/exception/NextStepServiceException.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/exception/NextStepServiceException.java
@@ -25,6 +25,8 @@ import io.getlime.core.rest.model.base.entity.Error;
  */
 public class NextStepServiceException extends Exception {
 
+    public static final String ERROR_COMMUNICATION = "ERROR_COMMUNICATION";
+
     private Error error;
 
     /**

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OperationController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OperationController.java
@@ -197,6 +197,7 @@ public class OperationController {
     /**
      * Get configurations of all operations.
      *
+     * @param request Get configurations of all operations request.
      * @return Get operation configurations response.
      */
     @RequestMapping(value = "/operation/config/list", method = RequestMethod.POST)

--- a/powerauth-webflow-authentication-form/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/form/controller/FormLoginController.java
+++ b/powerauth-webflow-authentication-form/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/form/controller/FormLoginController.java
@@ -103,9 +103,10 @@ public class FormLoginController extends AuthMethodController<UsernamePasswordAu
                 GetOperationDetailResponse updatedOperation = getOperation();
                 remainingAttemptsNS = updatedOperation.getRemainingAttempts();
             } catch (NextStepServiceException e2) {
-                throw new AuthStepException(e2.getError().getMessage(), e2);
+                logger.error("Error occurred in Next Step server", e);
+                throw new AuthStepException(e2.getError().getMessage(), e2, "error.communication");
             }
-            AuthStepException authEx = new AuthStepException(e.getError().getMessage(), e);
+            AuthStepException authEx = new AuthStepException(e.getError().getMessage(), e, "error.communication");
             Integer remainingAttemptsDA = e.getError().getRemainingAttempts();
             Integer remainingAttempts = resolveRemainingAttempts(remainingAttemptsDA, remainingAttemptsNS);
             authEx.setRemainingAttempts(remainingAttempts);
@@ -196,9 +197,10 @@ public class FormLoginController extends AuthMethodController<UsernamePasswordAu
             logger.info("Step result: CANCELED, operation ID: {}, authentication method: {}", operation.getOperationId(), getAuthMethodName().toString());
             return response;
         } catch (NextStepServiceException e) {
+            logger.error("Error occurred in Next Step server", e);
             final UsernamePasswordAuthenticationResponse response = new UsernamePasswordAuthenticationResponse();
             response.setResult(AuthStepResult.AUTH_FAILED);
-            response.setMessage(e.getMessage());
+            response.setMessage("error.communication");
             logger.info("Step result: AUTH_FAILED, authentication method: {}", getAuthMethodName().toString());
             return response;
         }

--- a/powerauth-webflow-authentication-init/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/init/controller/ApiController.java
+++ b/powerauth-webflow-authentication-init/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/init/controller/ApiController.java
@@ -101,8 +101,10 @@ public class ApiController extends AuthMethodController<InitOperationRequest, In
 
         if (operation == null) {
             final String operationName = "login";
-            final GetOperationConfigResponse operationConfig = getOperationConfig(operationName);
-            if (operationConfig == null) {
+            GetOperationConfigResponse operationConfig;
+            try {
+                operationConfig = getOperationConfig(operationName);
+            } catch (AuthStepException e) {
                 logger.error("Operation configuration is missing, operation name: {}", operationName);
                 return failedOperationResponse(null, "operationConfig.missing");
             }

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileAppApiController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileAppApiController.java
@@ -174,6 +174,7 @@ public class MobileAppApiController extends AuthMethodController<MobileTokenAuth
      * Get map of all operation configurations (operation name -> operation configuration).
      * @param operations Operation list.
      * @return Map of operation configurations.
+     * @throws AuthStepException Thrown in case operation configuration query fails.
      */
     private Map<String, GetOperationConfigResponse> getOperationConfigs(List<GetOperationDetailResponse> operations) throws AuthStepException {
         final Map<String, GetOperationConfigResponse> operationConfigs = new HashMap<>();

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileAppApiController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileAppApiController.java
@@ -99,11 +99,10 @@ public class MobileAppApiController extends AuthMethodController<MobileTokenAuth
      * @return Response with list of pending operations.
      * @throws InvalidActivationException Thrown in case activation is not valid.
      * @throws PowerAuthAuthenticationException Thrown in case PowerAuth authentication fails.
-     * @throws OperationNotConfiguredException Thrown in case operation is not configured.
      */
     @RequestMapping(value = "/operation/list/signature", method = RequestMethod.POST)
     @PowerAuth(resourceId = "/operation/list/signature", signatureType = {PowerAuthSignatureTypes.POSSESSION})
-    public @ResponseBody ObjectResponse<OperationListResponse> getOperationList(PowerAuthApiAuthentication apiAuthentication) throws InvalidActivationException, PowerAuthAuthenticationException, OperationNotConfiguredException {
+    public @ResponseBody ObjectResponse<OperationListResponse> getOperationList(PowerAuthApiAuthentication apiAuthentication) throws InvalidActivationException, PowerAuthAuthenticationException {
         return getOperationListImpl(apiAuthentication);
     }
 
@@ -113,7 +112,6 @@ public class MobileAppApiController extends AuthMethodController<MobileTokenAuth
      * @return Response with list of pending operations.
      * @throws InvalidActivationException Thrown in case activation is not valid.
      * @throws PowerAuthAuthenticationException Thrown in case PowerAuth authentication fails.
-     * @throws OperationNotConfiguredException Thrown in case operation is not configured.
      */
     @RequestMapping(value = "/operation/list", method = RequestMethod.POST)
     @PowerAuthToken(signatureType = {
@@ -122,7 +120,7 @@ public class MobileAppApiController extends AuthMethodController<MobileTokenAuth
             PowerAuthSignatureTypes.POSSESSION_KNOWLEDGE,
             PowerAuthSignatureTypes.POSSESSION_KNOWLEDGE_BIOMETRY
     })
-    public @ResponseBody ObjectResponse<OperationListResponse> getOperationListTokens(PowerAuthApiAuthentication apiAuthentication) throws InvalidActivationException, PowerAuthAuthenticationException, OperationNotConfiguredException {
+    public @ResponseBody ObjectResponse<OperationListResponse> getOperationListTokens(PowerAuthApiAuthentication apiAuthentication) throws InvalidActivationException, PowerAuthAuthenticationException {
         return getOperationListImpl(apiAuthentication);
     }
 
@@ -133,7 +131,7 @@ public class MobileAppApiController extends AuthMethodController<MobileTokenAuth
      * @throws InvalidActivationException Thrown in case activation is not valid.
      * @throws PowerAuthAuthenticationException Thrown in case PowerAuth authentication fails.
      */
-    private ObjectResponse<OperationListResponse> getOperationListImpl(PowerAuthApiAuthentication apiAuthentication) throws InvalidActivationException, PowerAuthAuthenticationException, OperationNotConfiguredException {
+    private ObjectResponse<OperationListResponse> getOperationListImpl(PowerAuthApiAuthentication apiAuthentication) throws InvalidActivationException, PowerAuthAuthenticationException {
         if (apiAuthentication != null && apiAuthentication.getUserId() != null) {
             String activationId = apiAuthentication.getActivationId();
             String userId = apiAuthentication.getUserId();

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOfflineController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOfflineController.java
@@ -34,6 +34,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.UpdateOperation
 import io.getlime.security.powerauth.lib.webflow.authentication.configuration.WebFlowServicesConfiguration;
 import io.getlime.security.powerauth.lib.webflow.authentication.controller.AuthMethodController;
 import io.getlime.security.powerauth.lib.webflow.authentication.exception.AuthStepException;
+import io.getlime.security.powerauth.lib.webflow.authentication.exception.CommunicationFailedException;
 import io.getlime.security.powerauth.lib.webflow.authentication.exception.MaxAttemptsExceededException;
 import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.errorhandling.exception.OfflineModeDisabledException;
 import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.errorhandling.exception.OfflineModeInvalidActivationException;
@@ -146,7 +147,8 @@ public class MobileTokenOfflineController extends AuthMethodController<QRCodeAut
             GetOperationDetailResponse updatedOperation = getOperation();
             remainingAttemptsNS = updatedOperation.getRemainingAttempts();
         } catch (NextStepServiceException e) {
-            throw new AuthStepException(e.getError().getMessage(), e);
+            logger.error("Error occurred in Next Step server", e);
+            throw new CommunicationFailedException("Authorization failed due to communication error");
         }
         OfflineModeInvalidAuthCodeException authEx = new OfflineModeInvalidAuthCodeException("Authorization code is invalid.");
         Integer remainingAttempts = resolveRemainingAttempts(remainingAttemptsPA, remainingAttemptsNS);
@@ -312,9 +314,10 @@ public class MobileTokenOfflineController extends AuthMethodController<QRCodeAut
             logger.info("Step result: CANCELED, operation ID: {}, authentication method: {}", operation.getOperationId(), getAuthMethodName().toString());
             return response;
         } catch (NextStepServiceException e) {
+            logger.error("Error occurred in Next Step server", e);
             final QRCodeAuthenticationResponse response = new QRCodeAuthenticationResponse();
             response.setResult(AuthStepResult.AUTH_FAILED);
-            response.setMessage(e.getMessage());
+            response.setMessage("error.communication");
             logger.info("Step result: AUTH_FAILED, authentication method: {}", getAuthMethodName().toString());
             return response;
         }

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOnlineController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOnlineController.java
@@ -249,7 +249,7 @@ public class MobileTokenOnlineController extends AuthMethodController<MobileToke
         } catch (NextStepServiceException e) {
             final MobileTokenAuthenticationResponse response = new MobileTokenAuthenticationResponse();
             response.setResult(AuthStepResult.AUTH_FAILED);
-            response.setMessage(e.getMessage());
+            response.setMessage("error.communication");
             logger.info("Step result: AUTH_FAILED, authentication method: {}", getAuthMethodName().toString());
             return response;
         }

--- a/powerauth-webflow-authentication-operation-review/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/operation/controller/OperationReviewController.java
+++ b/powerauth-webflow-authentication-operation-review/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/operation/controller/OperationReviewController.java
@@ -199,9 +199,10 @@ public class OperationReviewController extends AuthMethodController<OperationRev
             logger.info("Step result: CANCELED, operation ID: {}, authentication method: {}", operation.getOperationId(), getAuthMethodName().toString());
             return response;
         } catch (NextStepServiceException e) {
+            logger.error("Error occurred in Next Step server", e);
             final OperationReviewResponse response = new OperationReviewResponse();
             response.setResult(AuthStepResult.AUTH_FAILED);
-            response.setMessage(e.getMessage());
+            response.setMessage("error.communication");
             logger.info("Step result: AUTH_FAILED, authentication method: {}", getAuthMethodName().toString());
             return response;
         }

--- a/powerauth-webflow-authentication-sms/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/sms/controller/SMSAuthorizationController.java
+++ b/powerauth-webflow-authentication-sms/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/sms/controller/SMSAuthorizationController.java
@@ -102,9 +102,10 @@ public class SMSAuthorizationController extends AuthMethodController<SMSAuthoriz
                 GetOperationDetailResponse updatedOperation = getOperation();
                 remainingAttemptsNS = updatedOperation.getRemainingAttempts();
             } catch (NextStepServiceException e2) {
-                throw new AuthStepException(e2.getError().getMessage(), e2);
+                logger.error("Error occurred in Next Step server", e);
+                throw new AuthStepException(e2.getError().getMessage(), e2, "error.communication");
             }
-            AuthStepException authEx = new AuthStepException(e.getError().getMessage(), e);
+            AuthStepException authEx = new AuthStepException(e.getError().getMessage(), e, "error.communication");
             Integer remainingAttemptsDA = e.getError().getRemainingAttempts();
             Integer remainingAttempts = resolveRemainingAttempts(remainingAttemptsDA, remainingAttemptsNS);
             authEx.setRemainingAttempts(remainingAttempts);
@@ -151,7 +152,7 @@ public class SMSAuthorizationController extends AuthMethodController<SMSAuthoriz
             logger.error("Error when sending SMS message.", e);
             initResponse.setResult(AuthStepResult.AUTH_FAILED);
             logger.info("Init step result: AUTH_FAILED, operation ID: {}, authentication method: {}", operation.getOperationId(), getAuthMethodName().toString());
-            initResponse.setMessage(e.getMessage());
+            initResponse.setMessage("error.communication");
             return initResponse;
         }
     }
@@ -237,7 +238,7 @@ public class SMSAuthorizationController extends AuthMethodController<SMSAuthoriz
             logger.error("Error when canceling SMS message validation.", e);
             final SMSAuthorizationResponse cancelResponse = new SMSAuthorizationResponse();
             cancelResponse.setResult(AuthStepResult.AUTH_FAILED);
-            cancelResponse.setMessage(e.getMessage());
+            cancelResponse.setMessage("error.communication");
             logger.info("Step result: AUTH_FAILED, authentication method: {}", getAuthMethodName().toString());
             return cancelResponse;
         }

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/controller/AuthMethodController.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/controller/AuthMethodController.java
@@ -126,7 +126,7 @@ public abstract class AuthMethodController<T extends AuthStepRequest, R extends 
             return operation;
         } catch (NextStepServiceException e) {
             logger.error("Error occurred in Next Step server", e);
-            return null;
+            throw new CommunicationFailedException("Operation is not available");
         }
     }
 
@@ -150,13 +150,13 @@ public abstract class AuthMethodController<T extends AuthStepRequest, R extends 
      * @param operationName Operation name.
      * @return Operation configuration.
      */
-    protected GetOperationConfigResponse getOperationConfig(String operationName) {
+    protected GetOperationConfigResponse getOperationConfig(String operationName) throws AuthStepException {
         try {
             final ObjectResponse<GetOperationConfigResponse> operationConfigResponse = nextStepClient.getOperationConfig(operationName);
             return operationConfigResponse.getResponseObject();
         } catch (NextStepServiceException e) {
             logger.error("Error occurred in Next Step server", e);
-            return null;
+            throw new CommunicationFailedException("Operation configuration is not available");
         }
     }
 
@@ -164,13 +164,13 @@ public abstract class AuthMethodController<T extends AuthStepRequest, R extends 
      * Get operation configurations.
      * @return Operation configurations.
      */
-    protected GetOperationConfigsResponse getOperationConfigs() {
+    protected GetOperationConfigsResponse getOperationConfigs() throws AuthStepException {
         try {
             final ObjectResponse<GetOperationConfigsResponse> operationConfigsResponse = nextStepClient.getOperationConfigs();
             return operationConfigsResponse.getResponseObject();
         } catch (NextStepServiceException e) {
             logger.error("Error occurred in Next Step server", e);
-            return null;
+            throw new CommunicationFailedException("Operation configuration is not available");
         }
     }
 
@@ -185,7 +185,7 @@ public abstract class AuthMethodController<T extends AuthStepRequest, R extends 
      * @param userId User ID.
      * @return List of operations for given user.
      */
-    protected List<GetOperationDetailResponse> getOperationListForUser(String userId) {
+    protected List<GetOperationDetailResponse> getOperationListForUser(String userId) throws AuthStepException {
         try {
             final ObjectResponse<List<GetOperationDetailResponse>> operations = nextStepClient.getPendingOperations(userId, getAuthMethodName());
             final List<GetOperationDetailResponse> responseObject = operations.getResponseObject();
@@ -195,7 +195,8 @@ public abstract class AuthMethodController<T extends AuthStepRequest, R extends 
             }
             return operations.getResponseObject();
         } catch (NextStepServiceException e) {
-            return null;
+            logger.error("Error occurred in Next Step server", e);
+            throw new CommunicationFailedException("Operations are not available");
         }
     }
 
@@ -344,7 +345,7 @@ public abstract class AuthMethodController<T extends AuthStepRequest, R extends 
             return initResponse;
         } catch (NextStepServiceException e) {
             logger.error("Error while initiating operation", e);
-            return provider.failedAuthentication(null, "error.unknown");
+            return provider.failedAuthentication(null, "error.communication");
         }
     }
 
@@ -460,7 +461,7 @@ public abstract class AuthMethodController<T extends AuthStepRequest, R extends 
             }
         } catch (NextStepServiceException e) {
             logger.error("Error while building authorization response", e);
-            throw new AuthStepException(e.getError().getMessage(), e);
+            throw new CommunicationFailedException("Step authorization failed");
         }
     }
 

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/exception/AuthStepException.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/exception/AuthStepException.java
@@ -48,6 +48,17 @@ public class AuthStepException extends Exception {
     }
 
     /**
+     * Constructor with message, cause and message ID.
+     *
+     * @param message Error message.
+     * @param cause   Error cause (original exception, if any).
+     * @param messageId Error message localization key.
+     */
+    public AuthStepException(String message, Throwable cause, String messageId) {
+        super(message, cause);
+        this.messageId = messageId;
+    }
+    /**
      * Get number of remaining authentication attempts.
      * @return Number of remaining attempts.
      */

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/exception/CommunicationFailedException.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/exception/CommunicationFailedException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.lib.webflow.authentication.exception;
+
+/**
+ * Communication failed exception.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class CommunicationFailedException extends AuthStepException {
+
+    /**
+     * Constructor with message.
+     *
+     * @param message Error message.
+     */
+    public CommunicationFailedException(String message) {
+        super(message, "error.communication");
+    }
+
+}

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/exception/OperationNotConfiguredException.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/exception/OperationNotConfiguredException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.lib.webflow.authentication.exception;
+
+/**
+ * Operation not configured exception.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class OperationNotConfiguredException extends AuthStepException {
+
+    /**
+     * Constructor with message.
+     *
+     * @param message Error message.
+     */
+    public OperationNotConfiguredException(String message) {
+        super(message, "operationConfig.missing");
+    }
+
+}

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/AuthMethodQueryService.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/AuthMethodQueryService.java
@@ -24,6 +24,8 @@ import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthMethod;
 import io.getlime.security.powerauth.lib.nextstep.model.exception.NextStepServiceException;
 import io.getlime.security.powerauth.lib.nextstep.model.response.GetUserAuthMethodsResponse;
 import io.getlime.security.powerauth.soap.spring.client.PowerAuthServiceClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -37,6 +39,8 @@ import java.util.Map;
  */
 @Service
 public class AuthMethodQueryService {
+
+    private static final Logger logger = LoggerFactory.getLogger(AuthMethodQueryService.class);
 
     private final NextStepClient nextStepClient;
     private final PowerAuthServiceClient powerAuthServiceClient;
@@ -80,6 +84,7 @@ public class AuthMethodQueryService {
             }
             return false;
         } catch (NextStepServiceException e) {
+            logger.error("Error occurred in Next Step server", e);
             return false;
         }
     }

--- a/powerauth-webflow-i18n/src/main/resources/static/resources/messages_cs.properties
+++ b/powerauth-webflow-i18n/src/main/resources/static/resources/messages_cs.properties
@@ -4,6 +4,7 @@ error.sessionTerminated=Relace byla ukončena z důvodu delší nečinnosti.
 error.invalidRequest=Došlo k chybě při vykonávání požadavku.
 error.noAuthMethod=Nebyla nalezena žádná vhodná autentizační metoda.
 error.remote=Nastala chyba při komunikaci se vzdáleným systémem.
+error.communication=Nastala chyba při komunikaci.
 error.unknown=Nastala neznámá chyba.
 login.signIn=Přihlásit
 login.cancel=Zrušit

--- a/powerauth-webflow-i18n/src/main/resources/static/resources/messages_en.properties
+++ b/powerauth-webflow-i18n/src/main/resources/static/resources/messages_en.properties
@@ -4,6 +4,7 @@ error.sessionTerminated=Session has been terminated due to inactivity.
 error.invalidRequest=Invalid request.
 error.noAuthMethod=No authentication method is available to serve the request.
 error.remote=Error occurred during communication with the remote system.
+error.communication=Communication error occurred.
 error.unknown=Unknown error occurred.
 login.signIn=Sign In
 login.cancel=Cancel

--- a/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/configuration/OAuth2AuthorizationServerConfiguration.java
+++ b/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/configuration/OAuth2AuthorizationServerConfiguration.java
@@ -69,7 +69,7 @@ public class OAuth2AuthorizationServerConfiguration extends AuthorizationServerC
      * Client details service which stores client data in JDBC data source.
      * @return Client details service.
      */
-    @Bean("JdbcClientsDetailService")
+    @Bean("jdbcClientsDetailService")
     public ClientDetailsService clientDetailsService() {
         // client data is stored in JDBC data source (table oauth_client_details)
         return new JdbcClientDetailsService(dataSource);


### PR DESCRIPTION
This pull request contains following improvements related to error handling: 
- Fix #486: Do not expose service details when REST client fails
- Separated HTTP errors from JSON parsing errors
- Use user-friendly error messages instead of messages from Exceptions
- Do not throw Next Step exceptions in Web Flow
- Improved error handling
- Improved error logging

The new error screens are:
1. In case of communication errors with Data Adapter (service is down, a HTTP error occurs, unexpected non-JSON response with HTTP 200 status)

User authentication:
<img width="674" alt="screenshot 2019-03-05 at 15 00 43" src="https://user-images.githubusercontent.com/26658588/53810951-6ffc7a00-3f58-11e9-803b-8efc4d01b3f1.png">

SMS authorization:
<img width="502" alt="screenshot 2019-03-05 at 15 03 56" src="https://user-images.githubusercontent.com/26658588/53810761-ed73ba80-3f57-11e9-9722-45136faf4afe.png">

2. In case of communication errors with Next Step server (service is down, a HTTP error occurs, unexpected non-JSON response with HTTP 200 status)

<img width="666" alt="screenshot 2019-03-05 at 15 00 03" src="https://user-images.githubusercontent.com/26658588/53810794-fcf30380-3f57-11e9-82f3-640d947763a3.png">

Web Flow logs still contain all error details including HTTP status codes or parsing errors.

