### PR TITLE
Fix #593: Improve Android warning UI

### DIFF
--- a/powerauth-webflow/src/main/js/components/securityOverride.js
+++ b/powerauth-webflow/src/main/js/components/securityOverride.js
@@ -46,7 +46,7 @@ export default class SecurityOverride extends React.Component {
 
     render() {
         return (
-            <div className="text-center">
+            <div className="panel-body">
                 <h3><FormattedMessage id="security.warning.android.title"/></h3>
                 <hr className="my-4"/>
                 <div className="lead"><FormattedMessage id="security.warning.android.text"/></div>

--- a/powerauth-webflow/src/main/js/components/securityOverride.js
+++ b/powerauth-webflow/src/main/js/components/securityOverride.js
@@ -46,7 +46,7 @@ export default class SecurityOverride extends React.Component {
 
     render() {
         return (
-            <div className="jumbotron text-center">
+            <div className="text-center">
                 <h3><FormattedMessage id="security.warning.android.title"/></h3>
                 <hr className="my-4"/>
                 <div className="lead"><FormattedMessage id="security.warning.android.text"/></div>


### PR DESCRIPTION
An attemt to make the warning less ugly - original UI:

![image](https://user-images.githubusercontent.com/26658588/62046110-675a5800-b207-11e9-82d1-7799856bf79d.png)

After removing the Jumbotron:
![image](https://user-images.githubusercontent.com/26658588/62046121-6e816600-b207-11e9-8af3-371dd63c241c.png)
