### PR TITLE
Fix #754: Startup warning related to Joda-Time

### DIFF
--- a/powerauth-nextstep/pom.xml
+++ b/powerauth-nextstep/pom.xml
@@ -51,7 +51,7 @@
         <!-- Other Dependencies -->
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-joda</artifactId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
             <version>2.10.3</version>
         </dependency>
 

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/configuration/WebApplicationConfig.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/configuration/WebApplicationConfig.java
@@ -17,7 +17,7 @@ package io.getlime.security.powerauth.app.nextstep.configuration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.Jackson2ObjectMapperFactoryBean;
@@ -45,7 +45,7 @@ public class WebApplicationConfig implements WebMvcConfigurer {
         bean.setIndentOutput(true);
         bean.afterPropertiesSet();
         ObjectMapper objectMapper = bean.getObject();
-        objectMapper.registerModule(new JodaModule());
+        objectMapper.registerModule(new JavaTimeModule());
         // replacement for ISO8601DateFormat which is deprecated
         objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         return objectMapper;

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/StepResolutionService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/StepResolutionService.java
@@ -33,10 +33,10 @@ import io.getlime.security.powerauth.lib.nextstep.model.request.CreateOperationR
 import io.getlime.security.powerauth.lib.nextstep.model.request.UpdateOperationRequest;
 import io.getlime.security.powerauth.lib.nextstep.model.response.CreateOperationResponse;
 import io.getlime.security.powerauth.lib.nextstep.model.response.UpdateOperationResponse;
-import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -113,7 +113,8 @@ public class StepResolutionService {
         List<StepDefinitionEntity> stepDefinitions = filterStepDefinitions(request.getOperationName(), OperationRequestType.CREATE, null, null, null);
         response.getSteps().addAll(filterAuthSteps(stepDefinitions, null, request.getOperationName()));
         response.setTimestampCreated(new Date());
-        response.setTimestampExpires(new DateTime().plusSeconds(nextStepServerConfiguration.getOperationExpirationTime()).toDate());
+        ZonedDateTime timestampExpires = ZonedDateTime.now().plusSeconds(nextStepServerConfiguration.getOperationExpirationTime());
+        response.setTimestampExpires(Date.from(timestampExpires.toInstant()));
         response.setFormData(request.getFormData());
         Set<AuthResult> allResults = new HashSet<>();
         for (StepDefinitionEntity stepDef : stepDefinitions) {
@@ -156,7 +157,8 @@ public class StepResolutionService {
             response.setResultDescription("operation.timeout");
             return response;
         }
-        response.setTimestampExpires(new DateTime().plusSeconds(nextStepServerConfiguration.getOperationExpirationTime()).toDate());
+        ZonedDateTime timestampExpires = ZonedDateTime.now().plusSeconds(nextStepServerConfiguration.getOperationExpirationTime());
+        response.setTimestampExpires(Date.from(timestampExpires.toInstant()));
         AuthStepResult authStepResult = request.getAuthStepResult();
         if (isAuthMethodFailed(operation, request.getAuthMethod(), authStepResult)) {
             // check whether the authentication method has already failed completely, in case it has failed, update the authStepResult

--- a/powerauth-tpp-engine/pom.xml
+++ b/powerauth-tpp-engine/pom.xml
@@ -46,7 +46,7 @@
         <!-- Other Dependencies -->
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-joda</artifactId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
             <version>2.10.3</version>
         </dependency>
         <dependency>

--- a/powerauth-webflow-client/pom.xml
+++ b/powerauth-webflow-client/pom.xml
@@ -102,7 +102,7 @@
         <!-- Other Dependencies -->
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-joda</artifactId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
             <version>2.10.3</version>
         </dependency>
 

--- a/powerauth-webflow-client/src/main/java/io/getlime/security/powerauth/app/webflow/demo/configuration/WebApplicationConfig.java
+++ b/powerauth-webflow-client/src/main/java/io/getlime/security/powerauth/app/webflow/demo/configuration/WebApplicationConfig.java
@@ -17,7 +17,7 @@ package io.getlime.security.powerauth.app.webflow.demo.configuration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.Jackson2ObjectMapperFactoryBean;
@@ -45,7 +45,7 @@ public class WebApplicationConfig implements WebMvcConfigurer {
         bean.setIndentOutput(true);
         bean.afterPropertiesSet();
         ObjectMapper objectMapper = bean.getObject();
-        objectMapper.registerModule(new JodaModule());
+        objectMapper.registerModule(new JavaTimeModule());
         // replacement for ISO8601DateFormat which is deprecated
         objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         return objectMapper;

--- a/powerauth-webflow/pom.xml
+++ b/powerauth-webflow/pom.xml
@@ -74,7 +74,7 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-joda</artifactId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
             <version>2.10.3</version>
         </dependency>
         <dependency>

--- a/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/configuration/WebMvcConfiguration.java
+++ b/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/configuration/WebMvcConfiguration.java
@@ -18,7 +18,7 @@ package io.getlime.security.powerauth.app.webflow.configuration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.getlime.security.powerauth.app.webflow.i18n.ReloadableResourceBundleMessageSourceWithListing;
 import io.getlime.security.powerauth.rest.api.spring.annotation.PowerAuthAnnotationInterceptor;
 import io.getlime.security.powerauth.rest.api.spring.annotation.PowerAuthEncryptionArgumentResolver;
@@ -149,7 +149,7 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
         bean.setIndentOutput(true);
         bean.afterPropertiesSet();
         ObjectMapper objectMapper = bean.getObject();
-        objectMapper.registerModule(new JodaModule());
+        objectMapper.registerModule(new JavaTimeModule());
         // replacement for ISO8601DateFormat which is deprecated
         objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);


### PR DESCRIPTION
I have tested that the generated time format is the same as before in JSON: `2020-04-20T13:08:00+0000`.