### PR TITLE
Fix #655: AFS: Detect client IP address

### DIFF
--- a/docs/Web-Flow-0.23.0.md
+++ b/docs/Web-Flow-0.23.0.md
@@ -13,8 +13,9 @@ DDL update script for Oracle:
 ```sql
 ALTER TABLE ns_operation_config ADD afs_enabled NUMBER(1) DEFAULT 0 NOT NULL;
 
-ALTER TABLE wf_operation_session ADD operation_hash VARCHAR(256) DEFAULT 0 NOT NULL;
-ALTER TABLE wf_operation_session ADD websocket_session_id VARCHAR(32) DEFAULT 0 NOT NULL;
+ALTER TABLE wf_operation_session ADD operation_hash VARCHAR(256);
+ALTER TABLE wf_operation_session ADD websocket_session_id VARCHAR(32);
+ALTER TABLE wf_operation_session ADD client_ip VARCHAR(32);
 
 CREATE INDEX wf_operation_hash ON wf_operation_session (operation_hash);
 CREATE INDEX wf_websocket_session ON wf_operation_session (websocket_session_id);
@@ -26,8 +27,8 @@ ALTER TABLE `ns_operation_config` ADD `afs_enabled` BOOLEAN NOT NULL DEFAULT FAL
 
 ALTER TABLE `wf_operation_session` ADD `operation_hash` VARCHAR(256),  
 ALTER TABLE `wf_operation_session` ADD `websocket_session_id` VARCHAR(32),
+ALTER TABLE `wf_operation_session` ADD `client_ip` VARCHAR(32),
 
 CREATE INDEX wf_operation_hash ON wf_operation_session (operation_hash);
 CREATE INDEX wf_websocket_session ON wf_operation_session (websocket_session_id);
 ```
-

--- a/docs/sql/mysql/create_schema.sql
+++ b/docs/sql/mysql/create_schema.sql
@@ -162,6 +162,7 @@ CREATE TABLE wf_operation_session (
   http_session_id           VARCHAR(256) NOT NULL,
   operation_hash            VARCHAR(256),
   websocket_session_id      VARCHAR(32),
+  client_ip                 VARCHAR(32),
   result                    VARCHAR(32) NOT NULL,
   timestamp_created         TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 ) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/docs/sql/oracle/create_schema.sql
+++ b/docs/sql/oracle/create_schema.sql
@@ -169,6 +169,7 @@ CREATE TABLE wf_operation_session (
   http_session_id           VARCHAR(256) NOT NULL,
   operation_hash            VARCHAR(256),
   websocket_session_id      VARCHAR(32),
+  client_ip                 VARCHAR(32),
   result                    VARCHAR(32) NOT NULL,
   timestamp_created         TIMESTAMP
 );

--- a/docs/sql/postgresql/create_schema.sql
+++ b/docs/sql/postgresql/create_schema.sql
@@ -167,6 +167,9 @@ CREATE TABLE ns_step_definition (
 CREATE TABLE wf_operation_session (
   operation_id              VARCHAR(256) PRIMARY KEY NOT NULL,
   http_session_id           VARCHAR(256) NOT NULL,
+  operation_hash            VARCHAR(256),
+  websocket_session_id      VARCHAR(32),
+  client_ip                 VARCHAR(32),
   result                    VARCHAR(32) NOT NULL,
   timestamp_created         TIMESTAMP
 );

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MessageController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MessageController.java
@@ -49,7 +49,8 @@ public class MessageController {
     public void register(SimpMessageHeaderAccessor headerAccessor, WebSocketRegistrationRequest registrationRequest) {
         String sessionId = headerAccessor.getSessionId();
         String webSocketId = registrationRequest.getWebSocketId();
-        webSocketMessageService.storeWebSocketSession(webSocketId, sessionId);
+        String clientIp = (String) headerAccessor.getSessionAttributes().get("client_ip");
+        webSocketMessageService.storeWebSocketSession(webSocketId, sessionId, clientIp);
         webSocketMessageService.sendRegistrationMessage(webSocketId, sessionId);
     }
 

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/interceptor/WebSocketHandshakeInterceptor.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/interceptor/WebSocketHandshakeInterceptor.java
@@ -1,0 +1,40 @@
+package io.getlime.security.powerauth.lib.webflow.authentication.interceptor;
+
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.lang.NonNull;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+/**
+ * Web Socket handshake interceptor resolves the client IP address during Web Socket handshake and stores it into
+ * message header attributes.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class WebSocketHandshakeInterceptor implements HandshakeInterceptor {
+
+    @Override
+    public boolean beforeHandshake(@NonNull ServerHttpRequest request, @NonNull ServerHttpResponse response,
+                                   @NonNull WebSocketHandler wsHandler, @NonNull Map<String, Object> attributes) {
+        // Set client_ip attribute in WebSocket session, either from the X-FORWARDED-FOR HTTP header, if it is not
+        // available, use servlet request remote IP address.
+        if (request instanceof ServletServerHttpRequest) {
+            ServletServerHttpRequest servletRequest = (ServletServerHttpRequest) request;
+            String ipAddress = servletRequest.getServletRequest().getHeader("X-FORWARDED-FOR");
+            if (ipAddress == null) {
+                ipAddress = servletRequest.getServletRequest().getRemoteAddr();
+            }
+            attributes.put("client_ip", ipAddress);
+        }
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(@NonNull ServerHttpRequest request, @NonNull ServerHttpResponse response,
+                               @NonNull WebSocketHandler wsHandler, Exception exception) {
+    }
+}

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/repository/model/entity/OperationSessionEntity.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/repository/model/entity/OperationSessionEntity.java
@@ -46,6 +46,9 @@ public class OperationSessionEntity implements Serializable {
     @Column(name = "websocket_session_id")
     private String webSocketSessionId;
 
+    @Column(name = "client_ip")
+    private String clientIp;
+
     @Column(name = "result")
     @Enumerated(EnumType.STRING)
     private AuthResult result;
@@ -94,6 +97,14 @@ public class OperationSessionEntity implements Serializable {
 
     public void setWebSocketSessionId(String webSocketSessionId) {
         this.webSocketSessionId = webSocketSessionId;
+    }
+
+    public String getClientIp() {
+        return clientIp;
+    }
+
+    public void setClientIp(String clientIp) {
+        this.clientIp = clientIp;
     }
 
     public AuthResult getResult() {

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/OperationSessionService.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/OperationSessionService.java
@@ -142,11 +142,13 @@ public class OperationSessionService {
      * Lookup an operation by operation hash and store Web Socket session ID.
      * @param operationHash Operation hash.
      * @param webSocketSessionId Web Socket session ID.
+     * @param clientIp Remote client IP address.
      */
-    public void storeWebSocketSessionId(String operationHash, String webSocketSessionId) {
+    public void storeWebSocketSessionId(String operationHash, String webSocketSessionId, String clientIp) {
         OperationSessionEntity operationSessionEntity = operationSessionRepository.findByOperationHash(operationHash);
         if (operationSessionEntity != null) {
             operationSessionEntity.setWebSocketSessionId(webSocketSessionId);
+            operationSessionEntity.setClientIp(clientIp);
             operationSessionRepository.save(operationSessionEntity);
         }
     }

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/WebSocketMessageService.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/WebSocketMessageService.java
@@ -90,9 +90,10 @@ public class WebSocketMessageService {
      *
      * @param operationHash Operation hash.
      * @param webSocketSessionId Web Socket Session ID.
+     * @param clientIp Remote client IP address.
      */
-    public void storeWebSocketSession(String operationHash, String webSocketSessionId) {
-        operationSessionService.storeWebSocketSessionId(operationHash, webSocketSessionId);
+    public void storeWebSocketSession(String operationHash, String webSocketSessionId, String clientIp) {
+        operationSessionService.storeWebSocketSessionId(operationHash, webSocketSessionId, clientIp);
     }
 
 }

--- a/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/configuration/WebSocketConfiguration.java
+++ b/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/configuration/WebSocketConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.getlime.security.powerauth.app.webflow.configuration;
 
+import io.getlime.security.powerauth.lib.webflow.authentication.interceptor.WebSocketHandshakeInterceptor;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
@@ -38,7 +39,7 @@ public class WebSocketConfiguration implements WebSocketMessageBrokerConfigurer 
      */
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/websocket").setAllowedOrigins("*").withSockJS();
+        registry.addEndpoint("/websocket").addInterceptors(new WebSocketHandshakeInterceptor()).setAllowedOrigins("*").withSockJS();
     }
 
     /**


### PR DESCRIPTION
The client IP address is either resolved from `X-FORWARDED-FOR` HTTP header or from servlet request.

Note that the IP address may be IPv6. In this case `-Djava.net.preferIPv4Stack=true` needs to be set for the runtime, e.g. in Docker image or as an option for Tomcat.