### PR TITLE
Fix #675: Filter IPv6 IP addresses when detecting client IP address

### DIFF
--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/configuration/WebFlowServicesConfiguration.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/configuration/WebFlowServicesConfiguration.java
@@ -103,7 +103,7 @@ public class WebFlowServicesConfiguration {
     private AfsType afsType;
 
     /**
-     * Whether anti-fraud system requires IPv4 IP addresses.
+     * Whether anti-fraud system requires IPv4 addresses.
      */
     @Value("${powerauth.webflow.afs.forceIpv4:true}")
     private boolean afsForceIpv4;

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/configuration/WebFlowServicesConfiguration.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/configuration/WebFlowServicesConfiguration.java
@@ -102,6 +102,12 @@ public class WebFlowServicesConfiguration {
     @Value("${powerauth.webflow.afs.type:THREAT_MARK}")
     private AfsType afsType;
 
+    /**
+     * Whether anti-fraud system requires IPv4 IP addresses.
+     */
+    @Value("${powerauth.webflow.afs.forceIpv4:true}")
+    private boolean afsForceIpv4;
+
     @Autowired
     public WebFlowServicesConfiguration(SSLConfigurationService sslConfigurationService) {
         this.sslConfigurationService = sslConfigurationService;
@@ -215,5 +221,13 @@ public class WebFlowServicesConfiguration {
      */
     public AfsType getAfsType() {
         return afsType;
+    }
+
+    /**
+     * Get whether anti-fraud system requires IPv4 addresses.
+     * @return Whether anti-fraud system requires IPv4 addresses.
+     */
+    public boolean getAfsForceIpv4() {
+        return afsForceIpv4;
     }
 }

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/interceptor/WebSocketHandshakeInterceptor.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/interceptor/WebSocketHandshakeInterceptor.java
@@ -36,8 +36,8 @@ public class WebSocketHandshakeInterceptor implements HandshakeInterceptor {
                 if (ipAddress == null || !isIpv4Address(ipAddress)) {
                     ipAddress = servletRequest.getServletRequest().getRemoteAddr();
                     if (!isIpv4Address(ipAddress)) {
-                        // Fallback to 127.0.0.1 in case IPv4 address could not be determined
-                        ipAddress = "127.0.0.1";
+                        // IP address is null in case IPv4 address could not be determined, it should not be sent to AFS
+                        ipAddress = null;
                     }
                 }
             } else if (ipAddress == null) {

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/interceptor/WebSocketHandshakeInterceptor.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/interceptor/WebSocketHandshakeInterceptor.java
@@ -17,6 +17,12 @@ import java.util.Map;
  */
 public class WebSocketHandshakeInterceptor implements HandshakeInterceptor {
 
+    private final boolean forceIpv4;
+
+    public WebSocketHandshakeInterceptor(boolean forceIpv4) {
+        this.forceIpv4 = forceIpv4;
+    }
+
     @Override
     public boolean beforeHandshake(@NonNull ServerHttpRequest request, @NonNull ServerHttpResponse response,
                                    @NonNull WebSocketHandler wsHandler, @NonNull Map<String, Object> attributes) {
@@ -25,9 +31,20 @@ public class WebSocketHandshakeInterceptor implements HandshakeInterceptor {
         if (request instanceof ServletServerHttpRequest) {
             ServletServerHttpRequest servletRequest = (ServletServerHttpRequest) request;
             String ipAddress = servletRequest.getServletRequest().getHeader("X-FORWARDED-FOR");
-            if (ipAddress == null) {
+            if (forceIpv4) {
+                // IPv4 logic
+                if (ipAddress == null || !isIpv4Address(ipAddress)) {
+                    ipAddress = servletRequest.getServletRequest().getRemoteAddr();
+                    if (!isIpv4Address(ipAddress)) {
+                        // Fallback to 127.0.0.1 in case IPv4 address could not be determined
+                        ipAddress = "127.0.0.1";
+                    }
+                }
+            } else if (ipAddress == null) {
+                // IPv4 or IPv6 logic
                 ipAddress = servletRequest.getServletRequest().getRemoteAddr();
             }
+
             attributes.put("client_ip", ipAddress);
         }
         return true;
@@ -36,5 +53,16 @@ public class WebSocketHandshakeInterceptor implements HandshakeInterceptor {
     @Override
     public void afterHandshake(@NonNull ServerHttpRequest request, @NonNull ServerHttpResponse response,
                                @NonNull WebSocketHandler wsHandler, Exception exception) {
+    }
+
+    /**
+     * Determine whether IP address is an IPv4 address.
+     * @param address IP address as String.
+     * @return Whether IP address is an IPv4 address.
+     */
+    private boolean isIpv4Address(String address) {
+        // Source: https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch08s16.html
+        return address.matches("^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}↵\n" +
+                "(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$");
     }
 }

--- a/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/configuration/WebSocketConfiguration.java
+++ b/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/configuration/WebSocketConfiguration.java
@@ -15,7 +15,9 @@
  */
 package io.getlime.security.powerauth.app.webflow.configuration;
 
+import io.getlime.security.powerauth.lib.webflow.authentication.configuration.WebFlowServicesConfiguration;
 import io.getlime.security.powerauth.lib.webflow.authentication.interceptor.WebSocketHandshakeInterceptor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
@@ -33,13 +35,21 @@ public class WebSocketConfiguration implements WebSocketMessageBrokerConfigurer 
 
     public static final String MESSAGE_PREFIX = "/topic";
 
+    private final WebFlowServicesConfiguration configuration;
+
+    @Autowired
+    public WebSocketConfiguration(WebFlowServicesConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
     /**
      * Stomp endpoint registration for Web Sockets.
      * @param registry Stomp endpoint registry.
      */
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/websocket").addInterceptors(new WebSocketHandshakeInterceptor()).setAllowedOrigins("*").withSockJS();
+        WebSocketHandshakeInterceptor interceptor = new WebSocketHandshakeInterceptor(configuration.getAfsForceIpv4());
+        registry.addEndpoint("/websocket").addInterceptors(interceptor).setAllowedOrigins("*").withSockJS();
     }
 
     /**

--- a/powerauth-webflow/src/main/resources/application.properties
+++ b/powerauth-webflow/src/main/resources/application.properties
@@ -73,6 +73,7 @@ powerauth.webflow.timeout.warning.delayMs=60000
 # Anti-fraud system configuration
 powerauth.webflow.afs.enabled=false
 powerauth.webflow.afs.type=THREAT_MARK
+powerauth.webflow.afs.forceIpv4=true
 
 # Disable JMX
 spring.jmx.enabled=false


### PR DESCRIPTION
We have to handle the case when client is IPv6 behind a proxy which forwards the IPv6 address correctly, however AFS cannot handle it because it only supports IPv4. I added an option to enable forcing of IPv4 and fallback logic in case no IPv4 address could not be determined.