### PR TITLE
Fix #699: Two-step selection of account breaks mobile token

### DIFF
--- a/docs/Web-Flow-0.23.0.md
+++ b/docs/Web-Flow-0.23.0.md
@@ -30,6 +30,7 @@ CREATE INDEX wf_operation_hash ON wf_operation_session (operation_hash);
 CREATE INDEX wf_websocket_session ON wf_operation_session (websocket_session_id);
 
 ALTER TABLE ns_operation_history ADD request_auth_instruments VARCHAR(256);
+ALTER TABLE ns_operation_history ADD mobile_token_active NUMBER(1) DEFAULT 0 NOT NULL;
 ALTER TABLE ns_operation ADD user_account_status VARCHAR(32);
 
 CREATE TABLE ns_operation_afs (
@@ -69,6 +70,7 @@ CREATE INDEX `wf_operation_hash` ON `wf_operation_session` (`operation_hash`);
 CREATE INDEX `wf_websocket_session` ON `wf_operation_session` (`websocket_session_id`);
 
 ALTER TABLE `ns_operation_history` ADD `request_auth_instruments` VARCHAR(256);
+ALTER TABLE `ns_operation_history` ADD `mobile_token_active` BOOLEAN NOT NULL DEFAULT FALSE;
 ALTER TABLE `ns_operation` ADD `user_account_status` VARCHAR(32);
 
 CREATE TABLE ns_operation_afs (

--- a/docs/sql/mysql/create_schema.sql
+++ b/docs/sql/mysql/create_schema.sql
@@ -142,6 +142,7 @@ CREATE TABLE ns_operation_history (
   response_timestamp_created  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   response_timestamp_expires  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   chosen_auth_method          VARCHAR(32),
+  mobile_token_active         BOOLEAN NOT NULL DEFAULT FALSE,
   PRIMARY KEY (operation_id, result_id),
   FOREIGN KEY operation_fk (operation_id) REFERENCES ns_operation (operation_id),
   FOREIGN KEY auth_method_fk (request_auth_method) REFERENCES ns_auth_method (auth_method)

--- a/docs/sql/oracle/create_schema.sql
+++ b/docs/sql/oracle/create_schema.sql
@@ -149,6 +149,7 @@ CREATE TABLE ns_operation_history (
   response_timestamp_created  TIMESTAMP,
   response_timestamp_expires  TIMESTAMP,
   chosen_auth_method          VARCHAR(32),
+  mobile_token_active         NUMBER(1) DEFAULT 0 NOT NULL,
   CONSTRAINT history_pk PRIMARY KEY (operation_id, result_id),
   CONSTRAINT history_operation_fk FOREIGN KEY (operation_id) REFERENCES ns_operation (operation_id),
   CONSTRAINT history_auth_method_fk FOREIGN KEY (request_auth_method) REFERENCES ns_auth_method (auth_method)

--- a/docs/sql/postgresql/create_schema.sql
+++ b/docs/sql/postgresql/create_schema.sql
@@ -147,6 +147,7 @@ CREATE TABLE ns_operation_history (
   response_timestamp_created  TIMESTAMP,
   response_timestamp_expires  TIMESTAMP,
   chosen_auth_method          VARCHAR(32),
+  mobile_token_active         BOOLEAN NOT NULL DEFAULT FALSE,
   CONSTRAINT history_pk PRIMARY KEY (operation_id, result_id),
   CONSTRAINT history_operation_fk FOREIGN KEY (operation_id) REFERENCES ns_operation (operation_id),
   CONSTRAINT history_auth_method_fk FOREIGN KEY (request_auth_method) REFERENCES ns_auth_method (auth_method)

--- a/powerauth-nextstep-client/src/main/java/io/getlime/security/powerauth/lib/nextstep/client/NextStepClient.java
+++ b/powerauth-nextstep-client/src/main/java/io/getlime/security/powerauth/lib/nextstep/client/NextStepClient.java
@@ -436,6 +436,80 @@ public class NextStepClient {
     }
 
     /**
+     * Update mobile token status for current operation step via PUT method.
+     * @param operationId Operation ID.
+     * @param mobileTokenActive Whether mobile token is active.
+     * @return Object response.
+     * @throws NextStepServiceException Thrown when communication with Next Step server fails, including {@link Error} with ERROR code.
+     */
+    public ObjectResponse updateMobileToken(String operationId, boolean mobileTokenActive) throws NextStepServiceException {
+        try {
+            // Exchange next step request with NextStep server.
+            UpdateMobileTokenRequest request = new UpdateMobileTokenRequest();
+            request.setOperationId(operationId);
+            request.setMobileTokenActive(mobileTokenActive);
+            HttpEntity<ObjectRequest<UpdateMobileTokenRequest>> entity = new HttpEntity<>(new ObjectRequest<>(request));
+            ResponseEntity<ObjectResponse> response = restTemplate.exchange(serviceUrl + "/operation/mobileToken/status", HttpMethod.PUT, entity, new ParameterizedTypeReference<ObjectResponse>() {
+            });
+            return new ObjectResponse<>(response.getBody().getResponseObject());
+        } catch (HttpStatusCodeException ex) {
+            throw handleHttpError(ex);
+        } catch (ResourceAccessException ex) {
+            throw handleResourceAccessError(ex);
+        }
+    }
+
+    /**
+     * Update mobile token status for current operation step via POST method.
+     * @param operationId Operation ID.
+     * @param mobileTokenActive Whether mobile token is active.
+     * @return Object response.
+     * @throws NextStepServiceException Thrown when communication with Next Step server fails, including {@link Error} with ERROR code.
+     */
+    public ObjectResponse updateMobileTokenPost(String operationId, boolean mobileTokenActive) throws NextStepServiceException {
+        try {
+            // Exchange next step request with NextStep server.
+            UpdateMobileTokenRequest request = new UpdateMobileTokenRequest();
+            request.setOperationId(operationId);
+            request.setMobileTokenActive(mobileTokenActive);
+            HttpEntity<ObjectRequest<UpdateMobileTokenRequest>> entity = new HttpEntity<>(new ObjectRequest<>(request));
+            ResponseEntity<ObjectResponse> response = restTemplate.exchange(serviceUrl + "/operation/status/update", HttpMethod.POST, entity, new ParameterizedTypeReference<ObjectResponse>() {
+            });
+            return new ObjectResponse<>(response.getBody().getResponseObject());
+        } catch (HttpStatusCodeException ex) {
+            throw handleHttpError(ex);
+        } catch (ResourceAccessException ex) {
+            throw handleResourceAccessError(ex);
+        }
+    }
+
+    /**
+     * Get mobile token configuration configuration.
+     * @param userId User ID.
+     * @param operationName Operation name.
+     * @param authMethod Authentication method.
+     * @return Mobile token configuration.
+     * @throws NextStepServiceException Thrown when operation configuration is missing.
+     */
+    public ObjectResponse<GetMobileTokenConfigResponse> getMobileTokenConfig(String userId, String operationName, AuthMethod authMethod) throws NextStepServiceException {
+        try {
+            // Exchange next step request with NextStep server.
+            GetMobileTokenConfigRequest request = new GetMobileTokenConfigRequest();
+            request.setUserId(userId);
+            request.setOperationName(operationName);
+            request.setAuthMethod(authMethod);
+            HttpEntity<ObjectRequest<GetMobileTokenConfigRequest>> entity = new HttpEntity<>(new ObjectRequest<>(request));
+            ResponseEntity<ObjectResponse<GetMobileTokenConfigResponse>> response = restTemplate.exchange(serviceUrl + "/operation/mobileToken/config/detail", HttpMethod.POST, entity, new ParameterizedTypeReference<ObjectResponse<GetMobileTokenConfigResponse>>() {});
+            return new ObjectResponse<>(response.getBody().getResponseObject());
+        } catch (HttpStatusCodeException ex) {
+            throw handleHttpError(ex);
+        } catch (ResourceAccessException ex) {
+            // Next Step service is down
+            throw handleResourceAccessError(ex);
+        }
+    }
+
+    /**
      * Calls the operation details endpoint via POST method to get operation details.
      *
      * @param id Operation ID.

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/request/GetMobileTokenConfigRequest.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/request/GetMobileTokenConfigRequest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.lib.nextstep.model.request;
+
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthMethod;
+
+/**
+ * Request object used obtaining mobile token configuration.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class GetMobileTokenConfigRequest {
+
+    private String userId;
+    private String operationName;
+    private AuthMethod authMethod;
+
+    /**
+     * Get user ID.
+     * @return User ID.
+     */
+    public String getUserId() {
+        return userId;
+    }
+
+    /**
+     * Set user ID.
+     * @param userId User ID.
+     */
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    /**
+     * Get the operation name.
+     * @return Operation name.
+     */
+    public String getOperationName() {
+        return operationName;
+    }
+
+    /**
+     * Set the operation name.
+     * @param operationName Operation name.
+     */
+    public void setOperationName(String operationName) {
+        this.operationName = operationName;
+    }
+
+    /**
+     * Get authentication method.
+     * @return Authentication method.
+     */
+    public AuthMethod getAuthMethod() {
+        return authMethod;
+    }
+
+    /**
+     * Set authentication method.
+     * @param authMethod Authentication method.
+     */
+    public void setAuthMethod(AuthMethod authMethod) {
+        this.authMethod = authMethod;
+    }
+}

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/request/UpdateMobileTokenRequest.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/request/UpdateMobileTokenRequest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.lib.nextstep.model.request;
+
+/**
+ * Request object used for updating mobile token status.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class UpdateMobileTokenRequest {
+
+    private String operationId;
+    private boolean mobileTokenActive;
+
+    /**
+     * Default constructor.
+     */
+    public UpdateMobileTokenRequest() {
+    }
+
+    /**
+     * Constructor with mobile token status.
+     * @param operationId Operation ID.
+     * @param mobileTokenActive Whether mobile token is active.
+     */
+    public UpdateMobileTokenRequest(String operationId, boolean mobileTokenActive) {
+        this.operationId = operationId;
+        this.mobileTokenActive = mobileTokenActive;
+    }
+
+    /**
+     * Get operation ID.
+     * @return Operation ID.
+     */
+    public String getOperationId() {
+        return operationId;
+    }
+
+    /**
+     * Set operation ID.
+     * @param operationId Operation ID.
+     */
+    public void setOperationId(String operationId) {
+        this.operationId = operationId;
+    }
+
+    /**
+     * Get whether mobile token is active.
+     * @return Whether mobile token is active.
+     */
+    public boolean isMobileTokenActive() {
+        return mobileTokenActive;
+    }
+
+    /**
+     * Set whether mobile token is active.
+     * @param mobileTokenActive Whether mobile token is active.
+     */
+    public void setMobileTokenActive(boolean mobileTokenActive) {
+        this.mobileTokenActive = mobileTokenActive;
+    }
+}

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/response/GetMobileTokenConfigResponse.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/response/GetMobileTokenConfigResponse.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.lib.nextstep.model.response;
+
+/**
+ * Response object used obtaining mobile token configuration.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class GetMobileTokenConfigResponse {
+
+    private boolean mobileTokenEnabled;
+
+    /**
+     * Get whether mobile token is enabled.
+     * @return Whether mobile token is enabled.
+     */
+    public boolean isMobileTokenEnabled() {
+        return mobileTokenEnabled;
+    }
+
+    /**
+     * Set whether mobile token is enabled.
+     * @param mobileTokenEnabled Whether mobile token is enabled.
+     */
+    public void setMobileTokenEnabled(boolean mobileTokenEnabled) {
+        this.mobileTokenEnabled = mobileTokenEnabled;
+    }
+}

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OperationController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OperationController.java
@@ -25,11 +25,13 @@ import io.getlime.core.rest.model.base.response.Response;
 import io.getlime.security.powerauth.app.nextstep.repository.model.entity.OperationAfsActionEntity;
 import io.getlime.security.powerauth.app.nextstep.repository.model.entity.OperationEntity;
 import io.getlime.security.powerauth.app.nextstep.repository.model.entity.OperationHistoryEntity;
+import io.getlime.security.powerauth.app.nextstep.service.MobileTokenConfigurationService;
 import io.getlime.security.powerauth.app.nextstep.service.OperationConfigurationService;
 import io.getlime.security.powerauth.app.nextstep.service.OperationPersistenceService;
 import io.getlime.security.powerauth.app.nextstep.service.StepResolutionService;
 import io.getlime.security.powerauth.lib.nextstep.model.entity.*;
 import io.getlime.security.powerauth.lib.nextstep.model.entity.enumeration.UserAccountStatus;
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthMethod;
 import io.getlime.security.powerauth.lib.nextstep.model.exception.NextStepServiceException;
 import io.getlime.security.powerauth.lib.nextstep.model.exception.OperationAlreadyExistsException;
 import io.getlime.security.powerauth.lib.nextstep.model.exception.OperationNotConfiguredException;
@@ -63,6 +65,7 @@ public class OperationController {
     private final OperationPersistenceService operationPersistenceService;
     private final OperationConfigurationService operationConfigurationService;
     private final StepResolutionService stepResolutionService;
+    private final MobileTokenConfigurationService mobileTokenConfigurationService;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -71,13 +74,15 @@ public class OperationController {
      * @param operationPersistenceService Operation persistence service.
      * @param operationConfigurationService Operation configuration service.
      * @param stepResolutionService Step resolution service.
+     * @param mobileTokenConfigurationService Mobile token configuration service.
      */
     @Autowired
     public OperationController(OperationPersistenceService operationPersistenceService, OperationConfigurationService operationConfigurationService,
-                               StepResolutionService stepResolutionService) {
+                               StepResolutionService stepResolutionService, MobileTokenConfigurationService mobileTokenConfigurationService) {
         this.operationPersistenceService = operationPersistenceService;
         this.operationConfigurationService = operationConfigurationService;
         this.stepResolutionService = stepResolutionService;
+        this.mobileTokenConfigurationService = mobileTokenConfigurationService;
     }
 
     /**
@@ -360,10 +365,59 @@ public class OperationController {
 
     private Response updateChosenAuthMethodImpl(ObjectRequest<UpdateChosenAuthMethodRequest> request) throws OperationNotFoundException {
         logger.info("Received updateChosenAuthMethod request, operation ID: {}, chosen authentication method: {}", request.getRequestObject().getOperationId(), request.getRequestObject().getChosenAuthMethod().toString());
-        // persist operation form data update
+        // persist chosen auth method update
         operationPersistenceService.updateChosenAuthMethod(request.getRequestObject());
         logger.debug("The updateChosenAuthMethod request succeeded");
         return new Response();
+    }
+
+    /**
+     * Update mobile token status for an operation (PUT method).
+     * @param request Update operation request.
+     * @return Update operation response.
+     * @throws OperationNotFoundException Thrown when operation is not found.
+     */
+    @RequestMapping(value = "/operation/mobileToken/status", method = RequestMethod.PUT)
+    public @ResponseBody Response updateMobileToken(@RequestBody ObjectRequest<UpdateMobileTokenRequest> request) throws OperationNotFoundException {
+        return updateMobileTokenImpl(request);
+    }
+
+    /**
+     * Update operation with chosen authentication method (POST method alternative).
+     * @param request Update operation request.
+     * @return Update operation response.
+     * @throws OperationNotFoundException Thrown when operation is not found.
+     */
+    @RequestMapping(value = "/operation/mobileToken/status/update", method = RequestMethod.POST)
+    public @ResponseBody Response updateMobileTokenPost(@RequestBody ObjectRequest<UpdateMobileTokenRequest> request) throws OperationNotFoundException {
+        return updateMobileTokenImpl(request);
+    }
+
+    private Response updateMobileTokenImpl(ObjectRequest<UpdateMobileTokenRequest> request) throws OperationNotFoundException {
+        logger.info("Received updateMobileToken request, operation ID: {}, mobile token active: {}", request.getRequestObject().getOperationId(), request.getRequestObject().isMobileTokenActive());
+        // persist mobile token update
+        operationPersistenceService.updateMobileToken(request.getRequestObject());
+        logger.debug("The updateMobileToken request succeeded");
+        return new Response();
+    }
+
+    /**
+     * Get mobile token configuration.
+     * @param request Get mobile token configuration request.
+     * @return Get mobile token configuration response.
+     * @throws OperationNotFoundException Thrown when operation is not found.
+     */
+    @RequestMapping(value = "/operation/mobileToken/config/detail", method = RequestMethod.POST)
+    public @ResponseBody ObjectResponse<GetMobileTokenConfigResponse> getMobileTokenConfig(@RequestBody ObjectRequest<GetMobileTokenConfigRequest> request) throws OperationNotFoundException {
+        String userId = request.getRequestObject().getUserId();
+        String operationName = request.getRequestObject().getOperationName();
+        AuthMethod authMethod = request.getRequestObject().getAuthMethod();
+        logger.info("Received getMobileTokenConfig request, user ID: {}, operation name: {}, authentication method: {}", userId, operationName, authMethod);
+        boolean isMobileTokenEnabled = mobileTokenConfigurationService.isMobileTokenEnabled(userId, operationName, authMethod);
+        GetMobileTokenConfigResponse response = new GetMobileTokenConfigResponse();
+        response.setMobileTokenEnabled(isMobileTokenEnabled);
+        logger.debug("The getMobileTokenConfig request succeeded");
+        return new ObjectResponse<>(response);
     }
 
     /**

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OperationHistoryEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OperationHistoryEntity.java
@@ -71,6 +71,9 @@ public class OperationHistoryEntity implements Serializable {
     @Enumerated(EnumType.STRING)
     private AuthMethod chosenAuthMethod;
 
+    @Column(name = "mobile_token_active")
+    private boolean mobileTokenActive;
+
     @ManyToOne
     @JoinColumn(name = "operation_id", insertable = false, updatable = false)
     private OperationEntity operation;
@@ -168,6 +171,14 @@ public class OperationHistoryEntity implements Serializable {
 
     public void setChosenAuthMethod(AuthMethod chosenAuthMethod) {
         this.chosenAuthMethod = chosenAuthMethod;
+    }
+
+    public boolean isMobileTokenActive() {
+        return mobileTokenActive;
+    }
+
+    public void setMobileTokenActive(boolean mobileTokenActive) {
+        this.mobileTokenActive = mobileTokenActive;
     }
 
     /**

--- a/powerauth-webflow-authentication-approval-sca/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/approvalsca/controller/ApprovalScaController.java
+++ b/powerauth-webflow-authentication-approval-sca/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/approvalsca/controller/ApprovalScaController.java
@@ -101,6 +101,7 @@ public class ApprovalScaController extends AuthMethodController<ApprovalScaAuthR
         boolean mobileTokenEnabled = false;
         try {
             if (authMethodQueryService.isMobileTokenAvailable(userId, operation.getOperationId())) {
+                nextStepClient.updateMobileToken(operation.getOperationId(), true);
                 mobileTokenEnabled = true;
             }
         } catch (NextStepServiceException e) {

--- a/powerauth-webflow-authentication-login-sca/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/loginsca/controller/LoginScaController.java
+++ b/powerauth-webflow-authentication-login-sca/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/loginsca/controller/LoginScaController.java
@@ -148,6 +148,7 @@ public class LoginScaController extends AuthMethodController<LoginScaAuthRequest
                 boolean mobileTokenEnabled = false;
                 try {
                     if (authMethodQueryService.isMobileTokenAvailable(userId, operation.getOperationId())) {
+                        nextStepClient.updateMobileToken(operation.getOperationId(), true);
                         mobileTokenEnabled = true;
                     }
                 } catch (NextStepServiceException e) {

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOnlineController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOnlineController.java
@@ -16,6 +16,7 @@
 
 package io.getlime.security.powerauth.lib.webflow.authentication.mtoken.controller;
 
+import io.getlime.security.powerauth.lib.nextstep.client.NextStepClient;
 import io.getlime.security.powerauth.lib.nextstep.model.entity.OperationHistory;
 import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthMethod;
 import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthResult;
@@ -57,18 +58,21 @@ public class MobileTokenOnlineController extends AuthMethodController<MobileToke
 
     private final WebFlowServicesConfiguration webFlowServicesConfiguration;
     private final PushMessageService pushMessageService;
+    private final NextStepClient nextStepClient;
     private final HttpSession httpSession;
 
     /**
      * Controller constructor.
      * @param webFlowServicesConfiguration Web Flow configuration.
      * @param pushMessageService Push message service.
+     * @param nextStepClient Next Step client.
      * @param httpSession HTTP session.
      */
     @Autowired
-    public MobileTokenOnlineController(WebFlowServicesConfiguration webFlowServicesConfiguration, PushMessageService pushMessageService, HttpSession httpSession) {
+    public MobileTokenOnlineController(WebFlowServicesConfiguration webFlowServicesConfiguration, PushMessageService pushMessageService, NextStepClient nextStepClient, HttpSession httpSession) {
         this.webFlowServicesConfiguration = webFlowServicesConfiguration;
         this.pushMessageService = pushMessageService;
+        this.nextStepClient = nextStepClient;
         this.httpSession = httpSession;
     }
 
@@ -124,6 +128,10 @@ public class MobileTokenOnlineController extends AuthMethodController<MobileToke
         if (authMethod == AuthMethod.LOGIN_SCA || authMethod == AuthMethod.APPROVAL_SCA) {
             // Allow fallback to SMS in authentication method LOGIN_SCA
             initResponse.setSmsFallbackAvailable(true);
+        }
+        if (authMethod == AuthMethod.POWERAUTH_TOKEN) {
+            // User selected POWERAUTH_TOKEN in a non-SCA step, set mobile token as active
+            nextStepClient.updateMobileToken(operation.getOperationId(), true);
         }
         logger.debug("Step initialization succeeded, operation ID: {}, authentication method: {}", operation.getOperationId(), authMethod.toString());
         return initResponse;


### PR DESCRIPTION
I fixed the issue, however I cannot test it properly because I don't have a USB-C to USB adaper / USB-C to lightning cable during my trip. So I just tested that the `mobile_token_active` value is written into the DB which should cause the pending operations endpoint start returning correct response at the right moment. I will test it more thoroughly tomorrow once I buy the cable.