### PR TITLE
Fix #603: Optimize timeout API requests

### DIFF
--- a/powerauth-webflow/src/main/js/components/login.js
+++ b/powerauth-webflow/src/main/js/components/login.js
@@ -115,7 +115,7 @@ export default class Login extends React.Component {
         }
         return (
             <Panel>
-                {this.banners()}
+                {this.banners(true)}
                 {this.title()}
                 {this.loginForm(organizations[0].organizationId)}
             </Panel>
@@ -134,7 +134,7 @@ export default class Login extends React.Component {
                         return (
                             <Tab key={org.organizationId} eventKey={org.organizationId} title={formatMessage({id: org.displayNameKey})}>
                                 <Panel>
-                                    {this.banners()}
+                                    {this.banners(org.organizationId === this.props.context.chosenOrganizationId)}
                                     {this.title()}
                                     {this.loginForm(org.organizationId)}
                                 </Panel>
@@ -169,7 +169,7 @@ export default class Login extends React.Component {
                         intl={this.props.intl}
                         callback={organization => this.organizationChanged(organization.organizationId)}
                     />
-                    {this.banners()}
+                    {this.banners(true)}
                     {this.title()}
                     {this.loginForm(chosenOrganizationId)}
                 </Panel>
@@ -192,9 +192,9 @@ export default class Login extends React.Component {
         this.props.dispatch(selectOrganization(organizationId));
     }
 
-    banners() {
+    banners(timeoutCheckActive) {
         return (
-            <OperationTimeout/>
+            <OperationTimeout timeoutCheckActive={timeoutCheckActive}/>
         )
     }
 

--- a/powerauth-webflow/src/main/js/components/loginSca.js
+++ b/powerauth-webflow/src/main/js/components/loginSca.js
@@ -108,7 +108,7 @@ export default class LoginSca extends React.Component {
         }
         return (
             <Panel>
-                {this.banners()}
+                {this.banners(true)}
                 {this.title()}
                 {this.loginForm(organizations[0].organizationId)}
             </Panel>
@@ -127,7 +127,7 @@ export default class LoginSca extends React.Component {
                         return (
                             <Tab key={org.organizationId} eventKey={org.organizationId} title={formatMessage({id: org.displayNameKey})}>
                                 <Panel>
-                                    {this.banners()}
+                                    {this.banners(org.organizationId === this.props.context.chosenOrganizationId)}
                                     {this.title()}
                                     {this.loginForm(org.organizationId)}
                                 </Panel>
@@ -162,7 +162,7 @@ export default class LoginSca extends React.Component {
                         intl={this.props.intl}
                         callback={organization => this.organizationChanged(organization.organizationId)}
                     />
-                    {this.banners()}
+                    {this.banners(true)}
                     {this.title()}
                     {this.loginForm(chosenOrganizationId)}
                 </Panel>
@@ -185,9 +185,9 @@ export default class LoginSca extends React.Component {
         this.props.dispatch(selectOrganization(organizationId));
     }
 
-    banners() {
+    banners(timeoutCheckActive) {
         return (
-            <OperationTimeout/>
+            <OperationTimeout timeoutCheckActive={timeoutCheckActive}/>
         )
     }
 

--- a/powerauth-webflow/src/main/js/components/operationTimeout.js
+++ b/powerauth-webflow/src/main/js/components/operationTimeout.js
@@ -44,7 +44,7 @@ export default class OperationTimeout extends React.Component {
 
     componentWillReceiveProps(props) {
         if (!this.props.timeoutCheckActive && props.timeoutCheckActive) {
-            // Timeout check has just been activated e.g. by switching active organization
+            // Timeout check has just been activated e.g. by switching the active organization
             if (this.state.timeoutCheckScheduled) {
                 // Timeout check is already scheduled, just enable it
                 this.setState({timeoutCheckEnabled: true});
@@ -55,11 +55,11 @@ export default class OperationTimeout extends React.Component {
             return;
         }
         if (this.props.timeoutCheckActive && !props.timeoutCheckActive) {
-            // Timeout check has just been deactivated e.g. by switching active organization
+            // Timeout check has just been deactivated e.g. by switching the active organization
             this.setState({timeoutCheckEnabled: false});
             return;
         }
-        if (props.timeout) {
+        if (props.timeoutCheckActive && props.timeout) {
             if (!this.state.timeoutCheckScheduled && props.timeout.timeoutCheckEnabled && props.timeout.timeoutDelayMs > 0) {
                 this.setState({timeoutCheckEnabled: true, timeoutCheckScheduled: true});
                 let nextVerificationMs = props.timeout.timeoutDelayMs;


### PR DESCRIPTION
This pull request resolves the issue with `<OperationTimeout/>` component present in multiple tabs when multiple organizations are used. Only one `<OperationTimeout>` component is active depending on the active organization. The issue manifested by duplicate timeout requests as well as 500 error when updating operation state.