### PR TITLE
Mobile token configuration per operation

### DIFF
--- a/docs/Mobile-Token-Configuration.md
+++ b/docs/Mobile-Token-Configuration.md
@@ -5,3 +5,15 @@ Mobile Token application requires configuration in order to set an active activa
 Web Flow uses the configured activation when sending push notifications and when authorizing operations using Mobile Token. When activation is not configured for the user, the `POWERAUTH_TOKEN` authentication method is not available and the user needs to use an alternative method for authorization of the operation (e.g. `SMS_KEY`).
 
 See the [Next Step REST API documentation](./Next-Step-Server-REST-API-Reference.md#enable-an-authentication-method-for-given-user) which describes this configuration step.
+
+## Enabling Mobile Token
+
+The mobile token needs to be enabled using following configuration parameters:
+
+- Mobile token needs to be enabled in table `ns_operation_config` using the `mobile_token_enabled` column. This parameter configures whether 
+mobile token is enabled for given operation.
+- Mobile token needs to be enabled in table `ns_auth_method` using the `has_mobile_token` column. This parameter configures whether authentication method supports mobile token. 
+It should not be necessary to change the default settings, but it is possible to change on authentication method level whether mobile token is enabled.
+- Mobile token needs to be enabled in table `ns_user_prefs`. The `ns_auth_method.user_prefs_column` parameter specifies using which column is the mobile token enabled.
+Furthermore the activation ID for mobile needs to be configured, as explained above. Both enabling mobile token in user preferences and setting the activation
+ID is typically done by calling the Next Step REST API.

--- a/docs/Web-Flow-0.22.0.md
+++ b/docs/Web-Flow-0.22.0.md
@@ -79,6 +79,8 @@ ALTER TABLE ns_auth_method ADD has_mobile_token NUMBER(1) DEFAULT 0;
 
 UPDATE ns_auth_method SET has_mobile_token = 1 WHERE auth_method = 'POWERAUTH_TOKEN';
 
+ALTER TABLE ns_operation_config ADD mobile_token_enabled NUMBER(1) DEFAULT 0 NOT NULL;
+
 COMMIT;
 ```
 
@@ -193,6 +195,9 @@ UPDATE `da_sms_authorization` SET `verified` = FALSE WHERE `verified` IS NULL;
 ALTER TABLE `da_sms_authorization` ADD `has_mobile_token` BOOLEAN DEFAULT FALSE;
 
 UPDATE `ns_auth_method` SET `has_mobile_token` = TRUE WHERE `auth_method` = 'POWERAUTH_TOKEN';
+
+ALTER TABLE `ns_operation_config` ADD `mobile_token_enabled` BOOLEAN DEFAULT FALSE NOT NULL;
+
 ```
 
 As the next step, please add new authentication methods `CONSENT`, `LOGIN_SCA` and `APPROVAL_SCA`. The `order_number` parameter should be updated to exceed maximum `order_number` in table `ns_auth_method` by 1 for `CONSENT`, by 2 for `LOGIN_SCA` and by 3 for `APPROVAL_SCA`.

--- a/docs/sql/mysql/create_schema.sql
+++ b/docs/sql/mysql/create_schema.sql
@@ -89,6 +89,7 @@ CREATE TABLE ns_operation_config (
   operation_name            VARCHAR(32) PRIMARY KEY NOT NULL,
   template_version          CHAR NOT NULL,
   template_id               INTEGER NOT NULL,
+  mobile_token_enabled      BOOLEAN DEFAULT FALSE NOT NULL,
   mobile_token_mode         VARCHAR(256) NOT NULL
 ) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 

--- a/docs/sql/oracle/create_schema.sql
+++ b/docs/sql/oracle/create_schema.sql
@@ -89,6 +89,7 @@ CREATE TABLE ns_operation_config (
   operation_name            VARCHAR(32) PRIMARY KEY NOT NULL,
   template_version          VARCHAR(1) NOT NULL,
   template_id               INTEGER NOT NULL,
+  mobile_token_enabled      NUMBER(1) DEFAULT 0 NOT NULL,
   mobile_token_mode         VARCHAR(256) NOT NULL
 );
 

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/response/GetOperationConfigDetailResponse.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/response/GetOperationConfigDetailResponse.java
@@ -25,6 +25,7 @@ public class GetOperationConfigDetailResponse {
     private String operationName;
     private String templateVersion;
     private Integer templateId;
+    private boolean mobileTokenEnabled;
     private String mobileTokenMode;
 
     /**
@@ -73,6 +74,22 @@ public class GetOperationConfigDetailResponse {
      */
     public void setTemplateId(Integer templateId) {
         this.templateId = templateId;
+    }
+
+    /**
+     * Get whether mobile token is enabled for this operation.
+     * @return Whether mobile token is enabled.
+     */
+    public boolean isMobileTokenEnabled() {
+        return mobileTokenEnabled;
+    }
+
+    /**
+     * Set whether mobile token is enabled for this operation.
+     * @param mobileTokenEnabled Whether mobile token is enabled.
+     */
+    public void setMobileTokenEnabled(boolean mobileTokenEnabled) {
+        this.mobileTokenEnabled = mobileTokenEnabled;
     }
 
     /**

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/converter/OperationConfigConverter.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/converter/OperationConfigConverter.java
@@ -35,6 +35,7 @@ public class OperationConfigConverter {
         response.setOperationName(operationConfig.getOperationName());
         response.setTemplateVersion(operationConfig.getTemplateVersion());
         response.setTemplateId(operationConfig.getTemplateId());
+        response.setMobileTokenEnabled(operationConfig.isMobileTokenEnabled());
         response.setMobileTokenMode(operationConfig.getMobileTokenMode());
         return response;
     }

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OperationConfigEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OperationConfigEntity.java
@@ -43,6 +43,9 @@ public class OperationConfigEntity implements Serializable {
     @Column(name = "template_id")
     private Integer templateId;
 
+    @Column(name = "mobile_token_enabled")
+    private boolean mobileTokenEnabled;
+
     @Column(name = "mobile_token_mode")
     private String mobileTokenMode;
 
@@ -92,6 +95,22 @@ public class OperationConfigEntity implements Serializable {
      */
     public void setTemplateId(Integer templateId) {
         this.templateId = templateId;
+    }
+
+    /**
+     * Get whether mobile token is enabled for this operation.
+     * @return Whether mobile token is enabled.
+     */
+    public boolean isMobileTokenEnabled() {
+        return mobileTokenEnabled;
+    }
+
+    /**
+     * Set whether mobile token is enabled for this operation.
+     * @param mobileTokenEnabled Whether mobile token is enabled.
+     */
+    public void setMobileTokenEnabled(boolean mobileTokenEnabled) {
+        this.mobileTokenEnabled = mobileTokenEnabled;
     }
 
     /**

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/MobileTokenConfigurationService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/MobileTokenConfigurationService.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.app.nextstep.service;
+
+import io.getlime.security.powerauth.lib.nextstep.model.entity.UserAuthMethodDetail;
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthMethod;
+import io.getlime.security.powerauth.lib.nextstep.model.exception.OperationNotConfiguredException;
+import io.getlime.security.powerauth.lib.nextstep.model.response.GetOperationConfigDetailResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Service for retrieving mobile token configuration.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Service
+public class MobileTokenConfigurationService {
+
+    private static final Logger logger = LoggerFactory.getLogger(MobileTokenConfigurationService.class);
+
+    private final OperationConfigurationService operationConfigurationService;
+    private final AuthMethodService authMethodService;
+
+    /**
+     * Service constructor.
+     * @param operationConfigurationService Operation configuration service.
+     * @param authMethodService Authentication method service.
+     */
+    public MobileTokenConfigurationService(OperationConfigurationService operationConfigurationService, AuthMethodService authMethodService) {
+        this.operationConfigurationService = operationConfigurationService;
+        this.authMethodService = authMethodService;
+    }
+
+    /**
+     * Decide whether mobile token is enabled for given user ID, operation name and authentication method.
+     * @param userId User ID.
+     * @param operationName Operation name.
+     * @param authMethod Authentication method.
+     * @return Whether mobile token is enabled.
+     */
+    public boolean isMobileTokenEnabled(String userId, String operationName, AuthMethod authMethod) {
+        // Check input parameters
+        if (userId == null) {
+            logger.debug("Mobile token is disabled because user is unknown for this authentication step");
+            return false;
+        }
+        if (operationName == null) {
+            logger.warn("Invalid call of isMobileTokenEnabled, operation name is null");
+            return false;
+        }
+        if (authMethod == null) {
+            logger.warn("Invalid call of isMobileTokenEnabled, authentication method is null");
+            return false;
+        }
+
+        // Check whether mobile token is enabled for operation by operation name
+        try {
+            GetOperationConfigDetailResponse config = operationConfigurationService.getOperationConfig(operationName);
+            if (!config.isMobileTokenEnabled()) {
+                logger.debug("Mobile token is disabled for operation name: {}", operationName);
+                // Mobile token is not enabled for this operation, skip it
+                return false;
+            }
+        } catch (OperationNotConfiguredException e) {
+            // Operation is not configured, skip it
+            logger.error(e.getMessage(), e);
+            return false;
+        }
+
+        // Consider only authentication methods which are enabled for user
+        List<UserAuthMethodDetail> authMethods = authMethodService.listAuthMethodsEnabledForUser(userId);
+        boolean activationConfiguredForMobileToken = false;
+        for (UserAuthMethodDetail userAuthMethod : authMethods) {
+            // Check whether activation ID is configured for mobile token, this configuration is set using
+            // POWERAUTH_TOKEN authentication method.
+            if (userAuthMethod.getAuthMethod() == AuthMethod.POWERAUTH_TOKEN) {
+                Map<String, String> config = userAuthMethod.getConfig();
+                if (config != null) {
+                    String activationId = config.get("activationId");
+                    if (activationId != null && !activationId.isEmpty()) {
+                        activationConfiguredForMobileToken = true;
+                    }
+                }
+            }
+        }
+        if (!activationConfiguredForMobileToken) {
+            // Activation ID is not configured for mobile token, so mobile token cannot be used
+            logger.debug("Mobile token is disabled because activation is not configured in user preferences for user: {}", userId);
+            return false;
+        }
+
+        for (UserAuthMethodDetail userAuthMethod : authMethods) {
+            // In case the chosen auth method is enabled for user and it supports mobile token,
+            // this operation should be added into pending operation list.
+            if (userAuthMethod.getAuthMethod() == authMethod && userAuthMethod.getHasMobileToken()) {
+                logger.debug("Mobile token is enabled for user ID: {}, operation name: {}, authentication method: {}", userId, operationName, authMethod);
+                return true;
+            }
+        }
+
+        // Mobile token is disabled for this authentication method
+        logger.debug("Mobile token is disabled because authentication method {} does not support mobile token", authMethod);
+        return false;
+    }
+}

--- a/powerauth-webflow-authentication-approval-sca/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/approvalsca/controller/ApprovalScaInitController.java
+++ b/powerauth-webflow-authentication-approval-sca/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/approvalsca/controller/ApprovalScaInitController.java
@@ -85,7 +85,7 @@ public class ApprovalScaInitController extends AuthMethodController<ApprovalScaI
         // Find out whether mobile token is enabled
         boolean mobileTokenEnabled = false;
         try {
-            if (authMethodQueryService.isMobileTokenAuthMethodAvailable(userId, operation.getOperationId())) {
+            if (authMethodQueryService.isMobileTokenAvailable(userId, operation.getOperationId())) {
                 mobileTokenEnabled = true;
             }
         } catch (NextStepServiceException e) {

--- a/powerauth-webflow-authentication-login-sca/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/loginsca/controller/LoginScaInitController.java
+++ b/powerauth-webflow-authentication-login-sca/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/loginsca/controller/LoginScaInitController.java
@@ -141,7 +141,7 @@ public class LoginScaInitController extends AuthMethodController<LoginScaInitReq
                 // Find out whether mobile token is enabled
                 boolean mobileTokenEnabled = false;
                 try {
-                    if (authMethodQueryService.isMobileTokenAuthMethodAvailable(userId, operation.getOperationId())) {
+                    if (authMethodQueryService.isMobileTokenAvailable(userId, operation.getOperationId())) {
                         mobileTokenEnabled = true;
                     }
                 } catch (NextStepServiceException e) {
@@ -232,7 +232,7 @@ public class LoginScaInitController extends AuthMethodController<LoginScaInitReq
             // Find out whether mobile token is enabled
             boolean mobileTokenEnabled = false;
             try {
-                if (authMethodQueryService.isMobileTokenAuthMethodAvailable(operation.getUserId(), operation.getOperationId())) {
+                if (authMethodQueryService.isMobileTokenAvailable(operation.getUserId(), operation.getOperationId())) {
                     mobileTokenEnabled = true;
                 }
             } catch (NextStepServiceException e) {

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/AuthMethodQueryService.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/AuthMethodQueryService.java
@@ -165,7 +165,7 @@ public class AuthMethodQueryService {
         List<GetActivationListForUserResponse.Activations> allActivations = powerAuthServiceClient.getActivationListForUser(userId);
         for (GetActivationListForUserResponse.Activations activation : allActivations) {
             if (activation.getActivationStatus() == ActivationStatus.ACTIVE && activation.getActivationId().equals(configuredActivationId)) {
-                // User has an active activation and it is the configured activation - method can be used
+                // User has an active activation and it is the configured activation - mobile token is available
                 return true;
             }
         }

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/AuthMethodQueryService.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/AuthMethodQueryService.java
@@ -119,9 +119,9 @@ public class AuthMethodQueryService {
     /**
      * Get information whether mobile token is available. Following checks are performed:
      * <ul>
-     * <li>Operation is among pending operations for mobile token.</li>
-     * <li>Activation ID is configured for POWERAUTH_TOKEN method configuration for given user.</li>
-     * <li>User has an ACTIVE activation and it matches configured activation ID.</li>
+     * <li>Non-SCA operations: POWERAUTH_TOKEN method is available as a next step for the operation.</li>
+     * <li>SCA operations: Operation is among pending operations for mobile token.</li>
+     * <li>User has an ACTIVE activation in PowerAuth server and it matches configured activation ID in Next Step.</li>
      * </ul>
      *
      * @param userId User ID.

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/AuthMethodQueryService.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/AuthMethodQueryService.java
@@ -126,7 +126,7 @@ public class AuthMethodQueryService {
      *
      * @param userId User ID.
      * @param operationId Operation ID.
-     * @return Whether Mobile Token authentication method is currently available for given user ID and operation name.
+     * @return Whether Mobile Token authentication method is currently available for given user ID and operation ID.
      * @throws NextStepServiceException Thrown when Next Step request fails.
      */
     public boolean isMobileTokenAvailable(String userId, String operationId) throws NextStepServiceException {

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/AuthMethodQueryService.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/AuthMethodQueryService.java
@@ -126,7 +126,7 @@ public class AuthMethodQueryService {
      *
      * @param userId User ID.
      * @param operationId Operation ID.
-     * @return Whether Mobile Token authentication method is currently available for given user ID and operation ID.
+     * @return Whether Mobile Token is currently available for given user ID and operation ID.
      * @throws NextStepServiceException Thrown when Next Step request fails.
      */
     public boolean isMobileTokenAvailable(String userId, String operationId) throws NextStepServiceException {


### PR DESCRIPTION
This pull request contains following changes:
- Mobile token can now be configured on operation basis using table `ns_operation_config`, column `mobile_token_enabled`. The use case is when mobile token should be enabled for e.g. credit card payments but should be disabled for e.g. PSD2.
- I extended the usage of `ns_auth_method.has_mobile_token` to control not only pending operations, however it also controls whether mobile token is available for given authentication method.
- The existing mobile token configuration in `ns_user_prefs` which configures activation ID remains as before.

The pull request handles two use cases:
- SCA: the `/user/operation/list` endpoint (pending operations) filters out operations which do not have mobile token enabled for any of the 3 reasons mentioned above in case the request has `mobileTokenOnly=true` parameter set. This is done both when loading operations for mobile token API, as well as when initializing SCA login and approval steps (in case current operation is not present in pending operations for mobile token, mobile token is disabled).
- non-SCA: the `OPERATION_REVIEW` step needs to know which authentication methods to display before the actual authentication method is chosen. Hence Next Step needs to filter out the `POWERAUTH_TOKEN` step based on its actual availability.

The logic for SCA and non-SCA steps is unified in class `MobileTokenConfigurationService`, however it has different impact - as explained in paragraph above, for non-SCA operations the `POWERAUTH_TOKEN` step is filtered out in next steps, for SCA operations the pending operations list is filtered instead.
