### PR TITLE
Fix #609: Operation update endpoint does not return operation data

### DIFF
--- a/docs/Next-Step-Server-REST-API-Reference.md
+++ b/docs/Next-Step-Server-REST-API-Reference.md
@@ -1050,6 +1050,7 @@ Documentation for operation data is available [in a separate document](https://d
   "requestObject": {
     "operationName": "login",
     "operationData": "A2",
+    "externalTransactionId": "1234567890",
     "formData": {
       "title": {
         "id": "login.title"
@@ -1085,6 +1086,7 @@ Documentation for operation data is available [in a separate document](https://d
     "operationName": "authorize_payment",
     "operationId": null,
     "organizationId": null,
+    "externalTransactionId": "1234567890",
     "operationData": "A1*A100CZK*Q238400856/0300**D20190629*NUtility Bill Payment - 05/2019",
     "params": [],
     "formData": {
@@ -1165,6 +1167,7 @@ AISP:
     "operationId": "ec039314-7560-470a-b226-116c712e8fb3",
     "operationName": "login",
     "organizationId": null,
+    "externalTransactionId": "1234567890",
     "result": "CONTINUE",
     "resultDescription": null,
     "timestampCreated": "2019-07-30T12:51:28+0000",
@@ -1213,6 +1216,7 @@ PISP:
     "operationId": "f415a617-f7c0-4800-8436-f85eb075eb6f",
     "operationName": "authorize_payment",
     "organizationId": null,
+    "externalTransactionId": "1234567890",
     "result": "CONTINUE",
     "resultDescription": null,
     "timestampCreated": "2019-07-30T12:52:35+0000",
@@ -1346,16 +1350,69 @@ Alternative with `POST` method for environments which do not allow `PUT` methods
     "operationName": "authorize_payment",
     "userId": "12345678",
     "organizationId": "RETAIL",
+    "externalTransactionId": "1234567890",
     "result": "CONTINUE",
     "resultDescription": null,
     "timestampCreated": "2018-06-28T12:20:28+0000",
     "timestampExpires": "2018-06-28T12:20:43+0000",
+    "operationData": "A1*A100CZK*Q238400856/0300**D20190629*NUtility Bill Payment - 05/2019",
     "steps": [
       {
         "authMethod": "SMS_KEY",
         "params": []
       }
     ],
+    "formData": {
+      "title": {
+        "id": "operation.title",
+        "value": null
+      },
+      "greeting": {
+        "id": "operation.greeting",
+        "value": null
+      },
+      "summary": {
+        "id": "operation.summary",
+        "value": null
+      },
+      "config": [],
+      "parameters": [
+        {
+          "type": "AMOUNT",
+          "id": "operation.amount",
+          "label": null,
+          "valueFormatType": "AMOUNT",
+          "formattedValues": {},
+          "amount": 100,
+          "currency": "CZK",
+          "currencyId": "operation.currency"
+        },
+        {
+          "type": "KEY_VALUE",
+          "id": "operation.account",
+          "label": null,
+          "valueFormatType": "ACCOUNT",
+          "formattedValues": {},
+          "value": "238400856/0300"
+        },
+        {
+          "type": "KEY_VALUE",
+          "id": "operation.dueDate",
+          "label": null,
+          "valueFormatType": "DATE",
+          "formattedValues": {},
+          "value": "2019-06-29"
+        },
+        {
+          "type": "NOTE",
+          "id": "operation.note",
+          "label": null,
+          "valueFormatType": "TEXT",
+          "formattedValues": {},
+          "note": "Utility Bill Payment - 05/2019"
+        }
+      ]
+    },
     "expired": false
   }
 }

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/response/UpdateOperationResponse.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/response/UpdateOperationResponse.java
@@ -16,6 +16,7 @@
 package io.getlime.security.powerauth.lib.nextstep.model.response;
 
 import io.getlime.security.powerauth.lib.nextstep.model.entity.AuthStep;
+import io.getlime.security.powerauth.lib.nextstep.model.entity.OperationFormData;
 import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthResult;
 
 import java.util.ArrayList;
@@ -32,11 +33,15 @@ public class UpdateOperationResponse {
     private String operationId;
     private String operationName;
     private String userId;
+    private String organizationId;
+    private String externalTransactionId;
     private AuthResult result;
     private String resultDescription;
     private Date timestampCreated;
     private Date timestampExpires;
+    private String operationData;
     private List<AuthStep> steps;
+    private OperationFormData formData;
 
     /**
      * Default constructor.
@@ -91,6 +96,54 @@ public class UpdateOperationResponse {
      */
     public void setUserId(String userId) {
         this.userId = userId;
+    }
+
+    /**
+     * Get operation data.
+     * @return Operation data.
+     */
+    public String getOperationData() {
+        return operationData;
+    }
+
+    /**
+     * Get organization ID.
+     * @return Organization ID.
+     */
+    public String getOrganizationId() {
+        return organizationId;
+    }
+
+    /**
+     * Set organization ID.
+     * @param organizationId Organization ID.
+     */
+    public void setOrganizationId(String organizationId) {
+        this.organizationId = organizationId;
+    }
+
+    /**
+     * Get external transaction ID.
+     * @return External transaction ID.
+     */
+    public String getExternalTransactionId() {
+        return externalTransactionId;
+    }
+
+    /**
+     * Set external transaction ID.
+     * @param externalTransactionId External transaction ID.
+     */
+    public void setExternalTransactionId(String externalTransactionId) {
+        this.externalTransactionId = externalTransactionId;
+    }
+
+    /**
+     * Set operation data.
+     * @param operationData Operation data.
+     */
+    public void setOperationData(String operationData) {
+        this.operationData = operationData;
     }
 
     /**
@@ -174,6 +227,22 @@ public class UpdateOperationResponse {
      */
     public List<AuthStep> getSteps() {
         return steps;
+    }
+
+    /**
+     * Get form data (title, message, other visual attributes, ...) of the operation.
+     * @return Form data.
+     */
+    public OperationFormData getFormData() {
+        return formData;
+    }
+
+    /**
+     * Set form data object.
+     * @param formData Set form data.
+     */
+    public void setFormData(OperationFormData formData) {
+        this.formData = formData;
     }
 
 }

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/StepResolutionService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/StepResolutionService.java
@@ -16,6 +16,7 @@
 package io.getlime.security.powerauth.app.nextstep.service;
 
 import io.getlime.security.powerauth.app.nextstep.configuration.NextStepServerConfiguration;
+import io.getlime.security.powerauth.app.nextstep.converter.OperationConverter;
 import io.getlime.security.powerauth.app.nextstep.repository.AuthMethodRepository;
 import io.getlime.security.powerauth.app.nextstep.repository.StepDefinitionRepository;
 import io.getlime.security.powerauth.app.nextstep.repository.model.entity.AuthMethodEntity;
@@ -59,6 +60,8 @@ public class StepResolutionService {
     private final AuthMethodRepository authMethodRepository;
     private final MobileTokenConfigurationService mobileTokenConfigurationService;
     private final Map<String, List<StepDefinitionEntity>> stepDefinitionsPerOperation;
+
+    private final OperationConverter operationConverter = new OperationConverter();
 
     /**
      * Service constructor.
@@ -141,6 +144,11 @@ public class StepResolutionService {
         response.setOperationId(request.getOperationId());
         response.setOperationName(operation.getOperationName());
         response.setUserId(request.getUserId());
+        response.setOrganizationId(request.getOrganizationId());
+        response.setExternalTransactionId(operation.getExternalTransactionId());
+        // attach operation data and form data to the response
+        response.setOperationData(operation.getOperationData());
+        response.setFormData(operationConverter.fromEntity(operation).getFormData());
         response.setTimestampCreated(new Date());
         if (request.getAuthStepResult() == AuthStepResult.CANCELED) {
             // User canceled the operation. Save authStepResultDescription which contains the reason for cancellation.


### PR DESCRIPTION
This pull request enriches the response from update operation, so that all relevant data is provided like in the case when creating an operation.