### PR TITLE
Fix #601: Clean HTTP session properly

### DIFF
--- a/powerauth-webflow-authentication-consent/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/consent/controller/ConsentController.java
+++ b/powerauth-webflow-authentication-consent/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/consent/controller/ConsentController.java
@@ -105,6 +105,7 @@ public class ConsentController extends AuthMethodController<ConsentAuthRequest, 
         if (getConsentSkippedFromHttpSession()) {
             // Consent form is skipped, step authentication is complete
             logger.info("Step authentication succeeded, operation ID: {}, authentication method: {}", operation.getOperationId(), getAuthMethodName().toString());
+            cleanHttpSession();
             return new AuthenticationResult(operation.getUserId(), operation.getOrganizationId());
         }
         final String userId = operation.getUserId();
@@ -122,6 +123,7 @@ public class ConsentController extends AuthMethodController<ConsentAuthRequest, 
             if (validateResponse.getConsentValidationPassed()) {
                 ObjectResponse<SaveConsentFormResponse> daResponse2 = dataAdapterClient.saveConsentForm(userId, organizationId, operationContext, request.getOptions());
                 SaveConsentFormResponse saveResponse = daResponse2.getResponseObject();
+                cleanHttpSession();
                 if (saveResponse.isSaveSucceeded()) {
                     logger.info("Step authentication succeeded, operation ID: {}, authentication method: {}", operation.getOperationId(), getAuthMethodName().toString());
                     return new AuthenticationResult(operation.getUserId(), operation.getOrganizationId());
@@ -147,6 +149,7 @@ public class ConsentController extends AuthMethodController<ConsentAuthRequest, 
             try {
                 UpdateOperationResponse response = failAuthorization(operation.getOperationId(), operation.getUserId(), null);
                 if (response.getResult() == AuthResult.FAILED) {
+                    cleanHttpSession();
                     // FAILED result instead of CONTINUE means the authentication method is failed
                     throw new MaxAttemptsExceededException("Maximum number of authentication attempts exceeded.");
                 }

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOfflineController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOfflineController.java
@@ -140,6 +140,7 @@ public class MobileTokenOfflineController extends AuthMethodController<QrCodeAut
         if (signatureResponse.isSignatureValid()) {
             String userId = operation.getUserId();
             if (signatureResponse.getUserId().equals(userId)) {
+                cleanHttpSession();
                 logger.info("Step authentication succeeded, operation ID: {}, authentication method: {}", operation.getOperationId(), authMethod.toString());
                 return new AuthenticationResult(userId, operation.getOrganizationId());
             }

--- a/powerauth-webflow-authentication-sms/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/sms/controller/SmsAuthorizationController.java
+++ b/powerauth-webflow-authentication-sms/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/sms/controller/SmsAuthorizationController.java
@@ -182,6 +182,7 @@ public class SmsAuthorizationController extends AuthMethodController<SmsAuthoriz
             try {
                 UpdateOperationResponse response = failAuthorization(operation.getOperationId(), operation.getUserId(), null);
                 if (response.getResult() == AuthResult.FAILED) {
+                    cleanHttpSession();
                     // FAILED result instead of CONTINUE means the authentication method is failed
                     throw new MaxAttemptsExceededException("Maximum number of authentication attempts exceeded");
                 }


### PR DESCRIPTION
This pull request cleans HTTP session when `/authenticate` endpoint is called as well as during various cases in regular operation processing in controllers.

The problem was found because the `INITIAL_MESSAGE_SENT` attribute remained in HTTP session when the same HTTP session was reused by multiple operations - the previous operation was interrupted and since the attribute was already set, the initial SMS was not sent.