### PR TITLE
Fix #567: Invalid logic in getAuthMethodName for consent page

### DIFF
--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/controller/AuthMethodController.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/controller/AuthMethodController.java
@@ -199,8 +199,10 @@ public abstract class AuthMethodController<T extends AuthStepRequest, R extends 
                     (operation.getChosenAuthMethod() == AuthMethod.LOGIN_SCA || operation.getChosenAuthMethod() == AuthMethod.APPROVAL_SCA)) {
                 return operation.getChosenAuthMethod();
             }
-            // The second case is when the current step has LOGIN_SCA or APPROVAL_SCA as an authentication method.
-            if (currentHistory.getAuthMethod() == AuthMethod.LOGIN_SCA || currentHistory.getAuthMethod() == AuthMethod.APPROVAL_SCA) {
+            // The second case is when the current step has LOGIN_SCA or APPROVAL_SCA as an authentication method and next
+            // authentication method has not been chosen yet.
+            if (operation.getChosenAuthMethod() == null &&
+                    (currentHistory.getAuthMethod() == AuthMethod.LOGIN_SCA || currentHistory.getAuthMethod() == AuthMethod.APPROVAL_SCA)) {
                 return currentHistory.getAuthMethod();
             }
         }


### PR DESCRIPTION
Updated logic for init step of consent page, so that in `CONSENT` init call it is set what is the chosen authentication method. This is done because we do not write an empty record into operation history when an authentication method starts - chosen auth method is used for this purpose in case of SCA steps.
