### PR TITLE
Fix #596: Consent screen should allow longer consent texts

### DIFF
--- a/powerauth-webflow-client/src/main/resources/static/css/main.css
+++ b/powerauth-webflow-client/src/main/resources/static/css/main.css
@@ -197,6 +197,6 @@ a {
     float: left;
 }
 
-.auhtorized {
+.authorized {
     padding: 50px 0;
 }

--- a/powerauth-webflow-client/src/main/resources/templates/home.html
+++ b/powerauth-webflow-client/src/main/resources/templates/home.html
@@ -38,7 +38,7 @@
                 <img class="logo" src="./images/logo.png" alt="logo"/>
             </p>
             <div th:each="providerId : ${providerIds}" class="operations">
-                <div class="auhtorized" th:if="${!#lists.isEmpty(connectionMap[__${providerId}__])}">
+                <div class="authorized" th:if="${!#lists.isEmpty(connectionMap[__${providerId}__])}">
                     <p>
                         Operation authorized by <span class="tint"><span
                             th:text="${connectionMap[__${providerId}__][0].displayName}">user display name</span></span>!

--- a/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/configuration/WebFlowServerConfiguration.java
+++ b/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/configuration/WebFlowServerConfiguration.java
@@ -81,10 +81,16 @@ public class WebFlowServerConfiguration {
     private boolean afsEnabled;
 
     /**
+     * Whether limit for large consent panel is enabled.
+     */
+    @Value("${powerauth.webflow.consent.limit.enabled:false}")
+    private boolean consentPanelLimitEnabled;
+
+    /**
      * Configuration of limit for large consent panel in number of characters.
      */
-    @Value("${powerauth.webflow.consent.large.limit:750}")
-    private int limitLargeConsentPanel;
+    @Value("${powerauth.webflow.consent.limit.characters:750}")
+    private int consentPanelLimitCharacters;
 
     /**
      * Get custom external stylesheet URL.
@@ -154,10 +160,18 @@ public class WebFlowServerConfiguration {
     }
 
     /**
+     * Get whether limit for large consent panel is enabled.
+     * @return Whether limit for large consent panel is enabled.
+     */
+    public boolean isConsentPanelLimitEnabled() {
+        return consentPanelLimitEnabled;
+    }
+
+    /**
      * Get limit of characters for displaying large consent panel.
      * @return Limit of characters for displaying large consent panel.
      */
-    public int getLimitLargeConsentPanel() {
-        return limitLargeConsentPanel;
+    public int getConsentPanelLimitCharacters() {
+        return consentPanelLimitCharacters;
     }
 }

--- a/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/configuration/WebFlowServerConfiguration.java
+++ b/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/configuration/WebFlowServerConfiguration.java
@@ -81,6 +81,12 @@ public class WebFlowServerConfiguration {
     private boolean afsEnabled;
 
     /**
+     * Configuration of limit for large consent panel in number of characters.
+     */
+    @Value("${powerauth.webflow.consent.large.limit:750}")
+    private int limitLargeConsentPanel;
+
+    /**
      * Get custom external stylesheet URL.
      *
      * @return External stylesheet URL.
@@ -145,5 +151,13 @@ public class WebFlowServerConfiguration {
      */
     public boolean isAfsEnabled() {
         return afsEnabled;
+    }
+
+    /**
+     * Get limit of characters for displaying large consent panel.
+     * @return Limit of characters for displaying large consent panel.
+     */
+    public int getLimitLargeConsentPanel() {
+        return limitLargeConsentPanel;
     }
 }

--- a/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/controller/HomeController.java
+++ b/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/controller/HomeController.java
@@ -165,7 +165,8 @@ public class HomeController {
         model.putIfAbsent("afs_js_snippet_url", "");
 
         model.put("title", webFlowConfig.getPageTitle());
-        model.put("limitLargeConsentPanel", webFlowConfig.getLimitLargeConsentPanel());
+        model.put("consentPanelLimitEnabled", webFlowConfig.isConsentPanelLimitEnabled());
+        model.put("consentPanelLimitCharacters", webFlowConfig.getConsentPanelLimitCharacters());
         model.put("stylesheet", webFlowConfig.getCustomStyleSheetUrl());
         model.put("lang", LocaleContextHolder.getLocale().getLanguage());
         // JSON objects with i18n messages are inserted into the model to provide localization for the frontend

--- a/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/controller/HomeController.java
+++ b/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/controller/HomeController.java
@@ -165,6 +165,7 @@ public class HomeController {
         model.putIfAbsent("afs_js_snippet_url", "");
 
         model.put("title", webFlowConfig.getPageTitle());
+        model.put("limitLargeConsentPanel", webFlowConfig.getLimitLargeConsentPanel());
         model.put("stylesheet", webFlowConfig.getCustomStyleSheetUrl());
         model.put("lang", LocaleContextHolder.getLocale().getLanguage());
         // JSON objects with i18n messages are inserted into the model to provide localization for the frontend

--- a/powerauth-webflow/src/main/js/actions/consentActions.js
+++ b/powerauth-webflow/src/main/js/actions/consentActions.js
@@ -65,7 +65,7 @@ export function init() {
  * Perform SMS authentication.
  * @returns {Function} No return value.
  */
-export function authenticate(options) {
+export function authenticate(options, callback) {
     return function (dispatch) {
         axios.post("./api/auth/consent/authenticate", {
             options
@@ -76,10 +76,12 @@ export function authenticate(options) {
         }).then((response) => {
             switch (response.data.result) {
                 case 'CONFIRMED': {
+                    callback();
                     dispatchAction(dispatch, response);
                     break;
                 }
                 case 'CANCELED': {
+                    callback();
                     dispatch({
                         type: "SHOW_SCREEN_ERROR",
                         payload: {
@@ -117,13 +119,14 @@ export function authenticate(options) {
  * Cancel operation.
  * @returns {Function} No return value.
  */
-export function cancel() {
+export function cancel(callback) {
     return function (dispatch) {
         axios.post("./api/auth/consent/cancel", {}, {
             headers: {
                 'X-OPERATION-HASH': operationHash,
             }
         }).then((response) => {
+            callback();
             dispatch({
                 type: "SHOW_SCREEN_ERROR",
                 payload: {

--- a/powerauth-webflow/src/main/js/components/app.js
+++ b/powerauth-webflow/src/main/js/components/app.js
@@ -113,7 +113,7 @@ export class App extends React.Component {
                     )}
                 </div>
                 <div className="row">
-                    <div className="col-xs-12 col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-3 col-lg-6 col-lg-offset-3">
+                    <div id="main-panel" className="col-xs-12 col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-3 col-lg-6 col-lg-offset-3">
                         <div id="home" className="text-center">
                             <div id="logo"/>
                             <Component intl={this.props.intl}/>

--- a/powerauth-webflow/src/main/js/components/consent.js
+++ b/powerauth-webflow/src/main/js/components/consent.js
@@ -50,7 +50,8 @@ export default class Consent extends React.Component {
             consentHtml: null,
             options: null,
             validationErrorMessage: null,
-            optionValidationErrors: new Map()
+            optionValidationErrors: new Map(),
+            largePanelDisplayed: false
         };
     }
 
@@ -128,11 +129,14 @@ export default class Consent extends React.Component {
     enableLargePanel() {
         document.getElementById("main-panel").classList.remove("col-sm-8", "col-sm-offset-2", "col-md-6", "col-md-offset-3", "col-lg-6", "col-lg-offset-3");
         document.getElementById("main-panel").classList.add("col-sm-12", "col-md-12", "col-lg-12");
+        this.setState({largePanelDisplayed: true});
     }
 
     disableLargePanel() {
-        document.getElementById("main-panel").classList.remove("col-sm-12", "col-md-12", "col-lg-12");
-        document.getElementById("main-panel").classList.add("col-sm-8", "col-sm-offset-2", "col-md-6", "col-md-offset-3", "col-lg-6", "col-lg-offset-3");
+        if (this.state.largePanelDisplayed) {
+            document.getElementById("main-panel").classList.remove("col-sm-12", "col-md-12", "col-lg-12");
+            document.getElementById("main-panel").classList.add("col-sm-8", "col-sm-offset-2", "col-md-6", "col-md-offset-3", "col-lg-6", "col-lg-offset-3");
+        }
     }
 
     handleCheckboxChange(event) {

--- a/powerauth-webflow/src/main/js/components/consent.js
+++ b/powerauth-webflow/src/main/js/components/consent.js
@@ -38,6 +38,9 @@ export default class Consent extends React.Component {
     constructor() {
         super();
         this.init = this.init.bind(this);
+        this.handleLargeConsent = this.handleLargeConsent.bind(this);
+        this.enableLargePanel = this.enableLargePanel.bind(this);
+        this.disableLargePanel = this.disableLargePanel.bind(this);
         this.handleCheckboxChange = this.handleCheckboxChange.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
         this.handleCancel = this.handleCancel.bind(this);
@@ -65,8 +68,11 @@ export default class Consent extends React.Component {
 
     initConsent(props) {
         // Store consent HTML in local state, switching language or refresh will receive new consent HTML
+        const handleLargeConsent = this.handleLargeConsent;
         if (props.context.consentHtml) {
-            this.setState({consentHtml: props.context.consentHtml});
+            this.setState({consentHtml: props.context.consentHtml}, function () {
+                handleLargeConsent(props.context.consentHtml);
+            });
         }
         if (props.context.options) {
             // Update default values in context when options are received for the first time
@@ -113,6 +119,22 @@ export default class Consent extends React.Component {
         }
     }
 
+    handleLargeConsent(consentHtml) {
+        if (consentHtml && consentHtml.length > limitLargeConsentPanel) {
+            this.enableLargePanel();
+        }
+    }
+
+    enableLargePanel() {
+        document.getElementById("main-panel").classList.remove("col-sm-8", "col-sm-offset-2", "col-md-6", "col-md-offset-3", "col-lg-6", "col-lg-offset-3");
+        document.getElementById("main-panel").classList.add("col-sm-12", "col-md-12", "col-lg-12");
+    }
+
+    disableLargePanel() {
+        document.getElementById("main-panel").classList.remove("col-sm-12", "col-md-12", "col-lg-12");
+        document.getElementById("main-panel").classList.add("col-sm-8", "col-sm-offset-2", "col-md-6", "col-md-offset-3", "col-lg-6", "col-lg-offset-3");
+    }
+
     handleCheckboxChange(event) {
         // Update map of checked checkboxes in context
         const optionId = event.target.id;
@@ -134,13 +156,19 @@ export default class Consent extends React.Component {
 
     handleSubmit(event) {
         event.preventDefault();
+        const disableLargePanel = this.disableLargePanel;
         // Local state stores up-to-date consent options state
-        this.props.dispatch(authenticate(this.state.options));
+        this.props.dispatch(authenticate(this.state.options, function() {
+            disableLargePanel();
+        }));
     }
 
     handleCancel(event) {
         event.preventDefault();
-        this.props.dispatch(cancel());
+        const disableLargePanel = this.disableLargePanel;
+        this.props.dispatch(cancel(function() {
+            disableLargePanel();
+        }));
     }
 
     createHtml(html) {

--- a/powerauth-webflow/src/main/js/components/consent.js
+++ b/powerauth-webflow/src/main/js/components/consent.js
@@ -121,7 +121,7 @@ export default class Consent extends React.Component {
     }
 
     handleLargeConsent(consentHtml) {
-        if (consentHtml && consentHtml.length > limitLargeConsentPanel) {
+        if (consentPanelLimitEnabled && consentHtml && consentHtml.length >= consentPanelLimitCharacters) {
             this.enableLargePanel();
         }
     }

--- a/powerauth-webflow/src/main/resources/application.properties
+++ b/powerauth-webflow/src/main/resources/application.properties
@@ -72,7 +72,8 @@ powerauth.webflow.sms.resend.delayMs=60000
 powerauth.webflow.timeout.warning.delayMs=60000
 
 # Configuration of Limit for Large Consent Panel in Number of Characters
-powerauth.webflow.consent.large.limit=750
+powerauth.webflow.consent.limit.enabled=false
+powerauth.webflow.consent.limit.characters=750
 
 # Anti-fraud system configuration
 powerauth.webflow.afs.enabled=false

--- a/powerauth-webflow/src/main/resources/application.properties
+++ b/powerauth-webflow/src/main/resources/application.properties
@@ -71,6 +71,9 @@ powerauth.webflow.sms.resend.delayMs=60000
 # Configuration of Delay for Showing Operation Timeout Warning in Milliseconds
 powerauth.webflow.timeout.warning.delayMs=60000
 
+# Configuration of Limit for Large Consent Panel in Number of Characters
+powerauth.webflow.consent.large.limit=750
+
 # Anti-fraud system configuration
 powerauth.webflow.afs.enabled=false
 powerauth.webflow.afs.type=THREAT_MARK

--- a/powerauth-webflow/src/main/resources/templates/index.html
+++ b/powerauth-webflow/src/main/resources/templates/index.html
@@ -28,7 +28,8 @@
 
     var operationHash = [[${operationHash}]];
     var showAndroidSecurityWarning = [[${showAndroidSecurityWarning}]];
-    var limitLargeConsentPanel = [[${limitLargeConsentPanel}]];
+    var consentPanelLimitEnabled = [[${consentPanelLimitEnabled}]];
+    var consentPanelLimitCharacters = [[${consentPanelLimitCharacters}]];
     window.onbeforeunload = function() {
         // Modern browsers do not allow custom messages, so text will be only shown in old browsers.
         // Note that the onbeforeunload dialog does not appear in case user does no action, see:

--- a/powerauth-webflow/src/main/resources/templates/index.html
+++ b/powerauth-webflow/src/main/resources/templates/index.html
@@ -28,6 +28,7 @@
 
     var operationHash = [[${operationHash}]];
     var showAndroidSecurityWarning = [[${showAndroidSecurityWarning}]];
+    var limitLargeConsentPanel = [[${limitLargeConsentPanel}]];
     window.onbeforeunload = function() {
         // Modern browsers do not allow custom messages, so text will be only shown in old browsers.
         // Note that the onbeforeunload dialog does not appear in case user does no action, see:


### PR DESCRIPTION
When the consent HTML has more than configured number of characters a wide consent panel is displayed to allow better display of large consent texts.