### PR TITLE
Fix #574: Store information about used authorization instrument

### DIFF
--- a/docs/Web-Flow-0.23.0.md
+++ b/docs/Web-Flow-0.23.0.md
@@ -8,6 +8,7 @@ Following database changes were introduced in version `0.23.0`:
  
 - Added `afs_enabled` and `afs_config_id` columns to table `ns_operation_config`
 - Added `operation_hash`, `websocket_session_id` and `client_ip_address` columns to table `wf_operation_session`
+- Added `request_auth_instruments` column to table `ns_operation_history`
 - New tables `ns_operation_afs` and `wf_afs_config` for integration of anti-fraud system
 - Updated indexes and sequences
   
@@ -24,6 +25,8 @@ ALTER TABLE wf_operation_session ADD client_ip_address VARCHAR(32);
 
 CREATE INDEX wf_operation_hash ON wf_operation_session (operation_hash);
 CREATE INDEX wf_websocket_session ON wf_operation_session (websocket_session_id);
+
+ALTER TABLE ns_operation_history ADD request_auth_instruments VARCHAR(256);
 
 CREATE TABLE ns_operation_afs (
   afs_action_id               INTEGER PRIMARY KEY NOT NULL,
@@ -58,6 +61,8 @@ ALTER TABLE `wf_operation_session` ADD `client_ip_address` VARCHAR(32),
 
 CREATE INDEX `wf_operation_hash` ON `wf_operation_session` (`operation_hash`);
 CREATE INDEX `wf_websocket_session` ON `wf_operation_session` (`websocket_session_id`);
+
+ALTER TABLE `ns_operation_history` ADD `request_auth_instruments` VARCHAR(256);
 
 CREATE TABLE ns_operation_afs (
   afs_action_id               INTEGER PRIMARY KEY NOT NULL AUTO_INCREMENT,

--- a/docs/sql/mysql/create_schema.sql
+++ b/docs/sql/mysql/create_schema.sql
@@ -131,6 +131,7 @@ CREATE TABLE ns_operation_history (
   operation_id                VARCHAR(256) NOT NULL,
   result_id                   INTEGER NOT NULL,
   request_auth_method         VARCHAR(32) NOT NULL,
+  request_auth_instruments    VARCHAR(256),
   request_auth_step_result    VARCHAR(32) NOT NULL,
   request_params              VARCHAR(4096),
   response_result             VARCHAR(32) NOT NULL,

--- a/docs/sql/oracle/create_schema.sql
+++ b/docs/sql/oracle/create_schema.sql
@@ -138,6 +138,7 @@ CREATE TABLE ns_operation_history (
   operation_id                VARCHAR(256) NOT NULL,
   result_id                   INTEGER NOT NULL,
   request_auth_method         VARCHAR(32) NOT NULL,
+  request_auth_instruments    VARCHAR(256),
   request_auth_step_result    VARCHAR(32) NOT NULL,
   request_params              VARCHAR(4000),
   response_result             VARCHAR(32) NOT NULL,

--- a/docs/sql/postgresql/create_schema.sql
+++ b/docs/sql/postgresql/create_schema.sql
@@ -136,6 +136,7 @@ CREATE TABLE ns_operation_history (
   operation_id                VARCHAR(256) NOT NULL,
   result_id                   INTEGER NOT NULL,
   request_auth_method         VARCHAR(32) NOT NULL,
+  request_auth_instruments    VARCHAR(256),
   request_auth_step_result    VARCHAR(32) NOT NULL,
   request_params              VARCHAR(4000),
   response_result             VARCHAR(32) NOT NULL,

--- a/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/enumeration/AfsAuthInstrument.java
+++ b/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/enumeration/AfsAuthInstrument.java
@@ -13,23 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.getlime.security.powerauth.lib.webflow.authentication.method.approvalsca.model.request;
-
-import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthInstrument;
-import io.getlime.security.powerauth.lib.webflow.authentication.base.AuthStepRequest;
-
-import java.util.Collections;
-import java.util.List;
+package io.getlime.security.powerauth.lib.dataadapter.model.enumeration;
 
 /**
- * Model for an init request for SCA approval.
+ * Authentication instruments used for authentication / authorization during authentication steps.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */
-public class ApprovalScaInitRequest extends AuthStepRequest {
+public enum AfsAuthInstrument {
 
-    @Override
-    public List<AuthInstrument> getAuthInstruments() {
-        return Collections.emptyList();
-    }
+    /**
+     * Password is used for step authentication / authorization.
+     */
+    PASSWORD,
+
+    /**
+     * SMS authorization code is used for step authentication / authorization.
+     */
+    SMS_KEY,
+
+    /**
+     * PowerAuth mobile token application is used for step authentication / authorization.
+     */
+    POWERAUTH_TOKEN,
+
+    /**
+     * Hardware token is used for step authentication / authorization.
+     */
+    HW_TOKEN
+
 }

--- a/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/request/AfsRequestParameters.java
+++ b/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/request/AfsRequestParameters.java
@@ -17,7 +17,7 @@ package io.getlime.security.powerauth.lib.dataadapter.model.request;
 
 import io.getlime.security.powerauth.lib.dataadapter.model.enumeration.AfsAction;
 import io.getlime.security.powerauth.lib.dataadapter.model.enumeration.AfsType;
-import io.getlime.security.powerauth.lib.dataadapter.model.enumeration.AuthInstrument;
+import io.getlime.security.powerauth.lib.dataadapter.model.enumeration.AfsAuthInstrument;
 import io.getlime.security.powerauth.lib.dataadapter.model.enumeration.OperationTerminationReason;
 import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthStepResult;
 
@@ -54,7 +54,7 @@ public class AfsRequestParameters {
     /**
      * Authentication instruments used during this authentication step.
      */
-    private final List<AuthInstrument> authInstruments = new ArrayList<>();
+    private final List<AfsAuthInstrument> authInstruments = new ArrayList<>();
 
     /**
      * Authentication step result.
@@ -83,7 +83,7 @@ public class AfsRequestParameters {
      * @param authStepResult Authentication step result.
      * @param operationTerminationReason Reason why operation was terminated.
      */
-    public AfsRequestParameters(AfsType afsType, AfsAction afsAction, String clientIpAddress, int stepIndex, String username, List<AuthInstrument> authInstruments, AuthStepResult authStepResult, OperationTerminationReason operationTerminationReason) {
+    public AfsRequestParameters(AfsType afsType, AfsAction afsAction, String clientIpAddress, int stepIndex, String username, List<AfsAuthInstrument> authInstruments, AuthStepResult authStepResult, OperationTerminationReason operationTerminationReason) {
         this.afsType = afsType;
         this.afsAction = afsAction;
         this.clientIpAddress = clientIpAddress;
@@ -161,7 +161,7 @@ public class AfsRequestParameters {
      * Get authentication authentication instruments used during this step.
      * @return Authentication authentication instruments used during this step.
      */
-    public List<AuthInstrument> getAuthInstruments() {
+    public List<AfsAuthInstrument> getAuthInstruments() {
         return authInstruments;
     }
 

--- a/powerauth-nextstep-client/src/main/java/io/getlime/security/powerauth/lib/nextstep/client/NextStepClient.java
+++ b/powerauth-nextstep-client/src/main/java/io/getlime/security/powerauth/lib/nextstep/client/NextStepClient.java
@@ -28,6 +28,7 @@ import io.getlime.core.rest.model.base.response.Response;
 import io.getlime.security.powerauth.lib.nextstep.model.entity.ApplicationContext;
 import io.getlime.security.powerauth.lib.nextstep.model.entity.KeyValueParameter;
 import io.getlime.security.powerauth.lib.nextstep.model.entity.OperationFormData;
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthInstrument;
 import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthMethod;
 import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthStepResult;
 import io.getlime.security.powerauth.lib.nextstep.model.exception.*;
@@ -215,6 +216,7 @@ public class NextStepClient {
      * @param operationId Operation ID.
      * @param userId User ID.
      * @param authMethod Authentication method.
+     * @param authInstruments Authentication / authorization instruments.
      * @param organizationId Organization ID.
      * @param authStepResult Result of the last step.
      * @param authStepResultDescription Description of the result of the last step.
@@ -223,7 +225,7 @@ public class NextStepClient {
      * @return A Response with UpdateOperationResponse object for OK status or ErrorModel for ERROR status.
      * @throws NextStepServiceException Thrown when communication with Next Step server fails, including {@link Error} with ERROR code.
      */
-    public ObjectResponse<UpdateOperationResponse> updateOperation(String operationId, String userId, String organizationId, AuthMethod authMethod, AuthStepResult authStepResult, String authStepResultDescription, List<KeyValueParameter> params, ApplicationContext applicationContext) throws NextStepServiceException {
+    public ObjectResponse<UpdateOperationResponse> updateOperation(String operationId, String userId, String organizationId, AuthMethod authMethod, List<AuthInstrument> authInstruments, AuthStepResult authStepResult, String authStepResultDescription, List<KeyValueParameter> params, ApplicationContext applicationContext) throws NextStepServiceException {
         try {
             // Exchange next step request with NextStep server.
             UpdateOperationRequest request = new UpdateOperationRequest();
@@ -231,6 +233,7 @@ public class NextStepClient {
             request.setUserId(userId);
             request.setOrganizationId(organizationId);
             request.setAuthMethod(authMethod);
+            request.setAuthInstruments(authInstruments);
             request.setAuthStepResult(authStepResult);
             request.setAuthStepResultDescription(authStepResultDescription);
             if (params != null) {
@@ -254,6 +257,7 @@ public class NextStepClient {
      * @param operationId Operation ID.
      * @param userId User ID.
      * @param authMethod Authentication method.
+     * @param authInstruments Used authentication / authorization instruments.
      * @param organizationId Organization ID.
      * @param authStepResult Result of the last step.
      * @param authStepResultDescription Description of the result of the last step.
@@ -262,7 +266,7 @@ public class NextStepClient {
      * @return A Response with UpdateOperationResponse object for OK status or ErrorModel for ERROR status.
      * @throws NextStepServiceException Thrown when communication with Next Step server fails, including {@link Error} with ERROR code.
      */
-    public ObjectResponse<UpdateOperationResponse> updateOperationPost(String operationId, String userId, String organizationId, AuthMethod authMethod, AuthStepResult authStepResult, String authStepResultDescription, List<KeyValueParameter> params, ApplicationContext applicationContext) throws NextStepServiceException {
+    public ObjectResponse<UpdateOperationResponse> updateOperationPost(String operationId, String userId, String organizationId, AuthMethod authMethod, List<AuthInstrument> authInstruments, AuthStepResult authStepResult, String authStepResultDescription, List<KeyValueParameter> params, ApplicationContext applicationContext) throws NextStepServiceException {
         try {
             // Exchange next step request with NextStep server.
             UpdateOperationRequest request = new UpdateOperationRequest();
@@ -270,6 +274,7 @@ public class NextStepClient {
             request.setUserId(userId);
             request.setOrganizationId(organizationId);
             request.setAuthMethod(authMethod);
+            request.setAuthInstruments(authInstruments);
             request.setAuthStepResult(authStepResult);
             request.setAuthStepResultDescription(authStepResultDescription);
             if (params != null) {

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/enumeration/AuthInstrument.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/enumeration/AuthInstrument.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.getlime.security.powerauth.lib.dataadapter.model.enumeration;
+package io.getlime.security.powerauth.lib.nextstep.model.enumeration;
 
 /**
  * Authentication instruments used for authentication / authorization during authentication steps.

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/request/UpdateOperationRequest.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/request/UpdateOperationRequest.java
@@ -17,6 +17,7 @@ package io.getlime.security.powerauth.lib.nextstep.model.request;
 
 import io.getlime.security.powerauth.lib.nextstep.model.entity.ApplicationContext;
 import io.getlime.security.powerauth.lib.nextstep.model.entity.KeyValueParameter;
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthInstrument;
 import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthMethod;
 import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthStepResult;
 
@@ -34,6 +35,7 @@ public class UpdateOperationRequest {
     private String userId;
     private String organizationId;
     private AuthMethod authMethod;
+    private List<AuthInstrument> authInstruments;
     private AuthStepResult authStepResult;
     private String authStepResultDescription;
     private List<KeyValueParameter> params;
@@ -108,6 +110,22 @@ public class UpdateOperationRequest {
      */
     public void setAuthMethod(AuthMethod authMethod) {
         this.authMethod = authMethod;
+    }
+
+    /**
+     * Get used authentication / authorization instruments.
+     * @return Used authentication / authorization instruments.
+     */
+    public List<AuthInstrument> getAuthInstruments() {
+        return authInstruments;
+    }
+
+    /**
+     * Set used authentication / authorization instruments.
+     * @param authInstruments Used authentication / authorization instruments.
+     */
+    public void setAuthInstruments(List<AuthInstrument> authInstruments) {
+        this.authInstruments = authInstruments;
     }
 
     /**

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OperationHistoryEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OperationHistoryEntity.java
@@ -45,6 +45,9 @@ public class OperationHistoryEntity implements Serializable {
     @Enumerated(EnumType.STRING)
     private AuthMethod requestAuthMethod;
 
+    @Column(name = "request_auth_instruments")
+    private String requestAuthInstruments;
+
     @Column(name = "request_params")
     private String requestParams;
 
@@ -101,6 +104,14 @@ public class OperationHistoryEntity implements Serializable {
 
     public void setRequestAuthMethod(AuthMethod requestAuthMethod) {
         this.requestAuthMethod = requestAuthMethod;
+    }
+
+    public String getRequestAuthInstruments() {
+        return requestAuthInstruments;
+    }
+
+    public void setRequestAuthInstruments(String requestAuthInstruments) {
+        this.requestAuthInstruments = requestAuthInstruments;
     }
 
     public String getRequestParams() {

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/OperationPersistenceService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/OperationPersistenceService.java
@@ -162,8 +162,9 @@ public class OperationPersistenceService {
         operationHistory.setResponseResult(response.getResult());
         operationHistory.setResponseResultDescription(response.getResultDescription());
         try {
-            // Params and steps are saved as JSON for now - new entities would be required to store this data.
+            // Params, steps and auth instruments are saved as JSON for now - new entities would be required to store this data.
             // We can add these entities later in case they are needed.
+            operationHistory.setRequestAuthInstruments(objectMapper.writeValueAsString(request.getAuthInstruments()));
             operationHistory.setRequestParams(objectMapper.writeValueAsString(request.getParams()));
             operationHistory.setResponseSteps(objectMapper.writeValueAsString(response.getSteps()));
         } catch (JsonProcessingException e) {

--- a/powerauth-webflow-authentication-consent/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/consent/controller/ConsentController.java
+++ b/powerauth-webflow-authentication-consent/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/consent/controller/ConsentController.java
@@ -147,7 +147,7 @@ public class ConsentController extends AuthMethodController<ConsentAuthRequest, 
             // log failed authorization into operation history so that maximum number of Next Step update calls can be checked
             Integer remainingAttemptsNS;
             try {
-                UpdateOperationResponse response = failAuthorization(operation.getOperationId(), operation.getUserId(), null);
+                UpdateOperationResponse response = failAuthorization(operation.getOperationId(), operation.getUserId(), request.getAuthInstruments(), null);
                 if (response.getResult() == AuthResult.FAILED) {
                     cleanHttpSession();
                     // FAILED result instead of CONTINUE means the authentication method is failed

--- a/powerauth-webflow-authentication-consent/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/consent/model/request/ConsentAuthRequest.java
+++ b/powerauth-webflow-authentication-consent/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/consent/model/request/ConsentAuthRequest.java
@@ -16,8 +16,10 @@
 package io.getlime.security.powerauth.lib.webflow.authentication.consent.model.request;
 
 import io.getlime.security.powerauth.lib.dataadapter.model.entity.ConsentOption;
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthInstrument;
 import io.getlime.security.powerauth.lib.webflow.authentication.base.AuthStepRequest;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -38,5 +40,10 @@ public class ConsentAuthRequest extends AuthStepRequest {
 
     public List<ConsentOption> getOptions() {
         return options;
+    }
+
+    @Override
+    public List<AuthInstrument> getAuthInstruments() {
+        return Collections.emptyList();
     }
 }

--- a/powerauth-webflow-authentication-form/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/form/controller/FormLoginController.java
+++ b/powerauth-webflow-authentication-form/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/form/controller/FormLoginController.java
@@ -146,7 +146,7 @@ public class FormLoginController extends AuthMethodController<UsernamePasswordAu
             } else {
                 try {
                     if ("login.authenticationFailed".equals(authResponse.getErrorMessage())) {
-                        UpdateOperationResponse response = failAuthorization(operation.getOperationId(), null, null);
+                        UpdateOperationResponse response = failAuthorization(operation.getOperationId(), null, request.getAuthInstruments(), null);
                         if (response.getResult() == AuthResult.FAILED) {
                             // FAILED result instead of CONTINUE means the authentication method is failed
                             throw new MaxAttemptsExceededException("Maximum number of authentication attempts exceeded");

--- a/powerauth-webflow-authentication-form/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/form/model/request/UsernamePasswordAuthenticationRequest.java
+++ b/powerauth-webflow-authentication-form/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/form/model/request/UsernamePasswordAuthenticationRequest.java
@@ -15,7 +15,11 @@
  */
 package io.getlime.security.powerauth.lib.webflow.authentication.method.form.model.request;
 
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthInstrument;
 import io.getlime.security.powerauth.lib.webflow.authentication.base.AuthStepRequest;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Model for a username / password authentication request from client.
@@ -78,5 +82,10 @@ public class UsernamePasswordAuthenticationRequest extends AuthStepRequest {
      */
     public void setOrganizationId(String organizationId) {
         this.organizationId = organizationId;
+    }
+
+    @Override
+    public List<AuthInstrument> getAuthInstruments() {
+        return Collections.singletonList(AuthInstrument.PASSWORD);
     }
 }

--- a/powerauth-webflow-authentication-init/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/init/model/request/InitOperationRequest.java
+++ b/powerauth-webflow-authentication-init/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/init/model/request/InitOperationRequest.java
@@ -15,7 +15,11 @@
  */
 package io.getlime.security.powerauth.lib.webflow.authentication.method.init.model.request;
 
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthInstrument;
 import io.getlime.security.powerauth.lib.webflow.authentication.base.AuthStepRequest;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Models a registration request received from the client.
@@ -24,4 +28,8 @@ import io.getlime.security.powerauth.lib.webflow.authentication.base.AuthStepReq
  */
 public class InitOperationRequest extends AuthStepRequest {
 
+    @Override
+    public List<AuthInstrument> getAuthInstruments() {
+        return Collections.emptyList();
+    }
 }

--- a/powerauth-webflow-authentication-init/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/init/model/request/VerifyTimeoutRequest.java
+++ b/powerauth-webflow-authentication-init/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/init/model/request/VerifyTimeoutRequest.java
@@ -15,7 +15,11 @@
  */
 package io.getlime.security.powerauth.lib.webflow.authentication.method.init.model.request;
 
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthInstrument;
 import io.getlime.security.powerauth.lib.webflow.authentication.base.AuthStepRequest;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Request for operation timeout verification.
@@ -23,4 +27,9 @@ import io.getlime.security.powerauth.lib.webflow.authentication.base.AuthStepReq
  * @author Roman Strobl, roman.strobl@wultra.com
  */
 public class VerifyTimeoutRequest extends AuthStepRequest {
+
+    @Override
+    public List<AuthInstrument> getAuthInstruments() {
+        return Collections.emptyList();
+    }
 }

--- a/powerauth-webflow-authentication-login-sca/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/loginsca/model/request/LoginScaInitRequest.java
+++ b/powerauth-webflow-authentication-login-sca/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/loginsca/model/request/LoginScaInitRequest.java
@@ -15,7 +15,11 @@
  */
 package io.getlime.security.powerauth.lib.webflow.authentication.method.loginsca.model.request;
 
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthInstrument;
 import io.getlime.security.powerauth.lib.webflow.authentication.base.AuthStepRequest;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Model for an init request for SCA login.
@@ -59,5 +63,10 @@ public class LoginScaInitRequest extends AuthStepRequest {
      */
     public void setOrganizationId(String organizationId) {
         this.organizationId = organizationId;
+    }
+
+    @Override
+    public List<AuthInstrument> getAuthInstruments() {
+        return Collections.emptyList();
     }
 }

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileAppApiController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileAppApiController.java
@@ -23,6 +23,7 @@ import io.getlime.security.powerauth.lib.mtoken.model.entity.AllowedSignatureTyp
 import io.getlime.security.powerauth.lib.mtoken.model.request.OperationApproveRequest;
 import io.getlime.security.powerauth.lib.mtoken.model.request.OperationRejectRequest;
 import io.getlime.security.powerauth.lib.mtoken.model.response.OperationListResponse;
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthInstrument;
 import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthMethod;
 import io.getlime.security.powerauth.lib.nextstep.model.enumeration.OperationCancelReason;
 import io.getlime.security.powerauth.lib.nextstep.model.exception.NextStepServiceException;
@@ -54,9 +55,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * This controller presents endpoints that are consumed by the native mobile app,
@@ -244,7 +243,8 @@ public class MobileAppApiController extends AuthMethodController<MobileTokenAuth
             if (operation.getOperationData().equals(request.getRequestObject().getData())
                     && operation.getUserId() != null
                     && operation.getUserId().equals(apiAuthentication.getUserId())) {
-                final UpdateOperationResponse updateOperationResponse = authorize(operationId, userId, operation.getOrganizationId(), null);
+                final List<AuthInstrument> authInstruments = Collections.singletonList(AuthInstrument.POWERAUTH_TOKEN);
+                final UpdateOperationResponse updateOperationResponse = authorize(operationId, userId, operation.getOrganizationId(), authInstruments, null);
                 webSocketMessageService.notifyAuthorizationComplete(operationId, updateOperationResponse.getResult());
                 return new Response();
             } else {

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOfflineController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOfflineController.java
@@ -153,7 +153,7 @@ public class MobileTokenOfflineController extends AuthMethodController<QrCodeAut
         // otherwise fail authorization
         Integer remainingAttemptsNS;
         try {
-            UpdateOperationResponse response = failAuthorization(operation.getOperationId(), getOperation().getUserId(), null);
+            UpdateOperationResponse response = failAuthorization(operation.getOperationId(), getOperation().getUserId(), request.getAuthInstruments(), null);
             if (response.getResult() == AuthResult.FAILED) {
                 // FAILED result instead of CONTINUE means the authentication method is failed
                 cleanHttpSession();

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/model/request/MobileTokenAuthenticationRequest.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/model/request/MobileTokenAuthenticationRequest.java
@@ -1,6 +1,10 @@
 package io.getlime.security.powerauth.lib.webflow.authentication.mtoken.model.request;
 
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthInstrument;
 import io.getlime.security.powerauth.lib.webflow.authentication.base.AuthStepRequest;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Request for online mobile token authentication.
@@ -8,4 +12,9 @@ import io.getlime.security.powerauth.lib.webflow.authentication.base.AuthStepReq
  * @author Petr Dvorak, petr@wultra.com
  */
 public class MobileTokenAuthenticationRequest extends AuthStepRequest {
+
+    @Override
+    public List<AuthInstrument> getAuthInstruments() {
+        return Collections.singletonList(AuthInstrument.POWERAUTH_TOKEN);
+    }
 }

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/model/request/QrCodeAuthenticationRequest.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/model/request/QrCodeAuthenticationRequest.java
@@ -1,6 +1,10 @@
 package io.getlime.security.powerauth.lib.webflow.authentication.mtoken.model.request;
 
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthInstrument;
 import io.getlime.security.powerauth.lib.webflow.authentication.base.AuthStepRequest;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Request for QR code based authentication in offline mode for mobile token.
@@ -61,4 +65,8 @@ public class QrCodeAuthenticationRequest extends AuthStepRequest {
         this.nonce = nonce;
     }
 
+    @Override
+    public List<AuthInstrument> getAuthInstruments() {
+        return Collections.singletonList(AuthInstrument.POWERAUTH_TOKEN);
+    }
 }

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/model/request/QrCodeInitRequest.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/model/request/QrCodeInitRequest.java
@@ -1,13 +1,11 @@
 package io.getlime.security.powerauth.lib.webflow.authentication.mtoken.model.request;
 
-import io.getlime.security.powerauth.lib.webflow.authentication.base.AuthStepRequest;
-
 /**
  * Request for QR code initialization in offline mode for QR token.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */
-public class QrCodeInitRequest extends AuthStepRequest {
+public class QrCodeInitRequest {
 
     private String activationId;
 

--- a/powerauth-webflow-authentication-operation-review/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/operation/model/request/OperationDetailRequest.java
+++ b/powerauth-webflow-authentication-operation-review/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/operation/model/request/OperationDetailRequest.java
@@ -16,12 +16,11 @@
 
 package io.getlime.security.powerauth.lib.webflow.authentication.method.operation.model.request;
 
-import io.getlime.security.powerauth.lib.webflow.authentication.base.AuthStepRequest;
-
 /**
  * Request for operation detail.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */
-public class OperationDetailRequest extends AuthStepRequest {
+public class OperationDetailRequest {
+
 }

--- a/powerauth-webflow-authentication-operation-review/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/operation/model/request/OperationReviewRequest.java
+++ b/powerauth-webflow-authentication-operation-review/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/operation/model/request/OperationReviewRequest.java
@@ -16,7 +16,11 @@
 
 package io.getlime.security.powerauth.lib.webflow.authentication.method.operation.model.request;
 
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthInstrument;
 import io.getlime.security.powerauth.lib.webflow.authentication.base.AuthStepRequest;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Request for operation review.
@@ -24,4 +28,9 @@ import io.getlime.security.powerauth.lib.webflow.authentication.base.AuthStepReq
  * @author Petr Dvorak, petr@wultra.com
  */
 public class OperationReviewRequest extends AuthStepRequest {
+
+    @Override
+    public List<AuthInstrument> getAuthInstruments() {
+        return Collections.emptyList();
+    }
 }

--- a/powerauth-webflow-authentication-operation-review/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/operation/model/request/UpdateOperationChosenAuthMethodRequest.java
+++ b/powerauth-webflow-authentication-operation-review/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/operation/model/request/UpdateOperationChosenAuthMethodRequest.java
@@ -17,13 +17,12 @@
 package io.getlime.security.powerauth.lib.webflow.authentication.method.operation.model.request;
 
 import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthMethod;
-import io.getlime.security.powerauth.lib.webflow.authentication.base.AuthStepRequest;
 
 /**
  * Request to set chosen authentication method.
  * @author Roman Strobl, roman.strobl@wultra.com
  */
-public class UpdateOperationChosenAuthMethodRequest extends AuthStepRequest {
+public class UpdateOperationChosenAuthMethodRequest {
 
     private AuthMethod chosenAuthMethod;
 

--- a/powerauth-webflow-authentication-operation-review/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/operation/model/request/UpdateOperationFormDataRequest.java
+++ b/powerauth-webflow-authentication-operation-review/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/operation/model/request/UpdateOperationFormDataRequest.java
@@ -17,13 +17,12 @@
 package io.getlime.security.powerauth.lib.webflow.authentication.method.operation.model.request;
 
 import io.getlime.security.powerauth.lib.nextstep.model.entity.OperationFormData;
-import io.getlime.security.powerauth.lib.webflow.authentication.base.AuthStepRequest;
 
 /**
  * Request to update operation form data.
  * @author Roman Strobl, roman.strobl@wultra.com
  */
-public class UpdateOperationFormDataRequest extends AuthStepRequest {
+public class UpdateOperationFormDataRequest {
 
     private OperationFormData formData;
 

--- a/powerauth-webflow-authentication-sms/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/sms/controller/SmsAuthorizationController.java
+++ b/powerauth-webflow-authentication-sms/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/sms/controller/SmsAuthorizationController.java
@@ -501,12 +501,10 @@ public class SmsAuthorizationController extends AuthMethodController<SmsAuthoriz
         // Choose current AFS action
         final AfsAction afsAction;
         if (configuration.isAfsEnabled()) {
-            if (authMethod == AuthMethod.LOGIN_SCA || authMethod == AuthMethod.APPROVAL_SCA) {
-                if (authMethod == AuthMethod.LOGIN_SCA) {
-                    afsAction = AfsAction.LOGIN_AUTH;
-                } else {
-                    afsAction = AfsAction.APPROVAL_AUTH;
-                }
+            if (authMethod == AuthMethod.LOGIN_SCA) {
+                afsAction = AfsAction.LOGIN_AUTH;
+            } else if (authMethod == AuthMethod.APPROVAL_SCA) {
+                afsAction = AfsAction.APPROVAL_AUTH;
             } else {
                 afsAction = null;
             }

--- a/powerauth-webflow-authentication-sms/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/sms/model/request/SmsAuthorizationRequest.java
+++ b/powerauth-webflow-authentication-sms/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/sms/model/request/SmsAuthorizationRequest.java
@@ -15,7 +15,11 @@
  */
 package io.getlime.security.powerauth.lib.webflow.authentication.sms.model.request;
 
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthInstrument;
 import io.getlime.security.powerauth.lib.webflow.authentication.base.AuthStepRequest;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Request for SMS authorization.
@@ -26,6 +30,7 @@ public class SmsAuthorizationRequest extends AuthStepRequest {
 
     private String authCode;
     private String password;
+    private List<AuthInstrument> authInstruments = new ArrayList<>();
 
     /**
      * Get authorization code from SMS message.
@@ -57,5 +62,18 @@ public class SmsAuthorizationRequest extends AuthStepRequest {
      */
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    @Override
+    public List<AuthInstrument> getAuthInstruments() {
+        return authInstruments;
+    }
+
+    /**
+     * Set authorization instruments used in this request.
+     * @param authInstruments Authorization instruments used in this request.
+     */
+    public void setAuthInstruments(List<AuthInstrument> authInstruments) {
+        this.authInstruments = authInstruments;
     }
 }

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/base/AuthStepRequest.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/base/AuthStepRequest.java
@@ -16,10 +16,20 @@
 
 package io.getlime.security.powerauth.lib.webflow.authentication.base;
 
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthInstrument;
+
+import java.util.List;
+
 /**
  * Base class for any authentication step requests.
  *
  * @author Petr Dvorak, petr@wultra.com
  */
-public class AuthStepRequest {
+public abstract class AuthStepRequest {
+
+    /**
+     * Get authentication / authorization instruments used in this step.
+     * @return Authentication / authorization instuments used in this step.
+     */
+    public abstract List<AuthInstrument> getAuthInstruments();
 }

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/listener/WebSocketDisconnectListener.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/listener/WebSocketDisconnectListener.java
@@ -41,6 +41,7 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -103,7 +104,7 @@ public class WebSocketDisconnectListener implements ApplicationListener<SessionD
                         // Authentication method is not overridden, use last known authentication method
                         authMethod = operationHistory.get(operationHistory.size() - 1).getAuthMethod();
                     }
-                    nextStepClient.updateOperation(operationDetail.getOperationId(), operationDetail.getUserId(), operationDetail.getOrganizationId(), authMethod, AuthStepResult.CANCELED, OperationCancelReason.INTERRUPTED_OPERATION.toString(), null, operationDetail.getApplicationContext());
+                    nextStepClient.updateOperation(operationDetail.getOperationId(), operationDetail.getUserId(), operationDetail.getOrganizationId(), authMethod, Collections.emptyList(), AuthStepResult.CANCELED, OperationCancelReason.INTERRUPTED_OPERATION.toString(), null, operationDetail.getApplicationContext());
                     // Notify Data Adapter about cancellation
                     FormData formData = new FormDataConverter().fromOperationFormData(operationDetail.getFormData());
                     OperationContext operationContext = new OperationContext(operationDetail.getOperationId(), operationDetail.getOperationName(), operationDetail.getOperationData(), formData, operationDetail.getApplicationContext());

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/model/converter/AuthInstrumentConverter.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/model/converter/AuthInstrumentConverter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.lib.webflow.authentication.model.converter;
+
+import io.getlime.security.powerauth.lib.dataadapter.model.enumeration.AfsAuthInstrument;
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthInstrument;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Converter for authentication / authorization instruments.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class AuthInstrumentConverter {
+
+    public List<AfsAuthInstrument> fromAuthInstruments(List<AuthInstrument> authInstruments) {
+        List<AfsAuthInstrument> authInstrumentsAfs = new ArrayList<>();
+        for (AuthInstrument instrument: authInstruments) {
+            switch (instrument) {
+                case PASSWORD:
+                    authInstrumentsAfs.add(AfsAuthInstrument.PASSWORD);
+                    break;
+                case SMS_KEY:
+                    authInstrumentsAfs.add(AfsAuthInstrument.SMS_KEY);
+                    break;
+                case POWERAUTH_TOKEN:
+                    authInstrumentsAfs.add(AfsAuthInstrument.POWERAUTH_TOKEN);
+                    break;
+                case HW_TOKEN:
+                    authInstrumentsAfs.add(AfsAuthInstrument.HW_TOKEN);
+                    break;
+            }
+        }
+        return authInstrumentsAfs;
+    }
+}

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/AfsIntegrationService.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/AfsIntegrationService.java
@@ -24,7 +24,7 @@ import io.getlime.security.powerauth.lib.dataadapter.model.entity.FormData;
 import io.getlime.security.powerauth.lib.dataadapter.model.entity.OperationContext;
 import io.getlime.security.powerauth.lib.dataadapter.model.enumeration.AfsAction;
 import io.getlime.security.powerauth.lib.dataadapter.model.enumeration.AfsType;
-import io.getlime.security.powerauth.lib.dataadapter.model.enumeration.AuthInstrument;
+import io.getlime.security.powerauth.lib.dataadapter.model.enumeration.AfsAuthInstrument;
 import io.getlime.security.powerauth.lib.dataadapter.model.enumeration.OperationTerminationReason;
 import io.getlime.security.powerauth.lib.dataadapter.model.request.AfsRequestParameters;
 import io.getlime.security.powerauth.lib.dataadapter.model.response.AfsResponse;
@@ -108,7 +108,7 @@ public class AfsIntegrationService {
      * @param authInstruments Authentication instruments used in this step.
      * @param authStepResult Authentication step result.
      */
-    public void executeAuthAction(String operationId, AfsAction afsAction, String username, List<AuthInstrument> authInstruments, AuthStepResult authStepResult) {
+    public void executeAuthAction(String operationId, AfsAction afsAction, String username, List<AfsAuthInstrument> authInstruments, AuthStepResult authStepResult) {
         executeAfsAction(operationId, afsAction, authInstruments, authStepResult, username, null);
     }
 
@@ -133,7 +133,7 @@ public class AfsIntegrationService {
      * @param operationTerminationReason Reason why operation was terminated.
      * @return Response from anti-fraud system.
      */
-    private AfsResponse executeAfsAction(String operationId, AfsAction afsAction, List<AuthInstrument> authInstruments, AuthStepResult authStepResult, String username, OperationTerminationReason operationTerminationReason) {
+    private AfsResponse executeAfsAction(String operationId, AfsAction afsAction, List<AfsAuthInstrument> authInstruments, AuthStepResult authStepResult, String username, OperationTerminationReason operationTerminationReason) {
         if (configuration.isAfsEnabled()) {
             logger.debug("AFS integration is enabled");
             try {

--- a/powerauth-webflow/src/main/resources/application.properties
+++ b/powerauth-webflow/src/main/resources/application.properties
@@ -71,7 +71,7 @@ powerauth.webflow.sms.resend.delayMs=60000
 powerauth.webflow.timeout.warning.delayMs=60000
 
 # Anti-fraud system configuration
-powerauth.webflow.afs.enabled=true
+powerauth.webflow.afs.enabled=false
 powerauth.webflow.afs.type=THREAT_MARK
 powerauth.webflow.afs.detectIpAddress=false
 powerauth.webflow.afs.forceIpv4=true

--- a/powerauth-webflow/src/main/resources/application.properties
+++ b/powerauth-webflow/src/main/resources/application.properties
@@ -71,7 +71,7 @@ powerauth.webflow.sms.resend.delayMs=60000
 powerauth.webflow.timeout.warning.delayMs=60000
 
 # Anti-fraud system configuration
-powerauth.webflow.afs.enabled=false
+powerauth.webflow.afs.enabled=true
 powerauth.webflow.afs.type=THREAT_MARK
 powerauth.webflow.afs.detectIpAddress=false
 powerauth.webflow.afs.forceIpv4=true


### PR DESCRIPTION
This pull request introduces logging of used authentication / authorization instrument(s) into operation history, so that it is easier to find out which authentication / authorization instruments were used during individual steps.