### PR TITLE
Fix #705: Wrong expired error on mobile api

### DIFF
--- a/powerauth-webflow-authentication-approval-sca/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/approvalsca/controller/ApprovalScaController.java
+++ b/powerauth-webflow-authentication-approval-sca/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/approvalsca/controller/ApprovalScaController.java
@@ -82,7 +82,6 @@ public class ApprovalScaController extends AuthMethodController<ApprovalScaAuthR
     public ApprovalScaAuthResponse authenticateScaApproval(@RequestBody ApprovalScaAuthRequest request) throws AuthStepException, NextStepServiceException {
         GetOperationDetailResponse operation = getOperation();
         logger.info("Step authentication started, operation ID: {}, authentication method: {}", operation.getOperationId(), getAuthMethodName().toString());
-        checkOperationExpiration(operation);
         String userId = operation.getUserId();
         if (userId == null) {
             // At this point user ID must be known, method cannot continue
@@ -130,7 +129,6 @@ public class ApprovalScaController extends AuthMethodController<ApprovalScaAuthR
     public ApprovalScaInitResponse initScaApproval(@RequestBody ApprovalScaInitRequest request) throws AuthStepException, NextStepServiceException {
         GetOperationDetailResponse operation = getOperation();
         logger.info("Step init started, operation ID: {}, authentication method: {}", operation.getOperationId(), getAuthMethodName().toString());
-        checkOperationExpiration(operation);
         String userId = operation.getUserId();
         if (userId == null) {
             // At this point user ID must be known, method cannot continue

--- a/powerauth-webflow-authentication-consent/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/consent/controller/ConsentController.java
+++ b/powerauth-webflow-authentication-consent/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/consent/controller/ConsentController.java
@@ -101,7 +101,6 @@ public class ConsentController extends AuthMethodController<ConsentAuthRequest, 
     protected AuthenticationResult authenticate(ConsentAuthRequest request) throws AuthStepException {
         final GetOperationDetailResponse operation = getOperation();
         logger.info("Step authentication started, operation ID: {}, authentication method: {}", operation.getOperationId(), getAuthMethodName().toString());
-        checkOperationExpiration(operation);
         if (getConsentSkippedFromHttpSession()) {
             // Consent form is skipped, step authentication is complete
             logger.info("Step authentication succeeded, operation ID: {}, authentication method: {}", operation.getOperationId(), getAuthMethodName().toString());
@@ -186,7 +185,6 @@ public class ConsentController extends AuthMethodController<ConsentAuthRequest, 
     public ConsentInitResponse initConsentForm() throws AuthStepException {
         final GetOperationDetailResponse operation = getOperation();
         logger.info("Init step started, operation ID: {}, authentication method: {}", operation.getOperationId(), getAuthMethodName().toString());
-        checkOperationExpiration(operation);
 
         ConsentInitResponse initResponse = new ConsentInitResponse();
 

--- a/powerauth-webflow-authentication-form/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/form/controller/FormLoginController.java
+++ b/powerauth-webflow-authentication-form/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/form/controller/FormLoginController.java
@@ -116,7 +116,6 @@ public class FormLoginController extends AuthMethodController<UsernamePasswordAu
     protected AuthenticationResult authenticate(UsernamePasswordAuthRequest request) throws AuthStepException {
         GetOperationDetailResponse operation = getOperation();
         logger.info("Step authentication started, operation ID: {}, authentication method: {}", operation.getOperationId(), getAuthMethodName().toString());
-        checkOperationExpiration(operation);
 
         try {
             FormData formData = new FormDataConverter().fromOperationFormData(operation.getFormData());
@@ -343,7 +342,6 @@ public class FormLoginController extends AuthMethodController<UsernamePasswordAu
         }
         final GetOperationDetailResponse operation = getOperation();
         logger.info("Init step started, operation ID: {}, authentication method: {}", operation.getOperationId(), getAuthMethodName().toString());
-        checkOperationExpiration(operation);
         final UsernamePasswordInitResponse response = new UsernamePasswordInitResponse();
         try {
             ObjectResponse<GetOrganizationListResponse> nsObjectResponse = nextStepClient.getOrganizationList();

--- a/powerauth-webflow-authentication-init/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/init/controller/ApiController.java
+++ b/powerauth-webflow-authentication-init/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/init/controller/ApiController.java
@@ -84,7 +84,6 @@ public class ApiController extends AuthMethodController<InitOperationRequest, In
         try {
             operation = getOperation();
             logger.info("Operation found, operation ID: {}, operation name: {}", operation.getOperationId(), operation.getOperationName());
-            checkOperationExpiration(operation);
         } catch (OperationNotAvailableException ex) {
             logger.info("Operation not found");
             // Operation is not available - this state is valid in INIT authentication method, operation was not initialized yet

--- a/powerauth-webflow-authentication-init/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/init/controller/TimeoutController.java
+++ b/powerauth-webflow-authentication-init/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/init/controller/TimeoutController.java
@@ -65,7 +65,6 @@ public class TimeoutController extends AuthMethodController<VerifyTimeoutRequest
         }
         final GetOperationDetailResponse operation = getOperation();
         logger.debug("Verify timeout started, operation: {}", operation.getOperationId());
-        checkOperationExpiration(operation);
         final VerifyTimeoutResponse response = new VerifyTimeoutResponse();
 
         response.setTimeoutDelayMs(timeoutService.getTimeoutDelay(operation));

--- a/powerauth-webflow-authentication-login-sca/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/loginsca/controller/LoginScaController.java
+++ b/powerauth-webflow-authentication-login-sca/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/loginsca/controller/LoginScaController.java
@@ -107,7 +107,6 @@ public class LoginScaController extends AuthMethodController<LoginScaAuthRequest
     public LoginScaAuthResponse authenticateScaLogin(@RequestBody LoginScaAuthRequest request) throws AuthStepException, NextStepServiceException {
         GetOperationDetailResponse operation = getOperation();
         logger.info("Step authentication started, operation ID: {}, authentication method: {}", operation.getOperationId(), getAuthMethodName().toString());
-        checkOperationExpiration(operation);
         try {
             FormData formData = new FormDataConverter().fromOperationFormData(operation.getFormData());
             ApplicationContext applicationContext = operation.getApplicationContext();

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileAppApiController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileAppApiController.java
@@ -232,9 +232,6 @@ public class MobileAppApiController extends AuthMethodController<MobileTokenAuth
 
             final GetOperationDetailResponse operation = getOperation(operationId);
 
-            // Check for expired operation
-            checkOperationExpiration(operation);
-
             // Check if signature type is allowed
             if (!isSignatureTypeAllowedForOperation(operation.getOperationName(), apiAuthentication.getSignatureFactors())) {
                 throw new PowerAuthAuthenticationException();

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOfflineController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOfflineController.java
@@ -128,7 +128,6 @@ public class MobileTokenOfflineController extends AuthMethodController<QrCodeAut
         final String operationName = operation.getOperationName();
         final AuthMethod authMethod = getAuthMethodName(operation);
         logger.info("Step authentication started, operation ID: {}, authentication method: {}", operation.getOperationId(), authMethod.toString());
-        checkOperationExpiration(operation);
         // nonce is received from the UI - it was stored together with the QR code
         String nonce = request.getNonce();
         // data for signature is {OPERATION_ID}&{OPERATION_DATA}
@@ -193,7 +192,6 @@ public class MobileTokenOfflineController extends AuthMethodController<QrCodeAut
         final GetOperationDetailResponse operation = getOperation();
         final AuthMethod authMethod = getAuthMethodName();
         logger.info("Init step started, operation ID: {}, authentication method: {}", operation.getOperationId(), authMethod.toString());
-        checkOperationExpiration(operation);
 
         String userId = operation.getUserId();
 
@@ -255,7 +253,6 @@ public class MobileTokenOfflineController extends AuthMethodController<QrCodeAut
         GetOperationDetailResponse operation = getOperation();
         AuthMethod authMethod = getAuthMethodName(operation);
         try {
-            checkOperationExpiration(operation);
             return buildAuthorizationResponse(request, new AuthResponseProvider() {
 
                 @Override
@@ -354,7 +351,6 @@ public class MobileTokenOfflineController extends AuthMethodController<QrCodeAut
             throw new OfflineModeDisabledException("Offline mode is disabled");
         }
         GetOperationDetailResponse operation = getOperation();
-        checkOperationExpiration(operation);
         String operationId = operation.getOperationId();
         String operationData = operation.getOperationData();
         String operationName = operation.getOperationName();

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOnlineController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOnlineController.java
@@ -150,7 +150,7 @@ public class MobileTokenOnlineController extends AuthMethodController<MobileToke
         // Log level is set to FINE due to large amount of requests caused by polling.
         logger.debug("Step authentication started, operation ID: {}, authentication method: {}", operation.getOperationId(), authMethod.toString());
         if (operation.isExpired()) {
-            logger.info("Operation has timed out, operation ID: {}", operation);
+            logger.info("Operation has timed out, operation ID: {}", operation.getOperationId());
             // Handle operation expiration
             try {
                 cancelAuthorization(operation.getOperationId(), operation.getUserId(), OperationCancelReason.TIMED_OUT_OPERATION, null);

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/errorhandling/MobileApiExceptionResolver.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/errorhandling/MobileApiExceptionResolver.java
@@ -18,11 +18,7 @@ package io.getlime.security.powerauth.lib.webflow.authentication.mtoken.errorhan
 import io.getlime.core.rest.model.base.entity.Error;
 import io.getlime.core.rest.model.base.response.ErrorResponse;
 import io.getlime.security.powerauth.lib.mtoken.model.enumeration.ErrorCode;
-import io.getlime.security.powerauth.lib.nextstep.model.exception.OperationAlreadyCanceledException;
-import io.getlime.security.powerauth.lib.nextstep.model.exception.OperationAlreadyFailedException;
-import io.getlime.security.powerauth.lib.nextstep.model.exception.OperationAlreadyFinishedException;
-import io.getlime.security.powerauth.lib.webflow.authentication.exception.AuthStepException;
-import io.getlime.security.powerauth.lib.webflow.authentication.exception.OperationTimeoutException;
+import io.getlime.security.powerauth.lib.webflow.authentication.exception.*;
 import io.getlime.security.powerauth.lib.webflow.authentication.mtoken.errorhandling.exception.*;
 import io.getlime.security.powerauth.rest.api.base.exception.PowerAuthAuthenticationException;
 import org.slf4j.Logger;
@@ -132,7 +128,7 @@ public class MobileApiExceptionResolver {
      * @param t Throwable.
      * @return Response with error details.
      */
-    @ExceptionHandler(OperationAlreadyFinishedException.class)
+    @ExceptionHandler(OperationIsAlreadyFinished.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public @ResponseBody ErrorResponse handleOperationAlreadyFinishedException(Throwable t) {
         return error(ErrorCode.OPERATION_ALREADY_FINISHED, t);
@@ -143,7 +139,7 @@ public class MobileApiExceptionResolver {
      * @param t Throwable.
      * @return Response with error details.
      */
-    @ExceptionHandler(OperationAlreadyFailedException.class)
+    @ExceptionHandler(OperationIsAlreadyFailedException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public @ResponseBody ErrorResponse handleOperationAlreadyFailedException(Throwable t) {
         return error(ErrorCode.OPERATION_ALREADY_FAILED, t);
@@ -154,7 +150,7 @@ public class MobileApiExceptionResolver {
      * @param t Throwable.
      * @return Response with error details.
      */
-    @ExceptionHandler(OperationAlreadyCanceledException.class)
+    @ExceptionHandler(OperationIsAlreadyCanceledException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public @ResponseBody ErrorResponse handleOperationCanceledException(Throwable t) {
         return error(ErrorCode.OPERATION_ALREADY_CANCELED, t);

--- a/powerauth-webflow-authentication-operation-review/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/operation/controller/OperationReviewController.java
+++ b/powerauth-webflow-authentication-operation-review/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/operation/controller/OperationReviewController.java
@@ -98,7 +98,6 @@ public class OperationReviewController extends AuthMethodController<OperationRev
     protected AuthenticationResult authenticate(OperationReviewRequest request) throws AuthStepException {
         final GetOperationDetailResponse operation = getOperation();
         logger.info("Step authentication started, operation ID: {}, authentication method: {}", operation.getOperationId(), getAuthMethodName().toString());
-        checkOperationExpiration(operation);
         //TODO: Check pre-authenticated user here
         logger.info("Step authentication succeeded, operation ID: {}, authentication method: {}", operation.getOperationId(), getAuthMethodName().toString());
         return new AuthenticationResult(operation.getUserId(), operation.getOrganizationId());
@@ -122,7 +121,6 @@ public class OperationReviewController extends AuthMethodController<OperationRev
     @RequestMapping(value = "/detail", method = RequestMethod.POST)
     public @ResponseBody OperationReviewDetailResponse getOperationDetails(@RequestBody OperationDetailRequest request) throws AuthStepException {
         final GetOperationDetailResponse operation = getOperation();
-        checkOperationExpiration(operation);
         OperationReviewDetailResponse response = new OperationReviewDetailResponse();
         response.setData(operation.getOperationData());
         response.setFormData(decorateFormData(operation));
@@ -238,7 +236,6 @@ public class OperationReviewController extends AuthMethodController<OperationRev
 
     private Response updateFormDataImpl(UpdateOperationFormDataRequest request) throws NextStepServiceException, DataAdapterClientErrorException, AuthStepException {
         final GetOperationDetailResponse operation = getOperation();
-        checkOperationExpiration(operation);
         // update formData in Next Step server
         nextStepClient.updateOperationFormData(operation.getOperationId(), request.getFormData());
         // Send notification to Data Adapter if the bank account has changed.
@@ -281,7 +278,6 @@ public class OperationReviewController extends AuthMethodController<OperationRev
 
     private Response updateChosenAuthenticationMethodImpl(UpdateOperationChosenAuthMethodRequest request) throws NextStepServiceException, AuthStepException {
         final GetOperationDetailResponse operation = getOperation();
-        checkOperationExpiration(operation);
         // update chosenAuthMethod in Next Step server
         nextStepClient.updateChosenAuthMethod(operation.getOperationId(), request.getChosenAuthMethod());
         return new Response();

--- a/powerauth-webflow-authentication-sms/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/sms/controller/SmsAuthorizationController.java
+++ b/powerauth-webflow-authentication-sms/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/sms/controller/SmsAuthorizationController.java
@@ -111,7 +111,6 @@ public class SmsAuthorizationController extends AuthMethodController<SmsAuthoriz
         final GetOperationDetailResponse operation = getOperation();
         final AuthMethod authMethod = getAuthMethodName(operation);
         logger.info("Step authentication started, operation ID: {}, authentication method: {}", operation.getOperationId(), authMethod.toString());
-        checkOperationExpiration(operation);
         final String messageId = getMessageIdFromHttpSession();
         try {
             FormData formData = new FormDataConverter().fromOperationFormData(operation.getFormData());
@@ -334,7 +333,6 @@ public class SmsAuthorizationController extends AuthMethodController<SmsAuthoriz
         final GetOperationDetailResponse operation = getOperation();
         final AuthMethod authMethod = getAuthMethodName(operation);
         logger.info("Init step started, operation ID: {}, authentication method: {}", operation.getOperationId(), authMethod.toString());
-        checkOperationExpiration(operation);
         InitSmsAuthorizationResponse initResponse = new InitSmsAuthorizationResponse();
 
         // By default enable both SMS authorization and password verification (2FA)
@@ -422,7 +420,6 @@ public class SmsAuthorizationController extends AuthMethodController<SmsAuthoriz
         final GetOperationDetailResponse operation = getOperation();
         final AuthMethod authMethod = getAuthMethodName(operation);
         logger.info("Resend step started, operation ID: {}, authentication method: {}", operation.getOperationId(), authMethod.toString());
-        checkOperationExpiration(operation);
         ResendSmsAuthorizationResponse resendResponse = new ResendSmsAuthorizationResponse();
         resendResponse.setResendDelay(configuration.getSmsResendDelay());
         try {

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/controller/AuthMethodController.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/controller/AuthMethodController.java
@@ -311,7 +311,6 @@ public abstract class AuthMethodController<T extends AuthStepRequest, R extends 
      * @throws AuthStepException In case authorization fails.
      */
     protected UpdateOperationResponse failAuthorization(String operationId, String userId, List<AuthInstrument> authInstruments, List<KeyValueParameter> params) throws NextStepServiceException, AuthStepException {
-        // validate operation before requesting update
         GetOperationDetailResponse operation = getOperation(operationId, false);
         AuthMethod authMethod = getAuthMethodName(operation);
         logger.info("Fail step started, operation ID: {}, user ID: {}, authentication method: {}", operationId, userId, authMethod.toString());
@@ -344,7 +343,6 @@ public abstract class AuthMethodController<T extends AuthStepRequest, R extends 
      * @throws AuthStepException In case authorization fails.
      */
     protected UpdateOperationResponse cancelAuthorization(String operationId, String userId, OperationCancelReason cancelReason, List<KeyValueParameter> params) throws NextStepServiceException, AuthStepException {
-        // validate operation before requesting update
         GetOperationDetailResponse operation = getOperation(operationId, false);
         AuthMethod authMethod = getAuthMethodName(operation);
         logger.info("Step cancel started, operation ID: {}, authentication method: {}", operationId, authMethod.toString());

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/controller/AuthMethodController.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/controller/AuthMethodController.java
@@ -126,7 +126,7 @@ public abstract class AuthMethodController<T extends AuthStepRequest, R extends 
      * @throws AuthStepException Thrown when operation could not be retrieved or it is not available.
      */
     protected GetOperationDetailResponse getOperation(String operationId) throws AuthStepException {
-        return getOperation(operationId, false);
+        return getOperation(operationId, true);
     }
 
     /**
@@ -312,7 +312,7 @@ public abstract class AuthMethodController<T extends AuthStepRequest, R extends 
      */
     protected UpdateOperationResponse failAuthorization(String operationId, String userId, List<AuthInstrument> authInstruments, List<KeyValueParameter> params) throws NextStepServiceException, AuthStepException {
         // validate operation before requesting update
-        GetOperationDetailResponse operation = getOperation(operationId);
+        GetOperationDetailResponse operation = getOperation(operationId, false);
         AuthMethod authMethod = getAuthMethodName(operation);
         logger.info("Fail step started, operation ID: {}, user ID: {}, authentication method: {}", operationId, userId, authMethod.toString());
         ApplicationContext applicationContext = operation.getApplicationContext();
@@ -345,7 +345,7 @@ public abstract class AuthMethodController<T extends AuthStepRequest, R extends 
      */
     protected UpdateOperationResponse cancelAuthorization(String operationId, String userId, OperationCancelReason cancelReason, List<KeyValueParameter> params) throws NextStepServiceException, AuthStepException {
         // validate operation before requesting update
-        GetOperationDetailResponse operation = getOperation(operationId);
+        GetOperationDetailResponse operation = getOperation(operationId, false);
         AuthMethod authMethod = getAuthMethodName(operation);
         logger.info("Step cancel started, operation ID: {}, authentication method: {}", operationId, authMethod.toString());
         ApplicationContext applicationContext = operation.getApplicationContext();

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/controller/AuthMethodController.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/controller/AuthMethodController.java
@@ -132,15 +132,15 @@ public abstract class AuthMethodController<T extends AuthStepRequest, R extends 
     /**
      * Get operation detail with given operation ID.
      * @param operationId Operation ID.
-     * @param validateOperationSate Whether operation state should be validated.
+     * @param validateOperationState Whether operation state should be validated.
      * @return Operation detail.
      * @throws AuthStepException Thrown when operation could not be retrieved or it is not available.
      */
-    protected GetOperationDetailResponse getOperation(String operationId, boolean validateOperationSate) throws AuthStepException {
+    protected GetOperationDetailResponse getOperation(String operationId, boolean validateOperationState) throws AuthStepException {
         try {
             final ObjectResponse<GetOperationDetailResponse> operationDetail = nextStepClient.getOperationDetail(operationId);
             final GetOperationDetailResponse operation = operationDetail.getResponseObject();
-            if (validateOperationSate) {
+            if (validateOperationState) {
                 validateOperationState(operation);
             }
             filterStepsBasedOnActiveAuthMethods(operation.getSteps(), operation.getUserId(), operationId);

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/controller/AuthMethodController.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/controller/AuthMethodController.java
@@ -120,7 +120,7 @@ public abstract class AuthMethodController<T extends AuthStepRequest, R extends 
     }
 
     /**
-     * Get operation detail.
+     * Get operation detail with given operation ID.
      * @param operationId Operation ID.
      * @return Operation detail.
      * @throws AuthStepException Thrown when operation could not be retrieved or it is not available.

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/exception/OperationIsAlreadyCanceledException.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/exception/OperationIsAlreadyCanceledException.java
@@ -17,19 +17,19 @@
 package io.getlime.security.powerauth.lib.webflow.authentication.exception;
 
 /**
- * Operation already failed exception.
+ * Operation already canceled exception.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */
-public class OperationAlreadyFailedException extends AuthStepException {
+public class OperationIsAlreadyCanceledException extends AuthStepException {
 
     /**
      * Constructor with message.
      *
      * @param message Error message.
      */
-    public OperationAlreadyFailedException(String message) {
-        super(message, "operation.alreadyFailed");
+    public OperationIsAlreadyCanceledException(String message) {
+        super(message, "operation.alreadyCanceled");
     }
 
 }

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/exception/OperationIsAlreadyFailedException.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/exception/OperationIsAlreadyFailedException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.lib.webflow.authentication.exception;
+
+/**
+ * Operation already failed exception.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class OperationIsAlreadyFailedException extends AuthStepException {
+
+    /**
+     * Constructor with message.
+     *
+     * @param message Error message.
+     */
+    public OperationIsAlreadyFailedException(String message) {
+        super(message, "operation.alreadyFailed");
+    }
+
+}

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/exception/OperationIsAlreadyFinished.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/exception/OperationIsAlreadyFinished.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getlime.security.powerauth.lib.webflow.authentication.exception;
+
+/**
+ * Operation already finished exception.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class OperationIsAlreadyFinished extends AuthStepException {
+
+    /**
+     * Constructor with message.
+     *
+     * @param message Error message.
+     */
+    public OperationIsAlreadyFinished(String message) {
+        super(message, "operation.alreadyFinished");
+    }
+
+}


### PR DESCRIPTION
This pull reques contains following changes:
- Verification of operation expiration is centralized and it is moved it into validation of operation state. The `checkOperationExpiration()` method is private now.
- Operation expiration is checked before other validations to provide a friendly message for Mobile Token when the operation is expired instead of providing error with message about already failed operation (caused by another API call which validated the state). This fixes first part of the reported issue.
- The exception resolver was using incorrect exceptions (same class name, different package). I fixed the exception handling and translation of Next Step exceptions to Web Flow. I also renamed the conflicting exception classes. This fixes the second part of the issue - invalid error code.
- It is possible to bypass operation state validation in case custom steps need to be performed for retrieved operation (e.g. cancellation push message is sent for the operation).