### PR TITLE
Fix #515: Provide alternatives for DELETE and PUT methods

### DIFF
--- a/docs/Next-Step-Server-REST-API-Reference.md
+++ b/docs/Next-Step-Server-REST-API-Reference.md
@@ -377,6 +377,18 @@ Disables an authentication method for given user and lists all authentication me
     </tr>
 </table>
 
+Alternative with `POST` method for environments which do not allow `DELETE` methods:
+<table>
+    <tr>
+        <td>Method</td>
+        <td><code>POST</code></td>
+    </tr>
+    <tr>
+        <td>Resource URI</td>
+        <td><code>/user/auth-method/delete</code></td>
+    </tr>
+</table>
+
 #### Request
 
 - Headers:
@@ -1001,6 +1013,18 @@ Updates an operation in Next Step server.
     </tr>
 </table>
 
+Alternative with `POST` method for environments which do not allow `PUT` methods:
+<table>
+    <tr>
+        <td>Method</td>
+        <td><code>POST</code></td>
+    </tr>
+    <tr>
+        <td>Resource URI</td>
+        <td><code>/operation/update</code></td>
+    </tr>
+</table>
+
 #### Request
 
 - Headers:
@@ -1292,6 +1316,19 @@ Updates operation formData for given operation. Only the userInput part of formD
     </tr>
 </table>
 
+Alternative with `POST` method for environments which do not allow `PUT` methods:
+<table>
+    <tr>
+        <td>Method</td>
+        <td><code>POST</code></td>
+    </tr>
+    <tr>
+        <td>Resource URI</td>
+        <td><code>/operation/formData/update</code></td>
+    </tr>
+</table>
+
+
 #### Request
 
 - Headers:
@@ -1418,6 +1455,18 @@ Sets chosen authentication method for current operation step.
     <tr>
         <td>Resource URI</td>
         <td><code>/operation/chosenAuthMethod</code></td>
+    </tr>
+</table>
+
+Alternative with `POST` method for environments which do not allow `PUT` methods:
+<table>
+    <tr>
+        <td>Method</td>
+        <td><code>POST</code></td>
+    </tr>
+    <tr>
+        <td>Resource URI</td>
+        <td><code>/operation/chosenAuthMethod/update</code></td>
     </tr>
 </table>
 

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/AuthMethodController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/AuthMethodController.java
@@ -146,7 +146,7 @@ public class AuthMethodController {
      * @param request Update auth method request. Use non-null user ID in request and specify authMethod.
      * @return List of enabled authentication methods for given user wrapped in GetAuthMethodResponse.
      */
-    @RequestMapping(value = "/user/auth-method/disable", method = RequestMethod.POST)
+    @RequestMapping(value = "/user/auth-method/delete", method = RequestMethod.POST)
     public @ResponseBody ObjectResponse<GetUserAuthMethodsResponse> disableAuthMethodForUserPost(@RequestBody ObjectRequest<UpdateAuthMethodRequest> request) {
         return disableAuthMethodForUserImpl(request);
     }

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/AuthMethodController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/AuthMethodController.java
@@ -130,13 +130,28 @@ public class AuthMethodController {
     }
 
     /**
-     * Disable an authentication method for given user.
+     * Disable an authentication method for given user (DELETE method).
      *
      * @param request Update auth method request. Use non-null user ID in request and specify authMethod.
      * @return List of enabled authentication methods for given user wrapped in GetAuthMethodResponse.
      */
     @RequestMapping(value = "/user/auth-method", method = RequestMethod.DELETE)
     public @ResponseBody ObjectResponse<GetUserAuthMethodsResponse> disableAuthMethodForUser(@RequestBody ObjectRequest<UpdateAuthMethodRequest> request) {
+        return disableAuthMethodForUserImpl(request);
+    }
+
+    /**
+     * Disable an authentication method for given user (POST method alternative).
+     *
+     * @param request Update auth method request. Use non-null user ID in request and specify authMethod.
+     * @return List of enabled authentication methods for given user wrapped in GetAuthMethodResponse.
+     */
+    @RequestMapping(value = "/user/auth-method/disable", method = RequestMethod.POST)
+    public @ResponseBody ObjectResponse<GetUserAuthMethodsResponse> disableAuthMethodForUserPost(@RequestBody ObjectRequest<UpdateAuthMethodRequest> request) {
+        return disableAuthMethodForUserImpl(request);
+    }
+
+    private ObjectResponse<GetUserAuthMethodsResponse> disableAuthMethodForUserImpl(ObjectRequest<UpdateAuthMethodRequest> request) {
         logger.info("Received disableAuthMethodForUser request, user ID: {}, authentication method: {}", request.getRequestObject().getUserId(), request.getRequestObject().getAuthMethod().toString());
         UpdateAuthMethodRequest requestObject = request.getRequestObject();
         String userId = requestObject.getUserId();

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OperationController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OperationController.java
@@ -99,7 +99,7 @@ public class OperationController {
     }
 
     /**
-     * Update operation with given ID with a previous authentication step result.
+     * Update operation with given ID with a previous authentication step result (PUT method).
      *
      * @param request Update operation request.
      * @return Update operation response.
@@ -107,6 +107,22 @@ public class OperationController {
      */
     @RequestMapping(value = "/operation", method = RequestMethod.PUT)
     public @ResponseBody ObjectResponse<UpdateOperationResponse> updateOperation(@RequestBody ObjectRequest<UpdateOperationRequest> request) throws NextStepServiceException {
+        return updateOperationImpl(request);
+    }
+
+    /**
+     * Update operation with given ID with a previous authentication step result (POST method alternative).
+     *
+     * @param request Update operation request.
+     * @return Update operation response.
+     * @throws NextStepServiceException Thrown when next step resolution fails.
+     */
+    @RequestMapping(value = "/operation/update", method = RequestMethod.POST)
+    public @ResponseBody ObjectResponse<UpdateOperationResponse> updateOperationPost(@RequestBody ObjectRequest<UpdateOperationRequest> request) throws NextStepServiceException {
+        return updateOperationImpl(request);
+    }
+
+    private @ResponseBody ObjectResponse<UpdateOperationResponse> updateOperationImpl(@RequestBody ObjectRequest<UpdateOperationRequest> request) throws NextStepServiceException {
         logger.info("Received updateOperation request, operation ID: {}", request.getRequestObject().getOperationId());
         // resolve response based on dynamic step definitions
         UpdateOperationResponse response = stepResolutionService.resolveNextStepResponse(request.getRequestObject());
@@ -253,7 +269,7 @@ public class OperationController {
     }
 
     /**
-     * Update operation with updated form data.
+     * Update operation with updated form data (PUT method).
      *
      * @param request Update operation request.
      * @return Update operation response.
@@ -261,6 +277,22 @@ public class OperationController {
      */
     @RequestMapping(value = "/operation/formData", method = RequestMethod.PUT)
     public @ResponseBody Response updateOperationFormData(@RequestBody ObjectRequest<UpdateFormDataRequest> request) throws OperationNotFoundException {
+        return updateOperationFormDataImpl(request);
+    }
+
+    /**
+     * Update operation with updated form data (POST method alternative).
+     *
+     * @param request Update operation request.
+     * @return Update operation response.
+     * @throws OperationNotFoundException Thrown when operation is not found.
+     */
+    @RequestMapping(value = "/operation/formData/update", method = RequestMethod.POST)
+    public @ResponseBody Response updateOperationFormDataPost(@RequestBody ObjectRequest<UpdateFormDataRequest> request) throws OperationNotFoundException {
+        return updateOperationFormDataImpl(request);
+    }
+
+    private Response updateOperationFormDataImpl(ObjectRequest<UpdateFormDataRequest> request) throws OperationNotFoundException {
         logger.info("Received updateOperationFormData request, operation ID: {}", request.getRequestObject().getOperationId());
         // persist operation form data update
         operationPersistenceService.updateFormData(request.getRequestObject());
@@ -269,13 +301,28 @@ public class OperationController {
     }
 
     /**
-     * Update operation with chosen authentication method.
+     * Update operation with chosen authentication method (PUT method).
      * @param request Update operation request.
      * @return Update operation response.
      * @throws OperationNotFoundException Thrown when operation is not found.
      */
     @RequestMapping(value = "/operation/chosenAuthMethod", method = RequestMethod.PUT)
     public @ResponseBody Response updateChosenAuthMethod(@RequestBody ObjectRequest<UpdateChosenAuthMethodRequest> request) throws OperationNotFoundException {
+        return updateChosenAuthMethodImpl(request);
+    }
+
+    /**
+     * Update operation with chosen authentication method (POST method alternative).
+     * @param request Update operation request.
+     * @return Update operation response.
+     * @throws OperationNotFoundException Thrown when operation is not found.
+     */
+    @RequestMapping(value = "/operation/chosenAuthMethod/update", method = RequestMethod.POST)
+    public @ResponseBody Response updateChosenAuthMethodPost(@RequestBody ObjectRequest<UpdateChosenAuthMethodRequest> request) throws OperationNotFoundException {
+        return updateChosenAuthMethodImpl(request);
+    }
+
+    public Response updateChosenAuthMethodImpl(ObjectRequest<UpdateChosenAuthMethodRequest> request) throws OperationNotFoundException {
         logger.info("Received updateChosenAuthMethod request, operation ID: {}, chosen authentication method: {}", request.getRequestObject().getOperationId(), request.getRequestObject().getChosenAuthMethod().toString());
         // persist operation form data update
         operationPersistenceService.updateChosenAuthMethod(request.getRequestObject());

--- a/powerauth-webflow-authentication-operation-review/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/operation/controller/OperationReviewController.java
+++ b/powerauth-webflow-authentication-operation-review/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/operation/controller/OperationReviewController.java
@@ -209,7 +209,7 @@ public class OperationReviewController extends AuthMethodController<OperationRev
     }
 
     /**
-     * Update operation form data.
+     * Update operation form data (PUT method).
      * @param request Update operation form data request.
      * @return Object response.
      * @throws NextStepServiceException Thrown when communication with Next Step server fails.
@@ -218,6 +218,23 @@ public class OperationReviewController extends AuthMethodController<OperationRev
      */
     @RequestMapping(value = "/formData", method = RequestMethod.PUT)
     public @ResponseBody Response updateFormData(@RequestBody UpdateOperationFormDataRequest request) throws NextStepServiceException, DataAdapterClientErrorException, AuthStepException {
+        return updateFormDataImpl(request);
+    }
+
+    /**
+     * Update operation form data (POST method alternative).
+     * @param request Update operation form data request.
+     * @return Object response.
+     * @throws NextStepServiceException Thrown when communication with Next Step server fails.
+     * @throws DataAdapterClientErrorException Thrown when data could not be retrieved from Data Adapter.
+     * @throws AuthStepException Thrown when operation is invalid or not available.
+     */
+    @RequestMapping(value = "/formData/update", method = RequestMethod.POST)
+    public @ResponseBody Response updateFormDataPost(@RequestBody UpdateOperationFormDataRequest request) throws NextStepServiceException, DataAdapterClientErrorException, AuthStepException {
+        return updateFormDataImpl(request);
+    }
+
+    private Response updateFormDataImpl(UpdateOperationFormDataRequest request) throws NextStepServiceException, DataAdapterClientErrorException, AuthStepException {
         final GetOperationDetailResponse operation = getOperation();
         checkOperationExpiration(operation);
         // update formData in Next Step server
@@ -236,7 +253,7 @@ public class OperationReviewController extends AuthMethodController<OperationRev
     }
 
     /**
-     * Update chosen authentication method.
+     * Update chosen authentication method (PUT method).
      * @param request Update chosen authentication method request.
      * @return Object response.
      * @throws NextStepServiceException Thrown when communication with Next Step server fails.
@@ -244,6 +261,22 @@ public class OperationReviewController extends AuthMethodController<OperationRev
      */
     @RequestMapping(value = "/chosenAuthMethod", method = RequestMethod.PUT)
     public @ResponseBody Response updateChosenAuthenticationMethod(@RequestBody UpdateOperationChosenAuthMethodRequest request) throws NextStepServiceException, AuthStepException {
+        return updateChosenAuthenticationMethodImpl(request);
+    }
+
+    /**
+     * Update chosen authentication method (POST method alternative).
+     * @param request Update chosen authentication method request.
+     * @return Object response.
+     * @throws NextStepServiceException Thrown when communication with Next Step server fails.
+     * @throws AuthStepException Thrown when operation is invalid or not available.
+     */
+    @RequestMapping(value = "/chosenAuthMethod/update", method = RequestMethod.POST)
+    public @ResponseBody Response updateChosenAuthenticationMethodPost(@RequestBody UpdateOperationChosenAuthMethodRequest request) throws NextStepServiceException, AuthStepException {
+        return updateChosenAuthenticationMethodImpl(request);
+    }
+
+    private Response updateChosenAuthenticationMethodImpl(UpdateOperationChosenAuthMethodRequest request) throws NextStepServiceException, AuthStepException {
         final GetOperationDetailResponse operation = getOperation();
         checkOperationExpiration(operation);
         // update chosenAuthMethod in Next Step server


### PR DESCRIPTION
I added alternative `POST` methods for `DELETE` and `PUT` methods and documented them.