### PR TITLE
Fix #517: Backport alternative methods for DELETE and PUT into branch 0.20.x

### DIFF
--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/AuthMethodController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/AuthMethodController.java
@@ -128,13 +128,28 @@ public class AuthMethodController {
     }
 
     /**
-     * Disable an authentication method for given user.
+     * Disable an authentication method for given user (DELETE method).
      *
      * @param request Update auth method request. Use non-null user ID in request and specify authMethod.
      * @return List of enabled authentication methods for given user wrapped in GetAuthMethodResponse.
      */
     @RequestMapping(value = "/user/auth-method", method = RequestMethod.DELETE)
     public @ResponseBody ObjectResponse<GetUserAuthMethodsResponse> disableAuthMethodForUser(@RequestBody ObjectRequest<UpdateAuthMethodRequest> request) {
+        return disableAuthMethodForUserImpl(request);
+    }
+
+    /**
+     * Disable an authentication method for given user (POST method alternative).
+     *
+     * @param request Update auth method request. Use non-null user ID in request and specify authMethod.
+     * @return List of enabled authentication methods for given user wrapped in GetAuthMethodResponse.
+     */
+    @RequestMapping(value = "/user/auth-method/delete", method = RequestMethod.POST)
+    public @ResponseBody ObjectResponse<GetUserAuthMethodsResponse> disableAuthMethodForUserPost(@RequestBody ObjectRequest<UpdateAuthMethodRequest> request) {
+        return disableAuthMethodForUserImpl(request);
+    }
+
+    private ObjectResponse<GetUserAuthMethodsResponse> disableAuthMethodForUserImpl(ObjectRequest<UpdateAuthMethodRequest> request) {
         Logger.getLogger(this.getClass().getName()).log(Level.INFO, "Received disableAuthMethodForUser request, user ID: {0}, authentication method: {1}", new String[] {request.getRequestObject().getUserId(), request.getRequestObject().getAuthMethod().toString()});
         UpdateAuthMethodRequest requestObject = request.getRequestObject();
         String userId = requestObject.getUserId();

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OperationController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OperationController.java
@@ -100,7 +100,7 @@ public class OperationController {
     }
 
     /**
-     * Update operation with given ID with a previous authentication step result.
+     * Update operation with given ID with a previous authentication step result (PUT method).
      *
      * @param request Update operation request.
      * @return Update operation response.
@@ -108,6 +108,22 @@ public class OperationController {
      */
     @RequestMapping(value = "/operation", method = RequestMethod.PUT)
     public @ResponseBody ObjectResponse<UpdateOperationResponse> updateOperation(@RequestBody ObjectRequest<UpdateOperationRequest> request) throws NextStepServiceException {
+        return updateOperationImpl(request);
+    }
+
+    /**
+     * Update operation with given ID with a previous authentication step result (POST method alternative).
+     *
+     * @param request Update operation request.
+     * @return Update operation response.
+     * @throws NextStepServiceException Thrown when next step resolution fails.
+     */
+    @RequestMapping(value = "/operation/update", method = RequestMethod.POST)
+    public @ResponseBody ObjectResponse<UpdateOperationResponse> updateOperationPost(@RequestBody ObjectRequest<UpdateOperationRequest> request) throws NextStepServiceException {
+        return updateOperationImpl(request);
+    }
+
+    private @ResponseBody ObjectResponse<UpdateOperationResponse> updateOperationImpl(@RequestBody ObjectRequest<UpdateOperationRequest> request) throws NextStepServiceException {
         Logger.getLogger(this.getClass().getName()).log(Level.INFO, "Received updateOperation request, operation ID: {0}", request.getRequestObject().getOperationId());
         // resolve response based on dynamic step definitions
         UpdateOperationResponse response = stepResolutionService.resolveNextStepResponse(request.getRequestObject());
@@ -238,7 +254,7 @@ public class OperationController {
     }
 
     /**
-     * Update operation with updated form data.
+     * Update operation with updated form data (PUT method).
      *
      * @param request Update operation request.
      * @return Update operation response.
@@ -246,6 +262,22 @@ public class OperationController {
      */
     @RequestMapping(value = "/operation/formData", method = RequestMethod.PUT)
     public @ResponseBody Response updateOperationFormData(@RequestBody ObjectRequest<UpdateFormDataRequest> request) throws OperationNotFoundException {
+        return updateOperationFormDataImpl(request);
+    }
+
+    /**
+     * Update operation with updated form data (POST method alternative).
+     *
+     * @param request Update operation request.
+     * @return Update operation response.
+     * @throws OperationNotFoundException Thrown when operation is not found.
+     */
+    @RequestMapping(value = "/operation/formData/update", method = RequestMethod.POST)
+    public @ResponseBody Response updateOperationFormDataPost(@RequestBody ObjectRequest<UpdateFormDataRequest> request) throws OperationNotFoundException {
+        return updateOperationFormDataImpl(request);
+    }
+
+    private Response updateOperationFormDataImpl(ObjectRequest<UpdateFormDataRequest> request) throws OperationNotFoundException {
         Logger.getLogger(this.getClass().getName()).log(Level.INFO, "Received updateOperationFormData request, operation ID: {0}", request.getRequestObject().getOperationId());
         // persist operation form data update
         operationPersistenceService.updateFormData(request.getRequestObject());
@@ -254,13 +286,28 @@ public class OperationController {
     }
 
     /**
-     * Update operation with chosen authentication method.
+     * Update operation with chosen authentication method (PUT method).
      * @param request Update operation request.
      * @return Update operation response.
      * @throws OperationNotFoundException Thrown when operation is not found.
      */
     @RequestMapping(value = "/operation/chosenAuthMethod", method = RequestMethod.PUT)
     public @ResponseBody Response updateChosenAuthMethod(@RequestBody ObjectRequest<UpdateChosenAuthMethodRequest> request) throws OperationNotFoundException {
+        return updateChosenAuthMethodImpl(request);
+    }
+
+    /**
+     * Update operation with chosen authentication method (POST method alternative).
+     * @param request Update operation request.
+     * @return Update operation response.
+     * @throws OperationNotFoundException Thrown when operation is not found.
+     */
+    @RequestMapping(value = "/operation/chosenAuthMethod/update", method = RequestMethod.POST)
+    public @ResponseBody Response updateChosenAuthMethodPost(@RequestBody ObjectRequest<UpdateChosenAuthMethodRequest> request) throws OperationNotFoundException {
+        return updateChosenAuthMethodImpl(request);
+    }
+
+    public Response updateChosenAuthMethodImpl(ObjectRequest<UpdateChosenAuthMethodRequest> request) throws OperationNotFoundException {
         Logger.getLogger(this.getClass().getName()).log(Level.INFO, "Received updateChosenAuthMethod request, operation ID: {0}, chosen authentication method: {1}", new String[]{request.getRequestObject().getOperationId(), request.getRequestObject().getChosenAuthMethod().toString()});
         // persist operation form data update
         operationPersistenceService.updateChosenAuthMethod(request.getRequestObject());


### PR DESCRIPTION
This pull request backports the update of REST methods in Next Step. The Web Flow REST API changes were intentionally omitted. The documentation will be updated manually in developers portal, this branch does not have the `docs` folder yet.