### PR TITLE
Fix #720: Not allowed to deserialize error

### DIFF
--- a/powerauth-webflow-resources/pom.xml
+++ b/powerauth-webflow-resources/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.springframework.security.oauth.boot</groupId>
             <artifactId>spring-security-oauth2-autoconfigure</artifactId>
-            <version>2.2.0.RELEASE</version>
+            <version>2.2.2.RELEASE</version>
             <exclusions>
                 <exclusion>
                     <artifactId>bcpkix-jdk15on</artifactId>


### PR DESCRIPTION
Spring OAuth introduced a deserialization error, the error is fixed in spring-security-oauth2 version `2.3.8`.