### PR TITLE
Fix #518: Backport alternative methods for DELETE and PUT into branch 0.21.x

### DIFF
--- a/docs/Next-Step-Server-REST-API-Reference.md
+++ b/docs/Next-Step-Server-REST-API-Reference.md
@@ -377,6 +377,18 @@ Disables an authentication method for given user and lists all authentication me
     </tr>
 </table>
 
+Alternative with `POST` method for environments which do not allow `DELETE` methods:
+<table>
+    <tr>
+        <td>Method</td>
+        <td><code>POST</code></td>
+    </tr>
+    <tr>
+        <td>Resource URI</td>
+        <td><code>/user/auth-method/delete</code></td>
+    </tr>
+</table>
+
 #### Request
 
 - Headers:
@@ -1001,6 +1013,18 @@ Updates an operation in Next Step server.
     </tr>
 </table>
 
+Alternative with `POST` method for environments which do not allow `PUT` methods:
+<table>
+    <tr>
+        <td>Method</td>
+        <td><code>POST</code></td>
+    </tr>
+    <tr>
+        <td>Resource URI</td>
+        <td><code>/operation/update</code></td>
+    </tr>
+</table>
+
 #### Request
 
 - Headers:
@@ -1292,6 +1316,19 @@ Updates operation formData for given operation. Only the userInput part of formD
     </tr>
 </table>
 
+Alternative with `POST` method for environments which do not allow `PUT` methods:
+<table>
+    <tr>
+        <td>Method</td>
+        <td><code>POST</code></td>
+    </tr>
+    <tr>
+        <td>Resource URI</td>
+        <td><code>/operation/formData/update</code></td>
+    </tr>
+</table>
+
+
 #### Request
 
 - Headers:
@@ -1418,6 +1455,18 @@ Sets chosen authentication method for current operation step.
     <tr>
         <td>Resource URI</td>
         <td><code>/operation/chosenAuthMethod</code></td>
+    </tr>
+</table>
+
+Alternative with `POST` method for environments which do not allow `PUT` methods:
+<table>
+    <tr>
+        <td>Method</td>
+        <td><code>POST</code></td>
+    </tr>
+    <tr>
+        <td>Resource URI</td>
+        <td><code>/operation/chosenAuthMethod/update</code></td>
     </tr>
 </table>
 

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/AuthMethodController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/AuthMethodController.java
@@ -130,13 +130,28 @@ public class AuthMethodController {
     }
 
     /**
-     * Disable an authentication method for given user.
+     * Disable an authentication method for given user (DELETE method).
      *
      * @param request Update auth method request. Use non-null user ID in request and specify authMethod.
      * @return List of enabled authentication methods for given user wrapped in GetAuthMethodResponse.
      */
     @RequestMapping(value = "/user/auth-method", method = RequestMethod.DELETE)
     public @ResponseBody ObjectResponse<GetUserAuthMethodsResponse> disableAuthMethodForUser(@RequestBody ObjectRequest<UpdateAuthMethodRequest> request) {
+        return disableAuthMethodForUserImpl(request);
+    }
+
+    /**
+     * Disable an authentication method for given user (POST method alternative).
+     *
+     * @param request Update auth method request. Use non-null user ID in request and specify authMethod.
+     * @return List of enabled authentication methods for given user wrapped in GetAuthMethodResponse.
+     */
+    @RequestMapping(value = "/user/auth-method/delete", method = RequestMethod.POST)
+    public @ResponseBody ObjectResponse<GetUserAuthMethodsResponse> disableAuthMethodForUserPost(@RequestBody ObjectRequest<UpdateAuthMethodRequest> request) {
+        return disableAuthMethodForUserImpl(request);
+    }
+
+    private ObjectResponse<GetUserAuthMethodsResponse> disableAuthMethodForUserImpl(ObjectRequest<UpdateAuthMethodRequest> request) {
         logger.info("Received disableAuthMethodForUser request, user ID: {}, authentication method: {}", request.getRequestObject().getUserId(), request.getRequestObject().getAuthMethod().toString());
         UpdateAuthMethodRequest requestObject = request.getRequestObject();
         String userId = requestObject.getUserId();

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OperationController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OperationController.java
@@ -102,7 +102,7 @@ public class OperationController {
     }
 
     /**
-     * Update operation with given ID with a previous authentication step result.
+     * Update operation with given ID with a previous authentication step result (PUT method).
      *
      * @param request Update operation request.
      * @return Update operation response.
@@ -110,6 +110,22 @@ public class OperationController {
      */
     @RequestMapping(value = "/operation", method = RequestMethod.PUT)
     public @ResponseBody ObjectResponse<UpdateOperationResponse> updateOperation(@RequestBody ObjectRequest<UpdateOperationRequest> request) throws NextStepServiceException {
+        return updateOperationImpl(request);
+    }
+
+    /**
+     * Update operation with given ID with a previous authentication step result (POST method alternative).
+     *
+     * @param request Update operation request.
+     * @return Update operation response.
+     * @throws NextStepServiceException Thrown when next step resolution fails.
+     */
+    @RequestMapping(value = "/operation/update", method = RequestMethod.POST)
+    public @ResponseBody ObjectResponse<UpdateOperationResponse> updateOperationPost(@RequestBody ObjectRequest<UpdateOperationRequest> request) throws NextStepServiceException {
+        return updateOperationImpl(request);
+    }
+
+    private @ResponseBody ObjectResponse<UpdateOperationResponse> updateOperationImpl(@RequestBody ObjectRequest<UpdateOperationRequest> request) throws NextStepServiceException {
         logger.info("Received updateOperation request, operation ID: {}", request.getRequestObject().getOperationId());
         // resolve response based on dynamic step definitions
         UpdateOperationResponse response = stepResolutionService.resolveNextStepResponse(request.getRequestObject());
@@ -240,7 +256,7 @@ public class OperationController {
     }
 
     /**
-     * Update operation with updated form data.
+     * Update operation with updated form data (PUT method).
      *
      * @param request Update operation request.
      * @return Update operation response.
@@ -248,6 +264,22 @@ public class OperationController {
      */
     @RequestMapping(value = "/operation/formData", method = RequestMethod.PUT)
     public @ResponseBody Response updateOperationFormData(@RequestBody ObjectRequest<UpdateFormDataRequest> request) throws OperationNotFoundException {
+        return updateOperationFormDataImpl(request);
+    }
+
+    /**
+     * Update operation with updated form data (POST method alternative).
+     *
+     * @param request Update operation request.
+     * @return Update operation response.
+     * @throws OperationNotFoundException Thrown when operation is not found.
+     */
+    @RequestMapping(value = "/operation/formData/update", method = RequestMethod.POST)
+    public @ResponseBody Response updateOperationFormDataPost(@RequestBody ObjectRequest<UpdateFormDataRequest> request) throws OperationNotFoundException {
+        return updateOperationFormDataImpl(request);
+    }
+
+    private Response updateOperationFormDataImpl(ObjectRequest<UpdateFormDataRequest> request) throws OperationNotFoundException {
         logger.info("Received updateOperationFormData request, operation ID: {}", request.getRequestObject().getOperationId());
         // persist operation form data update
         operationPersistenceService.updateFormData(request.getRequestObject());
@@ -256,13 +288,28 @@ public class OperationController {
     }
 
     /**
-     * Update operation with chosen authentication method.
+     * Update operation with chosen authentication method (PUT method).
      * @param request Update operation request.
      * @return Update operation response.
      * @throws OperationNotFoundException Thrown when operation is not found.
      */
     @RequestMapping(value = "/operation/chosenAuthMethod", method = RequestMethod.PUT)
     public @ResponseBody Response updateChosenAuthMethod(@RequestBody ObjectRequest<UpdateChosenAuthMethodRequest> request) throws OperationNotFoundException {
+        return updateChosenAuthMethodImpl(request);
+    }
+
+    /**
+     * Update operation with chosen authentication method (POST method alternative).
+     * @param request Update operation request.
+     * @return Update operation response.
+     * @throws OperationNotFoundException Thrown when operation is not found.
+     */
+    @RequestMapping(value = "/operation/chosenAuthMethod/update", method = RequestMethod.POST)
+    public @ResponseBody Response updateChosenAuthMethodPost(@RequestBody ObjectRequest<UpdateChosenAuthMethodRequest> request) throws OperationNotFoundException {
+        return updateChosenAuthMethodImpl(request);
+    }
+
+    public Response updateChosenAuthMethodImpl(ObjectRequest<UpdateChosenAuthMethodRequest> request) throws OperationNotFoundException {
         logger.info("Received updateChosenAuthMethod request, operation ID: {}, chosen authentication method: {}", request.getRequestObject().getOperationId(), request.getRequestObject().getChosenAuthMethod().toString());
         // persist operation form data update
         operationPersistenceService.updateChosenAuthMethod(request.getRequestObject());


### PR DESCRIPTION
This pull request backports the update of REST methods in Next Step. The Web Flow REST API changes were intentionally omitted. The documentation was updated in the `docs` folder and we will need to regenerate the developers portal documentation.