### PR TITLE
Fixes from testing of consent screen

### DIFF
--- a/docs/Web-Flow-0.22.0.md
+++ b/docs/Web-Flow-0.22.0.md
@@ -4,10 +4,20 @@
 
 ### Database Changes
 
-We added `NOT NULL` definitions to database tables to improve data integrity.
-
+Following database changes were introduced in version `0.22.0`:
+ 
+- We added `NOT NULL` definitions to database tables to improve data integrity.
+- New optional columns added in operations in table `ns_operation` for application context:
+  - `application_id` - identifier of application
+  - `application_name` - application name
+  - `application_description` - application description
+  - `application_extras` - map of extra values used in application context
+  
 DDL update script for Oracle:
 ```
+
+-- Added not null constraints 
+
 ALTER TABLE NS_AUTH_METHOD MODIFY AUTH_METHOD NOT NULL;
 ALTER TABLE NS_AUTH_METHOD MODIFY ORDER_NUMBER NOT NULL;
 ALTER TABLE NS_AUTH_METHOD MODIFY CHECK_AUTH_FAILS NOT NULL;
@@ -39,10 +49,20 @@ ALTER TABLE DA_SMS_AUTHORIZATION MODIFY OPERATION_NAME NOT NULL;
 ALTER TABLE DA_SMS_AUTHORIZATION MODIFY AUTHORIZATION_CODE NOT NULL;
 ALTER TABLE DA_SMS_AUTHORIZATION MODIFY SALT NOT NULL;
 ALTER TABLE DA_SMS_AUTHORIZATION MODIFY MESSAGE_TEXT NOT NULL;
+
+-- Columns for application context in table NS_OPERATION 
+
+ALTER TABLE NS_OPERATION ADD APPLICATION_ID VARCHAR(256);
+ALTER TABLE NS_OPERATION ADD APPLICATION_NAME VARCHAR(256);
+ALTER TABLE NS_OPERATION ADD APPLICATION_DESCRIPTION VARCHAR(256);
+ALTER TABLE NS_OPERATION ADD APPLICATION_EXTRAS CLOB;
 ```
 
 DDL update script for MySQL:
 ```
+
+-- Added not null constraints 
+
 ALTER TABLE `ns_auth_method` MODIFY `auth_method` VARCHAR(32) NOT NULL;
 ALTER TABLE `ns_auth_method` MODIFY `order_number` INTEGER NOT NULL;
 ALTER TABLE `ns_auth_method` MODIFY `check_auth_fails` BOOLEAN NOT NULL;
@@ -74,4 +94,11 @@ ALTER TABLE `da_sms_authorization` MODIFY `operation_name` VARCHAR(32) NOT NULL;
 ALTER TABLE `da_sms_authorization` MODIFY `authorization_code` VARCHAR(32) NOT NULL;
 ALTER TABLE `da_sms_authorization` MODIFY `salt` VARBINARY(16) NOT NULL;
 ALTER TABLE `da_sms_authorization` MODIFY `message_text` TEXT NOT NULL;
+
+-- Columns for application context in table NS_OPERATION
+
+ALTER TABLE `ns_operation` ADD COLUMN `application_id` VARCHAR(256);
+ALTER TABLE `ns_operation` ADD COLUMN `application_name` VARCHAR(256);
+ALTER TABLE `ns_operation` ADD COLUMN `application_description` VARCHAR(256);
+ALTER TABLE `ns_operation` ADD COLUMN `application_extras` TEXT;
 ```

--- a/powerauth-webflow-authentication-consent/pom.xml
+++ b/powerauth-webflow-authentication-consent/pom.xml
@@ -44,6 +44,11 @@
             <artifactId>powerauth-data-adapter-client</artifactId>
             <version>0.22.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+            <artifactId>owasp-java-html-sanitizer</artifactId>
+            <version>20190610.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/powerauth-webflow-authentication-consent/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/consent/controller/ConsentController.java
+++ b/powerauth-webflow-authentication-consent/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/consent/controller/ConsentController.java
@@ -35,7 +35,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 /**
- * Controller which provides endpoints for SMS authorization.
+ * Controller which provides endpoints for OAuth 2.0 consent screen.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */

--- a/powerauth-webflow-authentication-consent/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/consent/controller/ConsentController.java
+++ b/powerauth-webflow-authentication-consent/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/consent/controller/ConsentController.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.getlime.security.powerauth.lib.webflow.authentication.consent.controller;
 
 import io.getlime.core.rest.model.base.response.ObjectResponse;

--- a/powerauth-webflow-authentication-consent/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/consent/model/request/ConsentAuthRequest.java
+++ b/powerauth-webflow-authentication-consent/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/consent/model/request/ConsentAuthRequest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.getlime.security.powerauth.lib.webflow.authentication.consent.model.request;
 
 import io.getlime.security.powerauth.lib.dataadapter.model.entity.ConsentOption;

--- a/powerauth-webflow-authentication-consent/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/consent/model/response/ConsentAuthResponse.java
+++ b/powerauth-webflow-authentication-consent/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/consent/model/response/ConsentAuthResponse.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.getlime.security.powerauth.lib.webflow.authentication.consent.model.response;
 
 import io.getlime.security.powerauth.lib.dataadapter.model.entity.ConsentOptionValidationResult;

--- a/powerauth-webflow-authentication-consent/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/consent/model/response/ConsentInitResponse.java
+++ b/powerauth-webflow-authentication-consent/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/consent/model/response/ConsentInitResponse.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.getlime.security.powerauth.lib.webflow.authentication.consent.model.response;
 
 import io.getlime.security.powerauth.lib.dataadapter.model.entity.ConsentOption;

--- a/powerauth-webflow-authentication-consent/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/consent/service/HtmlSanitizationService.java
+++ b/powerauth-webflow-authentication-consent/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/consent/service/HtmlSanitizationService.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.lib.webflow.authentication.consent.service;
+
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.PolicyFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service for sanitization of potentially unsafe HTML.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Service
+public class HtmlSanitizationService {
+
+    /**
+     * Sanitize unsafe HTML text.
+     * @param htmlText Unsafe HTML text.
+     * @return Sanitized HTML text.
+     */
+    public String sanitize(String htmlText) {
+        if (htmlText == null || htmlText.isEmpty()) {
+            return htmlText;
+        }
+        // The sanitization policy corresponds with https://www.npmjs.com/package/sanitize-html#what-are-the-default-options
+        PolicyFactory policy = new HtmlPolicyBuilder()
+                .allowAttributes("href", "name", "target").onElements("a")
+                .allowStandardUrlProtocols()
+                .allowElements("h3", "h4", "h5", "h6", "blockquote", "p", "a", "ul", "ol",
+                        "nl", "li", "b", "i", "strong", "em", "strike", "code", "hr", "br", "div",
+                        "table", "thead", "caption", "tbody", "tr", "th", "td", "pre", "iframe"
+                ).toFactory();
+        return policy.sanitize(htmlText);
+    }
+
+}

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/controller/AuthMethodController.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/controller/AuthMethodController.java
@@ -567,14 +567,6 @@ public abstract class AuthMethodController<T extends AuthStepRequest, R extends 
                 logger.warn("Operation was interrupted, operation ID: {}", operation.getOperationId());
                 throw new OperationInterruptedException("Operation was interrupted");
             }
-            // check steps for operations with AuthResult = CONTINUE, DONE and FAILED methods do not have steps
-            if (currentAuthMethod != AuthMethod.INIT && currentAuthMethod != AuthMethod.SHOW_OPERATION_DETAIL) {
-                // check whether AuthMethod is available in next steps, only done in real authentication methods
-                if (!isAuthMethodAvailable(operation)) {
-                    logger.warn("Authentication method is not available, operation ID: {}, authentication method: {}", operation.getOperationId(), currentAuthMethod.toString());
-                    throw new AuthMethodNotAvailableException("Authentication method is not available: " + currentAuthMethod);
-                }
-            }
             // special handling for SHOW_OPERATION_DETAIL - endpoint can be called only when either SMS_KEY or POWERAUTH_TOKEN are present in next steps
             if (currentAuthMethod == AuthMethod.SHOW_OPERATION_DETAIL) {
                 if (!isAuthMethodAvailable(operation, AuthMethod.SMS_KEY) && !isAuthMethodAvailable(operation, AuthMethod.POWERAUTH_TOKEN)) {


### PR DESCRIPTION
I found several issues when testing consent screen with `POWERAUTH_TOKEN` step instead of `SMS_KEY`:
- Operation must not be returned in pending operations in case it was already processed (e.g. consent screen is displayed after `POWERAUTH_TOKEN` step)
- Removed invalid check for authentication method availability (the logic was broken but discovered only now that an additional step is available after `POWERAUTH_TOKEN`)
- Updated JavaDoc
- Added documentation of database changes
- Implemented HTML sanitization based on used policy in `sanitize-html` JavaScript project