### PR TITLE
Fix #769: Improve validation of operation against HTTP session ID

### DIFF
--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/WebSocketMessageService.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/WebSocketMessageService.java
@@ -93,7 +93,7 @@ public class WebSocketMessageService {
      * @param operationHash Operation hash.
      * @param webSocketSessionId Web Socket Session ID.
      * @param clientIpAddress Remote client IP address.
-     * @return Whether Whether Web Socket registration was successful.
+     * @return Whether Web Socket registration was successful.
      */
     public boolean registerWebSocketSession(String operationHash, String webSocketSessionId, String clientIpAddress) {
         return operationSessionService.registerWebSocketSession(operationHash, webSocketSessionId, clientIpAddress);


### PR DESCRIPTION
HTTP session ID is checked when operation is initialized or continued.

I also tightened the bolts during Web Socket registration, Web Socket session can be registered only once.