### PR TITLE
Fix #758: Improve cancellation of OAuth request redirect

### DIFF
--- a/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/controller/HomeController.java
+++ b/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/controller/HomeController.java
@@ -31,6 +31,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.security.oauth2.provider.ClientDetails;
+import org.springframework.security.oauth2.provider.ClientDetailsService;
+import org.springframework.security.oauth2.provider.ClientRegistrationException;
 import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
 import org.springframework.security.web.savedrequest.SavedRequest;
 import org.springframework.stereotype.Controller;
@@ -44,6 +47,7 @@ import javax.servlet.http.HttpSession;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Simple controller, redirects to the main HTML page with JavaScript content.
@@ -62,6 +66,7 @@ public class HomeController {
     private final NextStepClient nextStepClient;
     private final AfsConfigRepository afsConfigRepository;
     private final HttpSession httpSession;
+    private final ClientDetailsService clientDetailsService;
 
     /**
      * Initialization of the HomeController with application configuration.
@@ -72,9 +77,10 @@ public class HomeController {
      * @param nextStepClient Next step client.
      * @param afsConfigRepository Anti-fraud system configuration repository.
      * @param httpSession HTTP session.
+     * @param clientDetailsService Client details service for accessing OAuth 2.0 client data.
      */
     @Autowired
-    public HomeController(AuthenticationManagementService authenticationManagementService, WebFlowServerConfiguration webFlowConfig, I18NService i18nService, OperationSessionService operationSessionService, NextStepClient nextStepClient, AfsConfigRepository afsConfigRepository, HttpSession httpSession) {
+    public HomeController(AuthenticationManagementService authenticationManagementService, WebFlowServerConfiguration webFlowConfig, I18NService i18nService, OperationSessionService operationSessionService, NextStepClient nextStepClient, AfsConfigRepository afsConfigRepository, HttpSession httpSession, ClientDetailsService clientDetailsService) {
         this.webFlowConfig = webFlowConfig;
         this.authenticationManagementService = authenticationManagementService;
         this.i18nService = i18nService;
@@ -82,6 +88,7 @@ public class HomeController {
         this.nextStepClient = nextStepClient;
         this.afsConfigRepository = afsConfigRepository;
         this.httpSession = httpSession;
+        this.clientDetailsService = clientDetailsService;
     }
 
     /**
@@ -230,13 +237,61 @@ public class HomeController {
             return "redirect:/oauth/error";
         }
         String[] redirectUriParameter = savedRequest.getParameterMap().get("redirect_uri");
-        if (redirectUriParameter == null || redirectUriParameter.length != 1) {
+        if (redirectUriParameter == null) {
+            logger.error("Parameter redirect_uri is missing");
+            return "redirect:/oauth/error";
+        }
+        if (redirectUriParameter.length != 1) {
             logger.error("Multiple redirect_uri request parameters found");
             return "redirect:/oauth/error";
         }
         String redirectUri = redirectUriParameter[0];
 
-        // extract optional state parameter from original request
+        // Verify client_id against oauth_client_details database table
+        String[] clientIdParameter = savedRequest.getParameterMap().get("client_id");
+        if (clientIdParameter == null) {
+            logger.error("Parameter client_id is missing");
+            return "redirect:/oauth/error";
+        }
+        if (clientIdParameter.length != 1) {
+            logger.error("Multiple client_id request parameters found");
+            return "redirect:/oauth/error";
+        }
+
+        String clientId = clientIdParameter[0];
+
+        try {
+            ClientDetails clientDetails = clientDetailsService.loadClientByClientId(clientId);
+            Set<String> registeredRedirectUris = clientDetails.getRegisteredRedirectUri();
+
+            // Verify that redirect URI is registered for provided client ID
+            if (!registeredRedirectUris.contains(redirectUri)) {
+                logger.error("Redirect URI '{}' is not registered for client_id: {}", redirectUri, clientId);
+                return "redirect:/oauth/error";
+            }
+        } catch (ClientRegistrationException ex) {
+            logger.error("Client details not found for client_id: {}, error: {}", clientId, ex.getMessage());
+            return "redirect:/oauth/error";
+        }
+
+        // Verify response type, only 'code' is supported
+        String[] responseTypeParameter = savedRequest.getParameterMap().get("response_type");
+        if (responseTypeParameter == null) {
+            logger.error("Parameter response_type is missing");
+            return "redirect:/oauth/error";
+        }
+        if (responseTypeParameter.length != 1) {
+            logger.error("Multiple response_type request parameters found");
+            return "redirect:/oauth/error";
+        }
+
+        String responseType = responseTypeParameter[0];
+        if (!"code".equals(responseType)) {
+            logger.error("Invalid response type: {}", responseType);
+            return "redirect:/oauth/error";
+        }
+
+        // Extract optional state parameter from original request
         String[] stateParameter = savedRequest.getParameterMap().get("state");
         String state = null;
         if (stateParameter.length > 1) {
@@ -259,7 +314,7 @@ public class HomeController {
             uriBuilder.queryParam("state", state);
         }
 
-        // append error, error_description and state based on https://www.oauth.com/oauth2-servers/authorization/the-authorization-response
+        // Append error, error_description and state based on https://www.oauth.com/oauth2-servers/authorization/the-authorization-response
         final String redirectWithError = uriBuilder
                 .build()
                 .toUriString();


### PR DESCRIPTION
Please check improved verification of redirect parameters during request cancellation.

One question: should we also make `state` mandatory? It is optional in Spring OAuth.