### PR TITLE
Fix #628: Implement consent engine

### DIFF
--- a/docs/sql/mysql/create_schema.sql
+++ b/docs/sql/mysql/create_schema.sql
@@ -90,7 +90,7 @@ CREATE TABLE ns_operation_config (
   template_version          CHAR NOT NULL,
   template_id               INTEGER NOT NULL,
   mobile_token_mode         VARCHAR(256) NOT NULL,
-  afs_enabled               BOOLEAN NOT NULL DEFAULT FALSE,
+  afs_enabled               BOOLEAN NOT NULL DEFAULT FALSE
 ) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- Table ns_organization stores definitions of organizations related to the operations.
@@ -179,6 +179,38 @@ CREATE TABLE da_sms_authorization (
   timestamp_created    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   timestamp_verified   TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   timestamp_expires    TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE tpp_consent
+(
+	`consent_id` VARCHAR(64) PRIMARY KEY NOT NULL,
+	`consent_name` VARCHAR(128) NOT NULL,
+	`consent_text` TEXT NOT NULL,
+	`version` INT NOT NULL
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE tpp_user_consent
+(
+    `id` INTEGER PRIMARY KEY NOT NULL AUTO_INCREMENT,
+    `user_id` VARCHAR(256) NOT NULL,
+    `client_id` VARCHAR(256) NOT NULL,
+    `consent_id` VARCHAR(64) NOT NULL,
+    `external_id` VARCHAR(256) NOT NULL,
+    `consent_parameters` TEXT NOT NULL,
+    `timestamp_created` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    `timestamp_updated` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+CREATE TABLE tpp_user_consent_history
+(
+    `id` INTEGER PRIMARY KEY NOT NULL AUTO_INCREMENT,
+    `user_id` VARCHAR(256) NOT NULL,
+    `client_id` VARCHAR(256) NOT NULL,
+    `consent_id` VARCHAR(64) NOT NULL,
+    `consent_change` VARCHAR(16) NOT NULL,
+    `external_id` VARCHAR(256) NOT NULL,
+    `consent_parameters` TEXT NOT NULL,
+    `timestamp_created` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 ) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- Table UserConnection is required only for the demo client application which is based on Spring Social.

--- a/docs/sql/oracle/create_schema.sql
+++ b/docs/sql/oracle/create_schema.sql
@@ -1,3 +1,9 @@
+--
+--  Create sequences.
+--
+CREATE SEQUENCE "TPP_USER_CONSENT_SEQ" MINVALUE 1 MAXVALUE 9999999999999999999999999999 INCREMENT BY 1 START WITH 1 CACHE 20 NOORDER NOCYCLE;
+CREATE SEQUENCE "TPP_USER_CONSENT_HISTORY_SEQ" MINVALUE 1 MAXVALUE 9999999999999999999999999999 INCREMENT BY 1 START WITH 1 CACHE 20 NOORDER NOCYCLE;
+
 -- Table oauth_client_details stores details about OAuth2 client applications.
 -- Every Web Flow client application should have a record in this table.
 -- See: https://github.com/spring-projects/spring-security-oauth/blob/master/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/client/JdbcClientDetailsService.java
@@ -119,7 +125,7 @@ CREATE TABLE ns_operation (
   result                    VARCHAR(32),
   timestamp_created         TIMESTAMP,
   timestamp_expires         TIMESTAMP,
-  CONSTRAINT operation_organization_fk FOREIGN KEY (organization_id) REFERENCES ns_organization (organization_id),
+  CONSTRAINT operation_organization_fk FOREIGN KEY (organization_id) REFERENCES ns_organization (organization_id)
 );
 
 -- Table ns_operation_history stores all changes of operations.
@@ -180,6 +186,38 @@ CREATE TABLE da_sms_authorization (
   timestamp_created    TIMESTAMP,
   timestamp_verified   TIMESTAMP,
   timestamp_expires    TIMESTAMP
+);
+
+CREATE TABLE tpp_consent
+(
+	consent_id VARCHAR(64) PRIMARY KEY NOT NULL,
+	consent_name VARCHAR(128) NOT NULL,
+	consent_text CLOB NOT NULL,
+	version INT NOT NULL
+);
+
+CREATE TABLE tpp_user_consent
+(
+    id INTEGER PRIMARY KEY NOT NULL,
+    user_id VARCHAR(256) NOT NULL,
+    client_id VARCHAR(256) NOT NULL,
+    consent_id VARCHAR(64) NOT NULL,
+    external_id VARCHAR(256) NOT NULL,
+    consent_parameters CLOB NOT NULL,
+    timestamp_created TIMESTAMP,
+    timestamp_updated TIMESTAMP
+);
+
+CREATE TABLE tpp_user_consent_history
+(
+    id INTEGER PRIMARY KEY NOT NULL,
+    user_id VARCHAR(256) NOT NULL,
+    client_id VARCHAR(256) NOT NULL,
+    consent_id VARCHAR(64) NOT NULL,
+    consent_change VARCHAR(16) NOT NULL,
+    external_id VARCHAR(256) NOT NULL,
+    consent_parameters CLOB NOT NULL,
+    timestamp_created TIMESTAMP
 );
 
 -- Table UserConnection is required only for the demo client application which is based on Spring Social.

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,8 @@
         <module>powerauth-webflow-resources</module>
         <module>powerauth-webflow-client</module>
         <module>powerauth-mtoken-model</module>
+        <module>powerauth-tpp-engine</module>
+        <module>powerauth-tpp-engine-model</module>
     </modules>
 
     <properties>
@@ -192,7 +194,7 @@
                     <plugin>
                         <groupId>org.zeroturnaround</groupId>
                         <artifactId>jrebel-maven-plugin</artifactId>
-                        <version>1.1.8</version>
+                        <version>1.1.9</version>
                         <executions>
                             <execution>
                                 <id>generate-rebel-xml</id>

--- a/powerauth-tpp-engine-model/pom.xml
+++ b/powerauth-tpp-engine-model/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Wultra s.r.o.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>powerauth-tpp-engine-model</artifactId>
+
+    <parent>
+        <artifactId>powerauth-webflow-parent</artifactId>
+        <groupId>io.getlime.security</groupId>
+        <version>0.22.0</version>
+    </parent>
+
+    <dependencies>
+        <!-- PowerAuth Dependencies -->
+        <dependency>
+            <groupId>io.getlime.core</groupId>
+            <artifactId>rest-model-base</artifactId>
+            <version>1.1.0</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/entity/GivenConsent.java
+++ b/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/entity/GivenConsent.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine.model.entity;
+
+import java.util.Date;
+
+/**
+ * Response entity representing consent status for given user and TPP app.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+public class GivenConsent {
+
+    /**
+     * Given consent ID.
+     */
+    private Long id;
+
+    /**
+     * TPP application client ID.
+     */
+    private String clientId;
+
+    /**
+     * Consent ID.
+     */
+    private String consentId;
+
+    /**
+     * Name of the consent.
+     */
+    private String consentName;
+
+    /**
+     * Text of the consent (possibly with placeholders).
+     */
+    private String consentText;
+
+    /**
+     * Parameters of the consent, to be filled in to placeholders.
+     */
+    private String consentParameters;
+
+    /**
+     * External ID of the consent initiation, usually related to operation ID or some other
+     * ID uniquely related to the operation.
+     */
+    private String externalId;
+
+    /**
+     * Timestamp the consent was created.
+     */
+    private Date timestampCreated;
+
+    /**
+     * Timestamp the consent was last re-approved.
+     */
+    private Date timestampUpdated;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getConsentId() {
+        return consentId;
+    }
+
+    public void setConsentId(String consentId) {
+        this.consentId = consentId;
+    }
+
+    public String getConsentName() {
+        return consentName;
+    }
+
+    public void setConsentName(String consentName) {
+        this.consentName = consentName;
+    }
+
+    public String getConsentText() {
+        return consentText;
+    }
+
+    public void setConsentText(String consentText) {
+        this.consentText = consentText;
+    }
+
+    public String getConsentParameters() {
+        return consentParameters;
+    }
+
+    public void setConsentParameters(String consentParameters) {
+        this.consentParameters = consentParameters;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+
+    public Date getTimestampCreated() {
+        return timestampCreated;
+    }
+
+    public void setTimestampCreated(Date timestampCreated) {
+        this.timestampCreated = timestampCreated;
+    }
+
+    public Date getTimestampUpdated() {
+        return timestampUpdated;
+    }
+
+    public void setTimestampUpdated(Date timestampUpdated) {
+        this.timestampUpdated = timestampUpdated;
+    }
+}

--- a/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/entity/GivenConsentHistory.java
+++ b/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/entity/GivenConsentHistory.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine.model.entity;
+
+import java.util.Date;
+
+/**
+ * Response entity object in the consent history.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+public class GivenConsentHistory {
+
+    /**
+     * Given consent ID.
+     */
+    private Long id;
+
+    /**
+     * TPP application client ID.
+     */
+    private String clientId;
+
+    /**
+     * Change of the consent that was made. This data item is backed by
+     * {@link io.getlime.security.powerauth.app.tppengine.model.enumeration.ConsentChange}
+     * and can have the same values (represented as string).
+     */
+    private String change;
+
+    /**
+     * Consent ID.
+     */
+    private String consentId;
+
+    /**
+     * Name of the consent.
+     */
+    private String consentName;
+
+    /**
+     * Text of the consent, possibly with placeholders.
+     */
+    private String consentText;
+
+    /**
+     * Consent parameters, to be filled to placeholders.
+     */
+    private String consentParameters;
+
+    /**
+     * External ID of the consent initiation, usually related to operation ID or some other
+     * ID uniquely related to the operation.
+     */
+    private String externalId;
+
+    /**
+     * Timestamp of when the change was made.
+     */
+    private Date timestampCreated;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getChange() {
+        return change;
+    }
+
+    public void setChange(String change) {
+        this.change = change;
+    }
+
+    public String getConsentId() {
+        return consentId;
+    }
+
+    public void setConsentId(String consentId) {
+        this.consentId = consentId;
+    }
+
+    public String getConsentName() {
+        return consentName;
+    }
+
+    public void setConsentName(String consentName) {
+        this.consentName = consentName;
+    }
+
+    public String getConsentText() {
+        return consentText;
+    }
+
+    public void setConsentText(String consentText) {
+        this.consentText = consentText;
+    }
+
+    public String getConsentParameters() {
+        return consentParameters;
+    }
+
+    public void setConsentParameters(String consentParameters) {
+        this.consentParameters = consentParameters;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+
+    public Date getTimestampCreated() {
+        return timestampCreated;
+    }
+
+    public void setTimestampCreated(Date timestampCreated) {
+        this.timestampCreated = timestampCreated;
+    }
+}

--- a/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/enumeration/ConsentChange.java
+++ b/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/enumeration/ConsentChange.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine.model.enumeration;
+
+/**
+ * Enum representing a status change of a consent.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+public enum ConsentChange {
+
+    /**
+     * Consent was granted.
+     */
+    APPROVE,
+
+    /**
+     * Consent was prolonged.
+     */
+    PROLONG,
+
+    /**
+     * Consent was rejected.
+     */
+    REJECT
+
+}

--- a/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/request/GiveConsentRequest.java
+++ b/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/request/GiveConsentRequest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine.model.request;
+
+import java.util.Map;
+
+/**
+ * Request for giving a consent (with provided ID) to third party provider (with given ID).
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+public class GiveConsentRequest {
+
+    /**
+     * User ID.
+     */
+    private String userId;
+
+    /**
+     * Consent ID.
+     */
+    private String consentId;
+
+    /**
+     * TPP app client ID.
+     */
+    private String clientId;
+
+    /**
+     * (optional) External ID, usually associated with operation ID.
+     */
+    private String externalId;
+
+    /**
+     * Consent parameters, to be filled into the consent text.
+     */
+    private Map<String, String> parameters;
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getConsentId() {
+        return consentId;
+    }
+
+    public void setConsentId(String consentId) {
+        this.consentId = consentId;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+
+    public void setParameters(Map<String, String> parameters) {
+        this.parameters = parameters;
+    }
+
+    public Map<String, String> getParameters() {
+        return parameters;
+    }
+}

--- a/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/request/RemoveConsentRequest.java
+++ b/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/request/RemoveConsentRequest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine.model.request;
+
+/**
+ * Request for removing a consent (with provided ID) to third party provider (with given ID).
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+public class RemoveConsentRequest {
+
+    /**
+     * User ID.
+     */
+    private String userId;
+
+    /**
+     * Consent ID.
+     */
+    private String consentId;
+
+    /**
+     * TPP app client ID.
+     */
+    private String clientId;
+
+    /**
+     * (optional) External identification of the change.
+     */
+    private String externalId;
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getConsentId() {
+        return consentId;
+    }
+
+    public void setConsentId(String consentId) {
+        this.consentId = consentId;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+}

--- a/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/response/ConsentDetailResponse.java
+++ b/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/response/ConsentDetailResponse.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine.model.response;
+
+/**
+ * Class representing a consent detail response.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+public class ConsentDetailResponse {
+
+    /**
+     * Identifier of the consent used for the consent query.
+     */
+    private String id;
+
+    /**
+     * Name of the consent, used for display of the list of existing consents.
+     */
+    private String name;
+
+    /**
+     * Text of the consent. It may contains placeholders in the form `{{PLACEHOLDER}}` that will
+     * be replaced at the later stages with a specific text (for example, a TPP name, an app name
+     * or resource owner data).
+     */
+    private String text;
+
+    /**
+     * Current version of the consent.
+     */
+    private Long version;
+
+    /**
+     * Non-parametric constructor.
+     */
+    public ConsentDetailResponse() {
+    }
+
+    /**
+     * Constructor for consent information.
+     * @param id Identifier of the consent.
+     * @param name Name of the consent, used for display.
+     * @param text Text of the consent with the placeholders (raw consent string).
+     * @param version Consent version.
+     */
+    public ConsentDetailResponse(String id, String name, String text, Long version) {
+        this.id = id;
+        this.name = name;
+        this.text = text;
+        this.version = version;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public Long getVersion() {
+        return version;
+    }
+
+    public void setVersion(Long version) {
+        this.version = version;
+    }
+}

--- a/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/response/ConsentHistoryListResponse.java
+++ b/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/response/ConsentHistoryListResponse.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine.model.response;
+
+import io.getlime.security.powerauth.app.tppengine.model.entity.GivenConsentHistory;
+
+import java.util.List;
+
+/**
+ * Class representing a response of the consent history for given user.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+public class ConsentHistoryListResponse {
+
+    /**
+     * User ID.
+     */
+    private String userId;
+
+    /**
+     * List of history items related to user consents.
+     */
+    private List<GivenConsentHistory> history;
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public List<GivenConsentHistory> getHistory() {
+        return history;
+    }
+
+    public void setHistory(List<GivenConsentHistory> history) {
+        this.history = history;
+    }
+}

--- a/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/response/ConsentListResponse.java
+++ b/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/response/ConsentListResponse.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine.model.response;
+
+import io.getlime.security.powerauth.app.tppengine.model.entity.GivenConsent;
+
+import java.util.List;
+
+/**
+ * Class representing currently given consents by a user.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+public class ConsentListResponse {
+
+    /**
+     * User ID.
+     */
+    private String userId;
+
+    /**
+     * List of consents currently given by the user.
+     */
+    private List<GivenConsent> consents;
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public List<GivenConsent> getConsents() {
+        return consents;
+    }
+
+    public void setConsents(List<GivenConsent> consents) {
+        this.consents = consents;
+    }
+}

--- a/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/response/GiveConsentResponse.java
+++ b/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/response/GiveConsentResponse.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine.model.response;
+
+/**
+ * Information about just given consent.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+public class GiveConsentResponse {
+
+    /**
+     * Given consent ID.
+     */
+    private Long id;
+
+    /**
+     * User ID.
+     */
+    private String userId;
+
+    /**
+     * TPP application client ID.
+     */
+    private String clientId;
+
+    /**
+     * Consent ID.
+     */
+    private String consentId;
+
+    /**
+     * Name of the consent.
+     */
+    private String consentName;
+
+    /**
+     * Text of the consent, possibly with placeholders.
+     */
+    private String consentText;
+
+    /**
+     * Parameters of the consent, to be filled in to placeholders.
+     */
+    private String consentParameters;
+
+    /**
+     * External ID of the consent initiation, usually related to operation ID or some other
+     * ID uniquely related to the operation.
+     */
+    private String externalId;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getConsentId() {
+        return consentId;
+    }
+
+    public void setConsentId(String consentId) {
+        this.consentId = consentId;
+    }
+
+    public String getConsentName() {
+        return consentName;
+    }
+
+    public void setConsentName(String consentName) {
+        this.consentName = consentName;
+    }
+
+    public String getConsentText() {
+        return consentText;
+    }
+
+    public void setConsentText(String consentText) {
+        this.consentText = consentText;
+    }
+
+    public String getConsentParameters() {
+        return consentParameters;
+    }
+
+    public void setConsentParameters(String consentParameters) {
+        this.consentParameters = consentParameters;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+}

--- a/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/response/UserConsentDetailResponse.java
+++ b/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/response/UserConsentDetailResponse.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine.model.response;
+
+import io.getlime.security.powerauth.app.tppengine.model.entity.GivenConsent;
+
+/**
+ * Response object representing a given consent to TPP app by given user.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+public class UserConsentDetailResponse {
+
+    /**
+     * User ID.
+     */
+    private String userId;
+
+    /**
+     * Information about given consent, or null in case a consent is not given by the user.
+     */
+    private GivenConsent consent;
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public GivenConsent getConsent() {
+        return consent;
+    }
+
+    public void setConsent(GivenConsent consent) {
+        this.consent = consent;
+    }
+}

--- a/powerauth-tpp-engine/pom.xml
+++ b/powerauth-tpp-engine/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <name>powerauth-nextstep</name>
-    <artifactId>powerauth-nextstep</artifactId>
-    <description>PowerAuth 2.0 Next Step Server</description>
+    <name>powerauth-tpp-engine</name>
+    <artifactId>powerauth-tpp-engine</artifactId>
+    <description>Default TPP registry and consent engine implementation</description>
     <version>0.22.0</version>
     <packaging>war</packaging>
 
@@ -17,7 +17,6 @@
     </parent>
 
     <dependencies>
-
         <!-- Spring Boot -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -40,7 +39,7 @@
         <!-- PowerAuth Dependencies -->
         <dependency>
             <groupId>io.getlime.security</groupId>
-            <artifactId>powerauth-nextstep-model</artifactId>
+            <artifactId>powerauth-tpp-engine-model</artifactId>
             <version>0.22.0</version>
         </dependency>
 
@@ -49,18 +48,6 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
             <version>2.10.0.pr1</version>
-        </dependency>
-
-        <!-- JAXB dependency for Java 11 -->
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jaxb</groupId>
-            <artifactId>jaxb-runtime</artifactId>
-            <version>2.3.1</version>
         </dependency>
 
         <!-- Documentation -->

--- a/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/ServletInitializer.java
+++ b/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/ServletInitializer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine;
+
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+
+public class ServletInitializer extends SpringBootServletInitializer {
+
+    @Override
+    protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
+        return application.sources(TppEngineApplication.class);
+    }
+
+}

--- a/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/TppEngineApplication.java
+++ b/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/TppEngineApplication.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TppEngineApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(TppEngineApplication.class, args);
+    }
+
+}

--- a/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/configuration/SecurityConfig.java
+++ b/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/configuration/SecurityConfig.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+/**
+ * Default Spring Security configuration.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+@Configuration
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    /**
+     * Configures HTTP security.
+     * @param http HTTP security.
+     * @throws Exception Thrown when configuration fails.
+     */
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.httpBasic().disable();
+        http.csrf().disable();
+    }
+
+}

--- a/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/configuration/SwaggerConfiguration.java
+++ b/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/configuration/SwaggerConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+/**
+ * Configuration class used for setting up Swagger documentation.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+@Configuration
+@EnableSwagger2
+public class SwaggerConfiguration {
+
+    @Bean
+    public Docket productApi() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("io.getlime.security.powerauth.app.tppengine"))
+                .paths(PathSelectors.any())
+                .build();
+    }
+
+}

--- a/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/controller/ConsentInfoController.java
+++ b/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/controller/ConsentInfoController.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine.controller;
+
+import io.getlime.core.rest.model.base.response.ObjectResponse;
+import io.getlime.security.powerauth.app.tppengine.exception.ConsentNotFoundException;
+import io.getlime.security.powerauth.app.tppengine.model.response.ConsentDetailResponse;
+import io.getlime.security.powerauth.app.tppengine.service.ConsentService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Controller class for providing information about consent.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+@RestController
+@RequestMapping("consent")
+public class ConsentInfoController {
+
+    private final ConsentService consentService;
+
+    @Autowired
+    public ConsentInfoController(ConsentService consentService) {
+        this.consentService = consentService;
+    }
+
+    @RequestMapping(method = RequestMethod.GET)
+    public ObjectResponse<ConsentDetailResponse> consentDetail(@RequestParam("id") String id) throws ConsentNotFoundException {
+        final ConsentDetailResponse response = consentService.consentDetail(id);
+        if (response == null) {
+            throw new ConsentNotFoundException(id);
+        } else {
+            return new ObjectResponse<>(response);
+        }
+    }
+
+}

--- a/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/controller/UserConsentController.java
+++ b/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/controller/UserConsentController.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine.controller;
+
+import io.getlime.core.rest.model.base.request.ObjectRequest;
+import io.getlime.core.rest.model.base.response.ObjectResponse;
+import io.getlime.core.rest.model.base.response.Response;
+import io.getlime.security.powerauth.app.tppengine.exception.ConsentNotFoundException;
+import io.getlime.security.powerauth.app.tppengine.model.request.GiveConsentRequest;
+import io.getlime.security.powerauth.app.tppengine.model.request.RemoveConsentRequest;
+import io.getlime.security.powerauth.app.tppengine.model.response.ConsentHistoryListResponse;
+import io.getlime.security.powerauth.app.tppengine.model.response.ConsentListResponse;
+import io.getlime.security.powerauth.app.tppengine.model.response.GiveConsentResponse;
+import io.getlime.security.powerauth.app.tppengine.model.response.UserConsentDetailResponse;
+import io.getlime.security.powerauth.app.tppengine.service.UserConsentService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Controller class for providing information about consents given or rejected by given users.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+@RestController
+@RequestMapping("user")
+public class UserConsentController {
+
+    private final UserConsentService userConsentService;
+
+    @Autowired
+    public UserConsentController(UserConsentService userConsentService) {
+        this.userConsentService = userConsentService;
+    }
+
+    /**
+     * Create a new approved consent to a TPP app for given user ID.
+     *
+     * @param request Information about the consent to create.
+     * @return Response with consent created.
+     */
+    @RequestMapping(value = "consent", method = RequestMethod.POST)
+    public ObjectResponse<GiveConsentResponse> giveConsent(@RequestBody ObjectRequest<GiveConsentRequest> request) throws ConsentNotFoundException {
+        final GiveConsentRequest requestObject = request.getRequestObject();
+        //TODO: add validator
+        GiveConsentResponse response = userConsentService.giveConsent(requestObject);
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Remove (reject) a consent from a TPP app for given user ID.
+     *
+     * @param request Information about consent to remove.
+     * @return Information about success or failure.
+     */
+    @RequestMapping(value = "consent", method = RequestMethod.DELETE)
+    public Response removeConsent(@RequestBody ObjectRequest<RemoveConsentRequest> request) throws ConsentNotFoundException {
+        RemoveConsentRequest requestObject = request.getRequestObject();
+        //TODO: add validator
+        userConsentService.removeConsent(requestObject);
+        return new Response();
+    }
+
+    /**
+     * Remove (reject) a consent from a TPP app for given user ID. Backup method using POST, instead of DELETE.
+     *
+     * @param request Information about consent to remove.
+     * @return Information about success or failure.
+     */
+    @RequestMapping(value = "consent/delete", method = RequestMethod.POST)
+    public Response removeConsentPost(@RequestBody ObjectRequest<RemoveConsentRequest> request) throws ConsentNotFoundException {
+        RemoveConsentRequest requestObject = request.getRequestObject();
+        //TODO: add validator
+        userConsentService.removeConsent(requestObject);
+        return new Response();
+    }
+
+    /**
+     * Remove (reject) a consent with given ID.
+     *
+     * @param consentId Consent ID.
+     * @return Information about success or failure.
+     */
+    @RequestMapping(value = "consent/id", method = RequestMethod.DELETE)
+    public Response removeConsent(@RequestParam("cid") Long consentId) throws ConsentNotFoundException {
+        userConsentService.removeConsent(consentId);
+        return new Response();
+    }
+
+    /**
+     * Remove (reject) a consent with given ID. Backup method using POST, instead of DELETE.
+     *
+     * @param consentId Consent ID.
+     * @return Information about success or failure.
+     */
+    @RequestMapping(value = "consent/id/delete", method = RequestMethod.POST)
+    public Response removeConsentPost(@RequestParam("cid") Long consentId) throws ConsentNotFoundException {
+        userConsentService.removeConsent(consentId);
+        return new Response();
+    }
+
+    /**
+     * Return the list of all current consents for a given user and optionally, filtered for given TPP app.
+     *
+     * @param userId User ID.
+     * @param clientId (optional) TPP App Client ID.
+     * @return List of consents that are currently active.
+     */
+    @RequestMapping(value = "consent", method = RequestMethod.GET)
+    public ObjectResponse<ConsentListResponse> listConsent(@RequestParam("userId") String userId, @RequestParam(value = "clientId", required = false) String clientId) throws ConsentNotFoundException {
+        final ConsentListResponse response = userConsentService.consentListForUser(userId, clientId);
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Return the detail of current status of a consent for a given user and third party app.
+     *
+     * @param userId User ID.
+     * @param clientId TPP App Client ID.
+     * @param consentId Consent ID.
+     * @return Check
+     */
+    @RequestMapping(value = "consent/status", method = RequestMethod.GET)
+    public ObjectResponse<UserConsentDetailResponse> listConsent(@RequestParam("userId") String userId, @RequestParam("clientId") String clientId, @RequestParam("consentId") String consentId) throws ConsentNotFoundException {
+        UserConsentDetailResponse response = userConsentService.consentStatus(userId, consentId, clientId);
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * History of consent approval or rejection for given user. Optionally, a TPP app may be specified to
+     * narrow down the results.
+     *
+     * @param userId User ID.
+     * @param clientId (optional) TPP App Client ID.
+     * @return List of history items.
+     */
+    @RequestMapping(value = "consent/history", method = RequestMethod.GET)
+    public ObjectResponse<ConsentHistoryListResponse> historyConsent(@RequestParam("userId") String userId, @RequestParam(value = "clientId", required = false) String clientId) throws ConsentNotFoundException {
+        ConsentHistoryListResponse response = userConsentService.consentHistoryForUser(userId, clientId);
+        return new ObjectResponse<>(response);
+    }
+
+}

--- a/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/converter/ConsentConverter.java
+++ b/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/converter/ConsentConverter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine.converter;
+
+import io.getlime.security.powerauth.app.tppengine.model.response.ConsentDetailResponse;
+import io.getlime.security.powerauth.app.tppengine.repository.model.entity.ConsentEntity;
+
+/**
+ * Converter related to consent entity conversions.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+public class ConsentConverter {
+
+    /**
+     * Convert a new consent detail response from database ce.
+     * @param ce Database ce representing a consent.
+     * @return Response object for consent detail.
+     */
+    public ConsentDetailResponse fromConsentEntity(ConsentEntity ce) {
+        return new ConsentDetailResponse(ce.getId(), ce.getName(), ce.getText(), ce.getVersion());
+    }
+
+}

--- a/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/exception/ConsentError.java
+++ b/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/exception/ConsentError.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine.exception;
+
+import io.getlime.core.rest.model.base.entity.Error;
+
+/**
+ * Error related to consent.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+public class ConsentError extends Error {
+
+    private static final String code = "CONSENT_ERROR";
+
+    public ConsentError() {
+        super();
+        this.setCode(code);
+    }
+
+    public ConsentError(String message) {
+        super(code, message);
+    }
+}

--- a/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/exception/ConsentNotFoundException.java
+++ b/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/exception/ConsentNotFoundException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine.exception;
+
+/**
+ * Exception thrown on missing consent.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+public class ConsentNotFoundException extends Exception {
+
+    private final String id;
+
+    public ConsentNotFoundException(String id) {
+        super();
+        this.id = id;
+    }
+
+    /**
+     * Get ID of the consent that was not found.
+     * @return ID of the consent that was not found.
+     */
+    public String getId() {
+        return id;
+    }
+
+}

--- a/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/exception/DefaultExceptionResolver.java
+++ b/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/exception/DefaultExceptionResolver.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine.exception;
+
+import io.getlime.core.rest.model.base.entity.Error;
+import io.getlime.core.rest.model.base.response.ErrorResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Controller advice responsible for default exception resolving.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+@ControllerAdvice
+public class DefaultExceptionResolver {
+
+    private static final Logger logger = LoggerFactory.getLogger(DefaultExceptionResolver.class);
+
+    /**
+     * Default exception handler, for unexpected errors.
+     * @param t Throwable.
+     * @return Response with error details.
+     */
+    @ExceptionHandler(Throwable.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public @ResponseBody ErrorResponse handleDefaultException(Throwable t) {
+        logger.error("Error occurred in TPP engine server", t);
+        Error error = new Error(Error.Code.ERROR_GENERIC, "error.unknown");
+        return new ErrorResponse(error);
+    }
+
+    /**
+     * Exception thrown in case consent was not found.
+     * @param t Exception thrown when consent is not found.
+     * @return Response with error details.
+     */
+    @ExceptionHandler(ConsentNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public @ResponseBody ErrorResponse handleConsentNotFoundException(ConsentNotFoundException t) {
+        logger.error("Consent with ID {} was not found", t.getId(), t);
+        return new ErrorResponse(new ConsentError("consent.missing"));
+    }
+
+}

--- a/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/repository/ConsentRepository.java
+++ b/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/repository/ConsentRepository.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine.repository;
+
+import io.getlime.security.powerauth.app.tppengine.repository.model.entity.ConsentEntity;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+/**
+ * Repository used for accessing the consent database.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+@Repository
+public interface ConsentRepository extends CrudRepository<ConsentEntity, String> {
+
+    @Query("SELECT c FROM ConsentEntity c WHERE c.id = :id ORDER BY c.version DESC")
+    Optional<ConsentEntity> findFirstById(@Param("id") String id);
+
+}

--- a/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/repository/UserConsentHistoryRepository.java
+++ b/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/repository/UserConsentHistoryRepository.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine.repository;
+
+import io.getlime.security.powerauth.app.tppengine.repository.model.entity.UserConsentHistoryEntity;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * Repository responsible for storing history of adding and removing consents of given user
+ * to TPP app.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+@Repository
+public interface UserConsentHistoryRepository extends CrudRepository<UserConsentHistoryEntity, Long> {
+
+    @Query("SELECT che FROM UserConsentHistoryEntity che WHERE che.userId = :userId")
+    List<UserConsentHistoryEntity> consentHistoryForUser(@Param("userId") String userId);
+
+    @Query("SELECT che FROM UserConsentHistoryEntity che WHERE che.userId = :userId AND che.clientId = :clientId")
+    List<UserConsentHistoryEntity> consentHistoryForUser(@Param("userId") String userId, @Param("clientId") String clientId);
+
+}

--- a/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/repository/UserConsentRepository.java
+++ b/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/repository/UserConsentRepository.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine.repository;
+
+import io.getlime.security.powerauth.app.tppengine.repository.model.entity.UserConsentEntity;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Repository interface used for storing approved and removing rejected consents
+ * of a user and TPP app.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+@Repository
+public interface UserConsentRepository extends CrudRepository<UserConsentEntity, Long> {
+
+    @Query("SELECT uc FROM UserConsentEntity uc WHERE uc.userId = :userId AND uc.clientId = :clientId AND uc.consentId = :consentId")
+    Optional<UserConsentEntity> findConsentStatus(@Param("userId") String userId, @Param("consentId") String consentId, @Param("clientId") String clientId);
+
+    @Query("SELECT uc FROM UserConsentEntity uc WHERE uc.userId = :userId")
+    List<UserConsentEntity> findAllConsentsGivenByUser(@Param("userId") String userId);
+
+    @Query("SELECT uc FROM UserConsentEntity uc WHERE uc.userId = :userId AND uc.clientId = :clientId")
+    List<UserConsentEntity> findConsentsGivenByUserToApp(@Param("userId") String userId, @Param("clientId") String clientId);
+
+}

--- a/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/repository/model/entity/ConsentEntity.java
+++ b/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/repository/model/entity/ConsentEntity.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine.repository.model.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.io.Serializable;
+
+/**
+ * Database entity representing a consent.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+@Entity
+@Table(name = "tpp_consent")
+public class ConsentEntity implements Serializable {
+
+    @Id
+    @Column(name = "consent_id")
+    private String id;
+
+    @Column(name = "consent_name")
+    private String name;
+
+    @Column(name = "consent_text")
+    private String text;
+
+    @Column(name = "version")
+    private Long version;
+
+    /**
+     * Get consent ID.
+     * @return Consent ID.
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Set consent ID.
+     * @param id Consent ID.
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Get consent name.
+     * @return Consent name.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Set consent name.
+     * @param name Consent name.
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Get consent text.
+     * @return Consent text.
+     */
+    public String getText() {
+        return text;
+    }
+
+    /**
+     * Set consent text.
+     * @param text Consent text.
+     */
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    /**
+     * Get consent version.
+     * @return Consent version.
+     */
+    public Long getVersion() {
+        return version;
+    }
+
+    /**
+     * Set consent version.
+     * @param version Consent version.
+     */
+    public void setVersion(Long version) {
+        this.version = version;
+    }
+}

--- a/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/repository/model/entity/UserConsentEntity.java
+++ b/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/repository/model/entity/UserConsentEntity.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine.repository.model.entity;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * Entity representing the current status of a consent.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+@Entity
+@Table(name = "tpp_user_consent")
+public class UserConsentEntity implements Serializable {
+
+    @Id
+    @SequenceGenerator(name = "tpp_user_consent", sequenceName = "tpp_user_consent_seq")
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "tpp_user_consent")
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "user_id")
+    private String userId;
+
+    @Column(name = "client_id")
+    private String clientId;
+
+    @Column(name = "consent_id")
+    private String consentId;
+
+    @Column(name = "consent_parameters")
+    private String parameters;
+
+    @Column(name = "external_id")
+    private String externalId;
+
+    @Column(name = "timestamp_created")
+    private Date timestampCreated;
+
+    @Column(name = "timestamp_updated")
+    private Date timestampUpdated;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getConsentId() {
+        return consentId;
+    }
+
+    public void setConsentId(String consentId) {
+        this.consentId = consentId;
+    }
+
+    public String getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(String parameters) {
+        this.parameters = parameters;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+
+    public Date getTimestampCreated() {
+        return timestampCreated;
+    }
+
+    public void setTimestampCreated(Date timestampCreated) {
+        this.timestampCreated = timestampCreated;
+    }
+
+    public Date getTimestampUpdated() {
+        return timestampUpdated;
+    }
+
+    public void setTimestampUpdated(Date timestampUpdated) {
+        this.timestampUpdated = timestampUpdated;
+    }
+}

--- a/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/repository/model/entity/UserConsentHistoryEntity.java
+++ b/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/repository/model/entity/UserConsentHistoryEntity.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine.repository.model.entity;
+
+import io.getlime.security.powerauth.app.tppengine.model.enumeration.ConsentChange;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * Database entity representing a historic event of consent approval or rejection,
+ * useful mainly for auditing purposes and for informing the end user.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+@Entity
+@Table(name = "tpp_user_consent_history")
+public class UserConsentHistoryEntity implements Serializable {
+
+    @Id
+    @SequenceGenerator(name = "tpp_user_consent_history", sequenceName = "tpp_user_consent_history_seq")
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "tpp_user_consent_history")
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "user_id")
+    private String userId;
+
+    @Column(name = "client_id")
+    private String clientId;
+
+    @Column(name = "consent_id")
+    private String consentId;
+
+    @Column(name = "consent_change")
+    @Enumerated(EnumType.STRING)
+    private ConsentChange change;
+
+    @Column(name = "external_id")
+    private String externalId;
+
+    @Column(name = "consent_parameters")
+    private String parameters;
+
+    @Column(name = "timestamp_created")
+    private Date timestampCreated;
+
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getConsentId() {
+        return consentId;
+    }
+
+    public void setConsentId(String consentId) {
+        this.consentId = consentId;
+    }
+
+    public ConsentChange getChange() {
+        return change;
+    }
+
+    public void setChange(ConsentChange change) {
+        this.change = change;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+
+    public String getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(String parameters) {
+        this.parameters = parameters;
+    }
+
+    public Date getTimestampCreated() {
+        return timestampCreated;
+    }
+
+    public void setTimestampCreated(Date timestampCreated) {
+        this.timestampCreated = timestampCreated;
+    }
+
+}

--- a/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/service/ConsentService.java
+++ b/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/service/ConsentService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine.service;
+
+import io.getlime.security.powerauth.app.tppengine.converter.ConsentConverter;
+import io.getlime.security.powerauth.app.tppengine.model.response.ConsentDetailResponse;
+import io.getlime.security.powerauth.app.tppengine.repository.ConsentRepository;
+import io.getlime.security.powerauth.app.tppengine.repository.model.entity.ConsentEntity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+/**
+ * Service used for accessing consent business logic.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+@Service
+public class ConsentService {
+
+    private final ConsentRepository consentRepository;
+
+    private final ConsentConverter consentConverter = new ConsentConverter();
+
+    @Autowired
+    public ConsentService(ConsentRepository consentRepository) {
+        this.consentRepository = consentRepository;
+    }
+
+    public ConsentDetailResponse consentDetail(String id) {
+        final Optional<ConsentEntity> consentEntity = consentRepository.findFirstById(id);
+        return consentEntity
+                .map(consentConverter::fromConsentEntity)
+                .orElse(null);
+    }
+
+}

--- a/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/service/UserConsentService.java
+++ b/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/service/UserConsentService.java
@@ -1,0 +1,397 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.getlime.security.powerauth.app.tppengine.exception.ConsentNotFoundException;
+import io.getlime.security.powerauth.app.tppengine.model.entity.GivenConsent;
+import io.getlime.security.powerauth.app.tppengine.model.entity.GivenConsentHistory;
+import io.getlime.security.powerauth.app.tppengine.model.enumeration.ConsentChange;
+import io.getlime.security.powerauth.app.tppengine.model.request.GiveConsentRequest;
+import io.getlime.security.powerauth.app.tppengine.model.request.RemoveConsentRequest;
+import io.getlime.security.powerauth.app.tppengine.model.response.ConsentHistoryListResponse;
+import io.getlime.security.powerauth.app.tppengine.model.response.ConsentListResponse;
+import io.getlime.security.powerauth.app.tppengine.model.response.GiveConsentResponse;
+import io.getlime.security.powerauth.app.tppengine.model.response.UserConsentDetailResponse;
+import io.getlime.security.powerauth.app.tppengine.repository.ConsentRepository;
+import io.getlime.security.powerauth.app.tppengine.repository.UserConsentHistoryRepository;
+import io.getlime.security.powerauth.app.tppengine.repository.UserConsentRepository;
+import io.getlime.security.powerauth.app.tppengine.repository.model.entity.ConsentEntity;
+import io.getlime.security.powerauth.app.tppengine.repository.model.entity.UserConsentEntity;
+import io.getlime.security.powerauth.app.tppengine.repository.model.entity.UserConsentHistoryEntity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.*;
+
+/**
+ * Service responsible for managing consent that users gave to the TPP apps.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+@Service
+public class UserConsentService {
+
+    private final ConsentRepository consentRepository;
+    private final UserConsentRepository userConsentRepository;
+    private final UserConsentHistoryRepository userConsentHistoryRepository;
+
+    @Autowired
+    public UserConsentService(ConsentRepository consentRepository, UserConsentRepository userConsentRepository, UserConsentHistoryRepository userConsentHistoryRepository) {
+        this.consentRepository = consentRepository;
+        this.userConsentRepository = userConsentRepository;
+        this.userConsentHistoryRepository = userConsentHistoryRepository;
+    }
+
+    /**
+     * Provide a list of all consents for given user, for a given TPP app.
+     *
+     * @param userId User ID.
+     * @param clientId Client ID (TPP app ID).
+     * @return List of all current consents for given TPP app.
+     * @throws ConsentNotFoundException In case some approved consent is not found due to database inconsistency.
+     */
+    @Transactional
+    public ConsentListResponse consentListForUser(String userId, String clientId) throws ConsentNotFoundException {
+
+        // Get the consents
+        final List<UserConsentEntity> consentEntities;
+        if (clientId != null) {
+            consentEntities = userConsentRepository.findConsentsGivenByUserToApp(userId, clientId);
+        } else {
+            consentEntities = userConsentRepository.findAllConsentsGivenByUser(userId);
+        }
+        final List<GivenConsent> givenConsents = listConsentsByUser(consentEntities);
+
+        // Prepare and return the response object
+        ConsentListResponse response = new ConsentListResponse();
+        response.setUserId(userId);
+        response.setConsents(givenConsents);
+        return response;
+    }
+
+    /**
+     * Provide a consent status for given user, TPP app and consent type.
+     *
+     * @param userId User ID.
+     * @param consentId Consent ID.
+     * @param clientId Client ID (TPP app ID).
+     * @return Information about consent status.
+     * @throws ConsentNotFoundException In case some approved consent is not found due to database inconsistency.
+     */
+    @Transactional
+    public UserConsentDetailResponse consentStatus(String userId, String consentId, String clientId) throws ConsentNotFoundException {
+
+        // Check if a consent with given consent ID exists
+        final Optional<ConsentEntity> consentOptional = consentRepository.findFirstById(consentId);
+        if (!consentOptional.isPresent()) {
+            throw new ConsentNotFoundException(consentId);
+        }
+        final ConsentEntity consent = consentOptional.get();
+
+        final Optional<UserConsentEntity> consentStatusOptional = userConsentRepository.findConsentStatus(userId, consentId, clientId);
+        if (consentStatusOptional.isPresent()) {
+
+            final UserConsentEntity consentStatus = consentStatusOptional.get();
+
+            //TODO: Replace by converter
+            GivenConsent givenConsent = new GivenConsent();
+            givenConsent.setId(consentStatus.getId());
+            givenConsent.setClientId(consentStatus.getClientId());
+            givenConsent.setConsentId(consentStatus.getConsentId());
+            givenConsent.setConsentParameters(consentStatus.getParameters());
+            givenConsent.setExternalId(consentStatus.getExternalId());
+            givenConsent.setTimestampCreated(consentStatus.getTimestampCreated());
+            givenConsent.setTimestampUpdated(consentStatus.getTimestampUpdated());
+            givenConsent.setConsentName(consent.getName());
+            givenConsent.setConsentText(consent.getText());
+
+            UserConsentDetailResponse response = new UserConsentDetailResponse();
+            response.setUserId(userId);
+            response.setConsent(givenConsent);
+
+            return response;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Create a consent approval for given TPP app by provided user.
+     *
+     * @param ro Request object with details of the consent.
+     * @return Response related to consent approval.
+     */
+    @Transactional
+    public GiveConsentResponse giveConsent(GiveConsentRequest ro) throws ConsentNotFoundException {
+
+        // Check if a consent with given consent exists
+        final Optional<ConsentEntity> consentOptional = consentRepository.findFirstById(ro.getConsentId());
+        if (!consentOptional.isPresent()) {
+            throw new ConsentNotFoundException(ro.getConsentId());
+        }
+        final ConsentEntity consent = consentOptional.get();
+
+        // Find if a user already gave this consent, so that it can be updated on save
+        final Optional<UserConsentEntity> consentStatusOptional = userConsentRepository.findConsentStatus(ro.getUserId(), ro.getConsentId(), ro.getClientId());
+        final UserConsentEntity consentStatus;
+        final Date date = new Date();
+        final boolean isApproved;
+        if (consentStatusOptional.isPresent()) {
+            consentStatus = consentStatusOptional.get();
+            consentStatus.setExternalId(ro.getExternalId());
+            consentStatus.setTimestampUpdated(date);
+            isApproved = true;
+        } else {
+            consentStatus = new UserConsentEntity();
+            consentStatus.setUserId(ro.getUserId());
+            consentStatus.setConsentId(ro.getConsentId());
+            consentStatus.setClientId(ro.getClientId());
+            consentStatus.setParameters(convertToJsonString(ro.getParameters()));
+            consentStatus.setExternalId(ro.getExternalId());
+            consentStatus.setTimestampCreated(date);
+            consentStatus.setTimestampUpdated(date);
+            isApproved = false;
+        }
+        final UserConsentEntity savedConsentStatus = userConsentRepository.save(consentStatus);
+
+        // Log a record to the history table
+        logConsentChange(
+                savedConsentStatus.getUserId(),
+                savedConsentStatus.getConsentId(),
+                savedConsentStatus.getClientId(),
+                savedConsentStatus.getExternalId(),
+                savedConsentStatus.getParameters(),
+                date,
+                isApproved ? ConsentChange.PROLONG : ConsentChange.APPROVE
+        );
+
+        // Return the response with the consent details
+        GiveConsentResponse response = new GiveConsentResponse();
+        response.setId(savedConsentStatus.getId());
+        response.setUserId(savedConsentStatus.getUserId());
+        response.setConsentId(savedConsentStatus.getConsentId());
+        response.setClientId(savedConsentStatus.getClientId());
+        response.setConsentParameters(savedConsentStatus.getParameters());
+        response.setExternalId(savedConsentStatus.getExternalId());
+        response.setConsentName(consent.getName());
+        response.setConsentText(consent.getText());
+        return response;
+    }
+
+    /**
+     * Remove consent a user gave to a TPP app. In case the consent is not given, this method is a no-op.
+     *
+     * @param ro Request object with a consent to be removed.
+     * @throws ConsentNotFoundException In case a consent with given ID is not found.
+     */
+    @Transactional
+    public void removeConsent(RemoveConsentRequest ro) throws ConsentNotFoundException {
+
+        // Check if a consent with given consent exists
+        final Optional<ConsentEntity> consentOptional = consentRepository.findFirstById(ro.getConsentId());
+        if (!consentOptional.isPresent()) {
+            throw new ConsentNotFoundException(ro.getConsentId());
+        }
+
+        // In case a consent exists, reject it
+        Optional<UserConsentEntity> consentStatusOptional = userConsentRepository.findConsentStatus(ro.getUserId(), ro.getConsentId(), ro.getClientId());
+        if (consentStatusOptional.isPresent()) {
+            final UserConsentEntity consentStatus = consentStatusOptional.get();
+            userConsentRepository.deleteById(consentStatus.getId());
+
+            // Log a record to the history table
+            logConsentChange(
+                    consentStatus.getUserId(),
+                    consentStatus.getConsentId(),
+                    consentStatus.getClientId(),
+                    ro.getExternalId(),
+                    consentStatus.getParameters(),
+                    new Date(),
+                    ConsentChange.REJECT
+            );
+        }
+
+    }
+
+    /**
+     * Remove consent a user gave to a TPP app. In case a user consent with given ID does not exist, this
+     * operation is a no-op.
+     *
+     * @param id User consent ID to be removed.
+     */
+    @Transactional
+    public void removeConsent(Long id) throws ConsentNotFoundException {
+
+        // In case a consent exists, reject it
+        Optional<UserConsentEntity> consentStatusOptional = userConsentRepository.findById(id);
+        if (consentStatusOptional.isPresent()) {
+            final UserConsentEntity consentStatus = consentStatusOptional.get();
+
+            // Check if a consent with given consent exists
+            final Optional<ConsentEntity> consentOptional = consentRepository.findFirstById(consentStatus.getConsentId());
+            if (!consentOptional.isPresent()) { // should happen only in case of data inconsistency.
+                throw new ConsentNotFoundException(consentStatus.getConsentId());
+            }
+
+            // Delete the consent with provided ID
+            userConsentRepository.deleteById(consentStatus.getId());
+
+            // Log a record to the history table
+            logConsentChange(
+                    consentStatus.getUserId(),
+                    consentStatus.getConsentId(),
+                    consentStatus.getClientId(),
+                    null,
+                    consentStatus.getParameters(),
+                    new Date(),
+                    ConsentChange.REJECT
+            );
+        }
+
+    }
+
+    /**
+     * Get the consent history for a given user. In case a client ID is specified, the results are filtered
+     * by the TPP application.
+     *
+     * @param userId User ID.
+     * @param clientId (optional) Client ID.
+     * @return Response with a consent history for given user (and optionally, a given app).
+     * @throws ConsentNotFoundException In case of inconsistency and deleted consent.
+     */
+    @Transactional
+    public ConsentHistoryListResponse consentHistoryForUser(String userId, String clientId) throws ConsentNotFoundException {
+
+        // Get the list of consent history items
+        List<UserConsentHistoryEntity> userConsentHistoryEntities;
+        if (clientId == null) {
+            userConsentHistoryEntities = userConsentHistoryRepository.consentHistoryForUser(userId);
+        } else {
+            userConsentHistoryEntities = userConsentHistoryRepository.consentHistoryForUser(userId, clientId);
+        }
+
+        // Iterate and convert the objects
+        List<GivenConsentHistory> givenConsentHistoryList = new ArrayList<>();
+        for (UserConsentHistoryEntity uche: userConsentHistoryEntities) {
+
+            // Find the consent template
+            final Optional<ConsentEntity> consentEntityOptional = consentRepository.findFirstById(uche.getConsentId());
+            if (!consentEntityOptional.isPresent()) {
+                throw new ConsentNotFoundException(uche.getConsentId());
+            }
+            final ConsentEntity consent = consentEntityOptional.get();
+
+            //TODO: Replace by converter
+            GivenConsentHistory givenConsentHistory = new GivenConsentHistory();
+            givenConsentHistory.setId(uche.getId());
+            givenConsentHistory.setConsentId(uche.getConsentId());
+            givenConsentHistory.setClientId(uche.getClientId());
+            givenConsentHistory.setTimestampCreated(uche.getTimestampCreated());
+            givenConsentHistory.setChange(uche.getChange().name());
+            givenConsentHistory.setConsentParameters(uche.getParameters());
+            givenConsentHistory.setExternalId(uche.getExternalId());
+            givenConsentHistory.setConsentName(consent.getName());
+            givenConsentHistory.setConsentText(consent.getText());
+
+            givenConsentHistoryList.add(givenConsentHistory);
+        }
+
+        // Prepare and return a response
+        ConsentHistoryListResponse response = new ConsentHistoryListResponse();
+        response.setUserId(userId);
+        response.setHistory(givenConsentHistoryList);
+        return response;
+    }
+
+    /**
+     * Log a consent approval, prolongation or rejection to the history table.
+     *
+     * @param userId User ID.
+     * @param consentId Consent ID.
+     * @param clientId Client ID.
+     * @param parameters Consent parameters.
+     * @param date Timestamp of the change.
+     */
+    private void logConsentChange(String userId, String consentId, String clientId, String externalId, String parameters, Date date, ConsentChange change) {
+        UserConsentHistoryEntity uche = new UserConsentHistoryEntity();
+        uche.setUserId(userId);
+        uche.setConsentId(consentId);
+        uche.setClientId(clientId);
+        uche.setExternalId(externalId);
+        uche.setParameters(parameters);
+        uche.setChange(change);
+        uche.setTimestampCreated(date);
+        userConsentHistoryRepository.save(uche);
+    }
+
+    /**
+     * Get list of all consents based on provided approved consent entities.
+     *
+     * @param consentEntities Consent entities approved by a user.
+     * @return List of given consents.
+     * @throws ConsentNotFoundException In case some approved consent is not found due to database inconsistency.
+     */
+    private List<GivenConsent> listConsentsByUser(List<UserConsentEntity> consentEntities) throws ConsentNotFoundException {
+        // Find all given consents by a user
+
+        final List<GivenConsent> givenConsents = new ArrayList<>();
+        for (UserConsentEntity uce: consentEntities) {
+
+            // Find the consent template
+            final Optional<ConsentEntity> consentEntityOptional = consentRepository.findFirstById(uce.getConsentId());
+            if (!consentEntityOptional.isPresent()) {
+                throw new ConsentNotFoundException(uce.getConsentId());
+            }
+            final ConsentEntity consent = consentEntityOptional.get();
+
+            // Prepare the consent entity for the response
+            //TODO: Replace by converter
+            GivenConsent givenConsent = new GivenConsent();
+            givenConsent.setId(uce.getId());
+            givenConsent.setClientId(uce.getClientId());
+            givenConsent.setConsentId(uce.getConsentId());
+            givenConsent.setConsentParameters(uce.getParameters());
+            givenConsent.setExternalId(uce.getExternalId());
+            givenConsent.setTimestampCreated(uce.getTimestampCreated());
+            givenConsent.setTimestampUpdated(uce.getTimestampUpdated());
+            givenConsent.setConsentName(consent.getName());
+            givenConsent.setConsentText(consent.getText());
+
+            // Add the consent entity to the list
+            givenConsents.add(givenConsent);
+        }
+
+        return givenConsents;
+    }
+
+    /**
+     * Convert Map to JSON String.
+     * @param parameters Map.
+     * @return JSON String.
+     */
+    private String convertToJsonString(Map<String, String> parameters) {
+        try {
+            return new ObjectMapper().writeValueAsString(parameters);
+        } catch (JsonProcessingException e) {
+            return null;
+        }
+    }
+
+}

--- a/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/service/UserConsentService.java
+++ b/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/service/UserConsentService.java
@@ -128,7 +128,10 @@ public class UserConsentService {
 
             return response;
         } else {
-            return null;
+            UserConsentDetailResponse response = new UserConsentDetailResponse();
+            response.setUserId(userId);
+            response.setConsent(null); // no consent given
+            return response;
         }
     }
 

--- a/powerauth-tpp-engine/src/main/resources/application.properties
+++ b/powerauth-tpp-engine/src/main/resources/application.properties
@@ -21,9 +21,9 @@ spring.jpa.hibernate.use-new-id-generator-mappings=false
 #spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false
 
 # Application Service Configuration
-powerauth.nextstep.service.applicationName=powerauth-tpp-engine
-powerauth.nextstep.service.applicationDisplayName=PowerAuth Web Flow 3rd Party and Consent Engine
-powerauth.nextstep.service.applicationEnvironment=
+powerauth.tppEngine.service.applicationName=powerauth-tpp-engine
+powerauth.tppEngine.service.applicationDisplayName=PowerAuth Web Flow 3rd Party and Consent Engine
+powerauth.tppEngine.service.applicationEnvironment=
 
 # Disable JMX
 spring.jmx.enabled=false

--- a/powerauth-tpp-engine/src/main/resources/application.properties
+++ b/powerauth-tpp-engine/src/main/resources/application.properties
@@ -1,0 +1,38 @@
+# Allow externalization of properties using application-ext.properties
+spring.profiles.active=ext
+
+# Database Configuration - MySQL
+spring.datasource.url=jdbc:mysql://localhost:3306/powerauth
+spring.datasource.username=powerauth
+spring.datasource.password=
+spring.datasource.driver-class-name=com.mysql.jdbc.Driver
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+spring.jpa.properties.hibernate.connection.characterEncoding=utf8
+spring.jpa.properties.hibernate.connection.useUnicode=true
+spring.jpa.hibernate.use-new-id-generator-mappings=false
+
+# Database Configuration - Oracle
+#spring.datasource.url=jdbc:oracle:thin:@//localhost:1521/powerauth
+#spring.datasource.username=powerauth
+#spring.datasource.password=
+#spring.datasource.driver-class-name=oracle.jdbc.OracleDriver
+# The following properties speed up Spring Boot startup
+#spring.jpa.database-platform=org.hibernate.dialect.Oracle12cDialect
+#spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false
+
+# Application Service Configuration
+powerauth.nextstep.service.applicationName=powerauth-tpp-engine
+powerauth.nextstep.service.applicationDisplayName=PowerAuth Web Flow 3rd Party and Consent Engine
+powerauth.nextstep.service.applicationEnvironment=
+
+# Disable JMX
+spring.jmx.enabled=false
+
+# Set JMX default domain in case JMX is enabled, otherwise the application startup fails due to clash in JMX bean names
+spring.jmx.default-domain=powerauth-tpp-engine
+
+# Set Jackson date format
+spring.jackson.date-format=yyyy-MM-dd'T'HH:mm:ssZ
+
+# Disable open session in view to avoid startup warning of Spring boot
+spring.jpa.open-in-view=false

--- a/powerauth-tpp-engine/src/test/java/io/getlime/security/powerauth/app/tppengine/TppEngineApplicationTests.java
+++ b/powerauth-tpp-engine/src/test/java/io/getlime/security/powerauth/app/tppengine/TppEngineApplicationTests.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.app.tppengine;
+
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class TppEngineApplicationTests {
+
+}


### PR DESCRIPTION
In this change, we deliver a base version of the consent engine. Consent engine is responsible for managing consents users gave to applications of the third parties. There are two new API contexts:

- `/consent` - Information about consents (consent templates) stored in the systems.
- `/user/consent` - Information about consents given by the system users.