### PR TITLE
Fix #917: Fix CSS issue after migration to React 16

### DIFF
--- a/powerauth-webflow/src/main/resources/static/resources/css/base.css
+++ b/powerauth-webflow/src/main/resources/static/resources/css/base.css
@@ -140,7 +140,7 @@ a:hover, a:active, a:focus {
     right: 10px;
 }
 
-#operation .panel-body {
+#operation .panel-default {
     padding: 30px;
     min-height: 400px;
 }
@@ -244,11 +244,11 @@ a:hover, a:active, a:focus {
 
 /* LOGIN */
 
-#login .panel-body {
+#login .panel-default {
     padding: 30px;
 }
 
-#login .panel-body .title {
+#login .panel-default .title {
     color: #7FC000;
 }
 

--- a/powerauth-webflow/src/main/resources/static/resources/css/customization.css
+++ b/powerauth-webflow/src/main/resources/static/resources/css/customization.css
@@ -129,7 +129,7 @@ a:hover, a:active, a:focus {
     color: #439fe6;
 }
 
-#login .panel-body .title {
+#login .panel-default .title {
     color: gray;
 }
 


### PR DESCRIPTION
The `panel-body` class is no longer used by `Panel` in React 16, so I switched the customization to the `panel-default` class. I visually compared the `0.24.1` version and the fix and they look the same.