### PR TITLE
Fix #792: Hibernate connection charset

### DIFF
--- a/docs/Web-Flow-Configuration.md
+++ b/docs/Web-Flow-Configuration.md
@@ -42,9 +42,9 @@ spring.datasource.url=jdbc:mysql://localhost:3306/powerauth
 spring.datasource.username=powerauth
 spring.datasource.password=
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
-spring.jpa.properties.hibernate.connection.CharSet=utf8mb4
 spring.jpa.properties.hibernate.connection.characterEncoding=utf8
 spring.jpa.properties.hibernate.connection.useUnicode=true
+#spring.jpa.properties.hibernate.connection.CharSet=utf8mb4
 
 # Database Configuration - PostgreSQL
 #spring.datasource.url=jdbc:postgresql://localhost:5432/powerauth
@@ -139,9 +139,9 @@ spring.datasource.url=jdbc:mysql://localhost:3306/powerauth
 spring.datasource.username=powerauth
 spring.datasource.password=
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
-spring.jpa.properties.hibernate.connection.CharSet=utf8mb4
 spring.jpa.properties.hibernate.connection.characterEncoding=utf8
 spring.jpa.properties.hibernate.connection.useUnicode=true
+#spring.jpa.properties.hibernate.connection.CharSet=utf8mb4
 
 # Database Configuration - PostgreSQL
 #spring.datasource.url=jdbc:postgresql://localhost:5432/powerauth
@@ -183,9 +183,9 @@ spring.datasource.url=jdbc:mysql://localhost:3306/powerauth
 spring.datasource.username=powerauth
 spring.datasource.password=
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
-spring.jpa.properties.hibernate.connection.CharSet=utf8mb4
 spring.jpa.properties.hibernate.connection.characterEncoding=utf8
 spring.jpa.properties.hibernate.connection.useUnicode=true
+#spring.jpa.properties.hibernate.connection.CharSet=utf8mb4
 
 # Database Configuration - PostgreSQL
 #spring.datasource.url=jdbc:postgresql://localhost:5432/postgres

--- a/powerauth-nextstep/src/main/resources/application.properties
+++ b/powerauth-nextstep/src/main/resources/application.properties
@@ -6,9 +6,9 @@ spring.datasource.url=jdbc:mysql://localhost:3306/powerauth
 spring.datasource.username=powerauth
 spring.datasource.password=
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
-spring.jpa.properties.hibernate.connection.CharSet=utf8mb4
 spring.jpa.properties.hibernate.connection.characterEncoding=utf8
 spring.jpa.properties.hibernate.connection.useUnicode=true
+#spring.jpa.properties.hibernate.connection.CharSet=utf8mb4
 
 # Database Configuration - PostgreSQL
 #spring.datasource.url=jdbc:postgresql://localhost:5432/powerauth

--- a/powerauth-webflow/src/main/resources/application.properties
+++ b/powerauth-webflow/src/main/resources/application.properties
@@ -31,9 +31,9 @@ spring.datasource.url=jdbc:mysql://localhost:3306/powerauth
 spring.datasource.username=powerauth
 spring.datasource.password=
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
-spring.jpa.properties.hibernate.connection.CharSet=utf8mb4
 spring.jpa.properties.hibernate.connection.characterEncoding=utf8
 spring.jpa.properties.hibernate.connection.useUnicode=true
+#spring.jpa.properties.hibernate.connection.CharSet=utf8mb4
 
 # Database Configuration - PostgreSQL
 #spring.datasource.url=jdbc:postgresql://localhost:5432/powerauth


### PR DESCRIPTION
I have commented out the `utf8mb4` charset setting. It was ignored by other DB engines, so I think no harm was done, but the setting was incorrect for sure.