### PR TITLE
Integrate PowerAuth operations into Next Step and Web Flow

### DIFF
--- a/docs/sql/mysql/create_schema.sql
+++ b/docs/sql/mysql/create_schema.sql
@@ -437,6 +437,7 @@ CREATE TABLE ns_operation_history (
   chosen_auth_method          VARCHAR(32),                         -- Information about which authentication method was chosen, in case user can chose the authentication method.
   mobile_token_active         BOOLEAN NOT NULL DEFAULT FALSE,      -- Information about if mobile token is active during the particular authentication step, in order to show the mobile token operation at the right time.
   authentication_id           VARCHAR(256),                        -- Reference to the authentication record.
+  pa_operation_id             VARCHAR(256),                        -- PowerAuth operation ID for PowerAuth operations.
   PRIMARY KEY (operation_id, result_id),
   FOREIGN KEY ns_history_operation_fk (operation_id) REFERENCES ns_operation (operation_id),
   FOREIGN KEY ns_history_auth_method_fk (request_auth_method) REFERENCES ns_auth_method (auth_method),

--- a/docs/sql/oracle/create_schema.sql
+++ b/docs/sql/oracle/create_schema.sql
@@ -460,6 +460,7 @@ CREATE TABLE ns_operation_history (
   chosen_auth_method          VARCHAR2(32 CHAR),                          -- Information about which authentication method was chosen, in case user can chose the authentication method.
   mobile_token_active         NUMBER(1) DEFAULT 0 NOT NULL,               -- Information about if mobile token is active during the particular authentication step, in order to show the mobile token operation at the right time.
   authentication_id           VARCHAR2(256 CHAR),                         -- Reference to the authentication record.
+  pa_operation_id             VARCHAR2(256 CHAR),                         -- PowerAuth operation ID for PowerAuth operations.
   CONSTRAINT ns_history_pk PRIMARY KEY (operation_id, result_id),
   CONSTRAINT ns_history_operation_fk FOREIGN KEY (operation_id) REFERENCES ns_operation (operation_id),
   CONSTRAINT ns_history_auth_method_fk FOREIGN KEY (request_auth_method) REFERENCES ns_auth_method (auth_method),

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/entity/OperationHistory.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/entity/OperationHistory.java
@@ -6,6 +6,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthStepResu
 import lombok.Data;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 /**
  * Class representing operation history entities.
@@ -21,5 +22,9 @@ public class OperationHistory {
     private AuthResult authResult;
     @NotNull
     private AuthStepResult requestAuthStepResult;
+    @NotNull
+    private boolean mobileTokenActive;
+    @Size(min = 1, max = 256)
+    private String paOperationId;
 
 }

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/entity/OperationHistory.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/entity/OperationHistory.java
@@ -22,9 +22,11 @@ public class OperationHistory {
     private AuthResult authResult;
     @NotNull
     private AuthStepResult requestAuthStepResult;
+    @Size(min = 2, max = 256)
+    private String authStepResultDescription;
     @NotNull
     private boolean mobileTokenActive;
     @Size(min = 1, max = 256)
-    private String paOperationId;
+    private String powerAuthOperationId;
 
 }

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/response/UpdateOperationResponse.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/response/UpdateOperationResponse.java
@@ -64,6 +64,7 @@ public class UpdateOperationResponse {
     private final List<AuthStep> steps = new ArrayList<>();
     private AuthMethod chosenAuthMethod;
     private boolean mobileTokenActive;
+    private String powerAuthOperationId;
     private OperationFormData formData;
 
 }

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OperationController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OperationController.java
@@ -379,9 +379,10 @@ public class OperationController {
      * @return Update operation response.
      * @throws OperationNotFoundException Thrown when operation is not found.
      * @throws OperationNotValidException Thrown when operation is not valid.
+     * @throws InvalidConfigurationException Thrown when Next Step configuration is invalid.
      */
     @RequestMapping(value = "operation/mobileToken/status", method = RequestMethod.PUT)
-    public Response updateMobileToken(@Valid @RequestBody ObjectRequest<UpdateMobileTokenRequest> request) throws OperationNotFoundException, OperationNotValidException {
+    public Response updateMobileToken(@Valid @RequestBody ObjectRequest<UpdateMobileTokenRequest> request) throws OperationNotFoundException, OperationNotValidException, InvalidConfigurationException {
         return updateMobileTokenImpl(request);
     }
 
@@ -391,13 +392,14 @@ public class OperationController {
      * @return Update operation response.
      * @throws OperationNotFoundException Thrown when operation is not found.
      * @throws OperationNotValidException Thrown when operation is not valid.
+     * @throws InvalidConfigurationException Thrown when Next Step configuration is invalid.
      */
     @RequestMapping(value = "operation/mobileToken/status/update", method = RequestMethod.POST)
-    public @ResponseBody Response updateMobileTokenPost(@Valid @RequestBody ObjectRequest<UpdateMobileTokenRequest> request) throws OperationNotFoundException, OperationNotValidException {
+    public @ResponseBody Response updateMobileTokenPost(@Valid @RequestBody ObjectRequest<UpdateMobileTokenRequest> request) throws OperationNotFoundException, OperationNotValidException, InvalidConfigurationException {
         return updateMobileTokenImpl(request);
     }
 
-    private Response updateMobileTokenImpl(ObjectRequest<UpdateMobileTokenRequest> request) throws OperationNotFoundException, OperationNotValidException {
+    private Response updateMobileTokenImpl(ObjectRequest<UpdateMobileTokenRequest> request) throws OperationNotFoundException, OperationNotValidException, InvalidConfigurationException {
         logger.info("Received updateMobileToken request, operation ID: {}, mobile token active: {}", request.getRequestObject().getOperationId(), request.getRequestObject().isMobileTokenActive());
         // persist mobile token update
         operationPersistenceService.updateMobileToken(request.getRequestObject());

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OperationController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OperationController.java
@@ -262,10 +262,9 @@ public class OperationController {
      *
      * @param request Get pending operations request.
      * @return List with operation details.
-     * @throws InvalidConfigurationException Thrown when Next Step configuration is invalid.
      */
     @RequestMapping(value = "user/operation/list", method = RequestMethod.POST)
-    public ObjectResponse<List<GetOperationDetailResponse>> getPendingOperations(@Valid @RequestBody ObjectRequest<GetPendingOperationsRequest> request) throws InvalidConfigurationException {
+    public ObjectResponse<List<GetOperationDetailResponse>> getPendingOperations(@Valid @RequestBody ObjectRequest<GetPendingOperationsRequest> request) {
         // Log level is FINE to avoid flooding logs, this endpoint is used all the time.
         logger.debug("Received getPendingOperations request, user ID: {}", request.getRequestObject().getUserId());
 

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OperationController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OperationController.java
@@ -204,7 +204,7 @@ public class OperationController {
 
         GetOperationDetailRequest requestObject = request.getRequestObject();
 
-        OperationEntity operation = operationPersistenceService.getOperation(requestObject.getOperationId());
+        OperationEntity operation = operationPersistenceService.getOperation(requestObject.getOperationId(), true);
         GetOperationDetailResponse response = operationConverter.fromEntity(operation);
 
         // add steps from current response

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/converter/OperationConverter.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/converter/OperationConverter.java
@@ -155,9 +155,10 @@ public class OperationConverter {
             OperationHistory h = new OperationHistory();
             h.setAuthMethod(history.getRequestAuthMethod());
             h.setRequestAuthStepResult(history.getRequestAuthStepResult());
+            h.setAuthStepResultDescription(history.getResponseResultDescription());
             h.setAuthResult(history.getResponseResult());
             h.setMobileTokenActive(history.isMobileTokenActive());
-            h.setPaOperationId(history.getPowerAuthOperationId());
+            h.setPowerAuthOperationId(history.getPowerAuthOperationId());
             response.getHistory().add(h);
         }
         // set chosen authentication method

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/converter/OperationConverter.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/converter/OperationConverter.java
@@ -156,6 +156,8 @@ public class OperationConverter {
             h.setAuthMethod(history.getRequestAuthMethod());
             h.setRequestAuthStepResult(history.getRequestAuthStepResult());
             h.setAuthResult(history.getResponseResult());
+            h.setMobileTokenActive(history.isMobileTokenActive());
+            h.setPaOperationId(history.getPowerAuthOperationId());
             response.getHistory().add(h);
         }
         // set chosen authentication method

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OperationHistoryEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OperationHistoryEntity.java
@@ -81,6 +81,9 @@ public class OperationHistoryEntity implements Serializable {
     @JoinColumn(name = "authentication_id")
     private AuthenticationEntity authentication;
 
+    @Column(name = "pa_operation_id")
+    private String powerAuthOperationId;
+
     @ToString.Exclude
     @ManyToOne
     @JoinColumn(name = "operation_id", insertable = false, updatable = false, nullable = false)

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/AuthMethodChangeService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/AuthMethodChangeService.java
@@ -145,9 +145,12 @@ public class AuthMethodChangeService {
             response.setResult(AuthResult.FAILED);
             response.setResultDescription("error.invalidRequest");
         }
-        boolean enabled = mobileTokenConfigurationService.enableMobileToken(operation);
+        String paOperationId = mobileTokenConfigurationService.enableMobileToken(operation);
+        boolean enabled = paOperationId != null;
         response.setMobileTokenActive(enabled);
-        if (!enabled) {
+        if (enabled) {
+            response.setPowerAuthOperationId(paOperationId);
+        } else {
             // Mobile token is not available, return failed result
             response.getSteps().clear();
             response.setResult(AuthResult.FAILED);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/OperationPersistenceService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/OperationPersistenceService.java
@@ -259,7 +259,7 @@ public class OperationPersistenceService {
         String userId = request.getUserId();
         String organizationId = request.getOrganizationId();
         UserAccountStatus accountStatus = request.getAccountStatus();
-        OperationEntity operation = getOperation(operationId, false);
+        OperationEntity operation = getOperation(operationId);
         operation.setUserId(userId);
         if (organizationId != null) {
             Optional<OrganizationEntity> organizationOptional = organizationRepository.findById(organizationId);
@@ -569,7 +569,7 @@ public class OperationPersistenceService {
     public void createAfsAction(CreateAfsActionRequest request) {
         try {
             OperationAfsActionEntity afsEntity = new OperationAfsActionEntity();
-            OperationEntity operation = getOperation(request.getOperationId(), false);
+            OperationEntity operation = getOperation(request.getOperationId());
             afsEntity.setOperation(operation);
             afsEntity.setAfsAction(request.getAfsAction());
             afsEntity.setStepIndex(request.getStepIndex());

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/OperationPersistenceService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/OperationPersistenceService.java
@@ -362,8 +362,7 @@ public class OperationPersistenceService {
         }
         if (request.isMobileTokenActive()) {
             String paOperationId = mobileTokenConfigurationService.enableMobileToken(operation);
-            boolean enabled = paOperationId != null;
-            currentHistory.setMobileTokenActive(enabled);
+            currentHistory.setMobileTokenActive(true);
             currentHistory.setPowerAuthOperationId(paOperationId);
         } else {
             currentHistory.setMobileTokenActive(false);
@@ -478,6 +477,11 @@ public class OperationPersistenceService {
     private boolean validateMobileTokenOperation(OperationEntity operation) {
         OperationHistoryEntity currentHistoryEntity = operation.getCurrentOperationHistoryEntity();
         if (currentHistoryEntity != null && currentHistoryEntity.getResponseResult() == AuthResult.CONTINUE && currentHistoryEntity.isMobileTokenActive()) {
+            if (currentHistoryEntity.getPowerAuthOperationId() == null) {
+                // PowerAuth operation was not created, but mobile token is active
+                return true;
+            }
+            // PowerAuth operation was created, reconcile states of both operations
             OperationDetailResponse detail = powerAuthOperationService.getOperationDetail(operation);
             // PowerAuth operation expired, cancel Next Step operation
             if (detail.getStatus() == OperationStatus.EXPIRED) {

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/PowerAuthOperationService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/PowerAuthOperationService.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2019 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.app.nextstep.service;
+
+import com.wultra.security.powerauth.client.PowerAuthClient;
+import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
+import com.wultra.security.powerauth.client.model.request.OperationCreateRequest;
+import com.wultra.security.powerauth.client.model.response.OperationDetailResponse;
+import com.wultra.security.powerauth.client.v3.ActivationStatus;
+import com.wultra.security.powerauth.client.v3.GetActivationStatusResponse;
+import io.getlime.security.powerauth.app.nextstep.configuration.NextStepServerConfiguration;
+import io.getlime.security.powerauth.app.nextstep.converter.OperationConverter;
+import io.getlime.security.powerauth.app.nextstep.repository.model.entity.OperationEntity;
+import io.getlime.security.powerauth.lib.dataadapter.client.DataAdapterClient;
+import io.getlime.security.powerauth.lib.dataadapter.client.DataAdapterClientErrorException;
+import io.getlime.security.powerauth.lib.dataadapter.model.entity.OperationContext;
+import io.getlime.security.powerauth.lib.dataadapter.model.response.GetPAOperationMappingResponse;
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthMethod;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Service for managing operations in PowerAuth server.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Service
+public class PowerAuthOperationService {
+
+    private static final Logger logger = LoggerFactory.getLogger(PowerAuthOperationService.class);
+
+    private static final String PARAMETER_OPERATION_DATA = "operation_data";
+
+    private final NextStepServerConfiguration nextStepServerConfiguration;
+    private final PowerAuthClient powerAuthClient;
+    private final DataAdapterClient dataAdapterClient;
+
+    private final OperationConverter operationConverter = new OperationConverter();
+
+    /**
+     * Service constructor.
+     * @param nextStepServerConfiguration Next Step server configuration.
+     * @param powerAuthClient PowerAuth client.
+     * @param dataAdapterClient Data Adapter client.
+     */
+    @Autowired
+    public PowerAuthOperationService(NextStepServerConfiguration nextStepServerConfiguration, PowerAuthClient powerAuthClient, DataAdapterClient dataAdapterClient) {
+        this.nextStepServerConfiguration = nextStepServerConfiguration;
+        this.powerAuthClient = powerAuthClient;
+        this.dataAdapterClient = dataAdapterClient;
+    }
+
+    /**
+     * Create a PowerAuth operation.
+     * @param operation Next Step operation entity.
+     * @param activationId Activation ID.
+     */
+    public String createOperation(OperationEntity operation, String activationId) {
+        boolean operationEnabled = nextStepServerConfiguration.isPowerAuthOperationSupportEnabled();
+        if (!operationEnabled) {
+            return null;
+        }
+        String userId = operation.getUserId();
+        String organizationId = null;
+        if (operation.getOrganization() != null) {
+            organizationId = operation.getOrganization().getOrganizationId();
+        }
+        try {
+            // Check activation status
+            GetActivationStatusResponse status = powerAuthClient.getActivationStatus(activationId);
+            if (status.getActivationStatus() != ActivationStatus.ACTIVE) {
+                return null;
+            }
+
+            // Get operation mapping from Data Adapter
+            OperationContext operationContext = operationConverter.toOperationContext(operation);
+            AuthMethod authMethod = operation.getCurrentOperationHistoryEntity().getRequestAuthMethod();
+            GetPAOperationMappingResponse mappingResponse = dataAdapterClient.getPAOperationMapping(userId, organizationId, authMethod, operationContext).getResponseObject();
+            OperationCreateRequest request = new OperationCreateRequest();
+            request.setUserId(operation.getUserId());
+            request.setApplicationId(status.getApplicationId());
+            request.setExternalId(operation.getOperationId());
+            request.setTemplateName(mappingResponse.getTemplateName());
+            Map<String, String> parameters = new LinkedHashMap<>();
+            parameters.put(PARAMETER_OPERATION_DATA, operation.getOperationData());
+            request.setParameters(parameters);
+
+            // Create PowerAuth operation and store PA operation ID
+            OperationDetailResponse paResponse = powerAuthClient.createOperation(request);
+            return paResponse.getId();
+        } catch (PowerAuthClientException | DataAdapterClientErrorException ex) {
+            logger.warn(ex.getMessage(), ex);
+        }
+        return null;
+    }
+
+}

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/PowerAuthOperationService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/PowerAuthOperationService.java
@@ -94,7 +94,7 @@ public class PowerAuthOperationService {
 
             // Get operation mapping from Data Adapter
             OperationContext operationContext = operationConverter.toOperationContext(operation);
-            AuthMethod authMethod = operation.getCurrentOperationHistoryEntity().getRequestAuthMethod();
+            AuthMethod authMethod = operation.getCurrentOperationHistoryEntity().getChosenAuthMethod();
             GetPAOperationMappingResponse mappingResponse = dataAdapterClient.getPAOperationMapping(userId, organizationId, authMethod, operationContext).getResponseObject();
             OperationCreateRequest request = new OperationCreateRequest();
             request.setUserId(operation.getUserId());
@@ -102,7 +102,7 @@ public class PowerAuthOperationService {
             request.setExternalId(operation.getOperationId());
             request.setTemplateName(mappingResponse.getTemplateName());
             Map<String, String> parameters = new LinkedHashMap<>();
-            parameters.put(PARAMETER_OPERATION_DATA, operation.getOperationData());
+            parameters.put(PARAMETER_OPERATION_DATA, mappingResponse.getOperationData());
             request.setParameters(parameters);
 
             // Create PowerAuth operation and store PA operation ID

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/PowerAuthOperationService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/PowerAuthOperationService.java
@@ -16,7 +16,6 @@
 package io.getlime.security.powerauth.app.nextstep.service;
 
 import com.wultra.security.powerauth.client.PowerAuthClient;
-import com.wultra.security.powerauth.client.model.enumeration.OperationStatus;
 import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
 import com.wultra.security.powerauth.client.model.request.OperationCreateRequest;
 import com.wultra.security.powerauth.client.model.request.OperationDetailRequest;
@@ -116,11 +115,11 @@ public class PowerAuthOperationService {
     }
 
     /**
-     * Get PowerAuth operation status.
+     * Get PowerAuth operation detail.
      * @param operation Operation entity.
-     * @return PowerAuth operation status.
+     * @return PowerAuth operation detail.
      */
-    public OperationStatus getOperationStatus(OperationEntity operation) {
+    public OperationDetailResponse getOperationDetail(OperationEntity operation) {
         boolean operationEnabled = nextStepServerConfiguration.isPowerAuthOperationSupportEnabled();
         if (!operationEnabled) {
             return null;
@@ -136,8 +135,7 @@ public class PowerAuthOperationService {
             OperationDetailRequest request = new OperationDetailRequest();
             request.setOperationId(paOperationId);
 
-            OperationDetailResponse paResponse = powerAuthClient.operationDetail(request);
-            return paResponse.getStatus();
+            return powerAuthClient.operationDetail(request);
         } catch (PowerAuthClientException ex) {
             logger.warn(ex.getMessage(), ex);
         }

--- a/powerauth-webflow-authentication-approval-sca/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/approvalsca/controller/ApprovalScaController.java
+++ b/powerauth-webflow-authentication-approval-sca/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/approvalsca/controller/ApprovalScaController.java
@@ -239,7 +239,7 @@ public class ApprovalScaController extends AuthMethodController<ApprovalScaAuthR
     public AuthStepResponse cancelAuthentication() throws AuthStepException {
         try {
             final GetOperationDetailResponse operation = getOperation();
-            cancelAuthorization(operation.getOperationId(), operation.getUserId(), OperationCancelReason.UNKNOWN, null);
+            cancelAuthorization(operation.getOperationId(), operation.getUserId(), OperationCancelReason.UNKNOWN, null, true);
             final AuthStepResponse response = new AuthStepResponse();
             response.setResult(AuthStepResult.CANCELED);
             response.setMessage("operation.canceled");

--- a/powerauth-webflow-authentication-consent/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/consent/controller/ConsentController.java
+++ b/powerauth-webflow-authentication-consent/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/consent/controller/ConsentController.java
@@ -341,7 +341,7 @@ public class ConsentController extends AuthMethodController<ConsentAuthRequest, 
     public ConsentAuthResponse cancelAuthentication() throws AuthStepException {
         try {
             final GetOperationDetailResponse operation = getOperation();
-            cancelAuthorization(operation.getOperationId(), operation.getUserId(), OperationCancelReason.UNKNOWN, null);
+            cancelAuthorization(operation.getOperationId(), operation.getUserId(), OperationCancelReason.UNKNOWN, null, false);
             final ConsentAuthResponse cancelResponse = new ConsentAuthResponse();
             cancelResponse.setResult(AuthStepResult.CANCELED);
             cancelResponse.setMessage("operation.canceled");

--- a/powerauth-webflow-authentication-form/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/form/controller/FormLoginController.java
+++ b/powerauth-webflow-authentication-form/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/form/controller/FormLoginController.java
@@ -310,7 +310,7 @@ public class FormLoginController extends AuthMethodController<UsernamePasswordAu
     UsernamePasswordAuthResponse cancelAuthentication() throws AuthStepException {
         try {
             final GetOperationDetailResponse operation = getOperation();
-            cancelAuthorization(operation.getOperationId(), operation.getUserId(), OperationCancelReason.UNKNOWN, null);
+            cancelAuthorization(operation.getOperationId(), operation.getUserId(), OperationCancelReason.UNKNOWN, null, false);
             final UsernamePasswordAuthResponse response = new UsernamePasswordAuthResponse();
             response.setResult(AuthStepResult.CANCELED);
             response.setMessage("operation.canceled");

--- a/powerauth-webflow-authentication-login-sca/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/loginsca/controller/LoginScaController.java
+++ b/powerauth-webflow-authentication-login-sca/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/loginsca/controller/LoginScaController.java
@@ -35,7 +35,6 @@ import io.getlime.security.powerauth.lib.nextstep.model.entity.enumeration.UserA
 import io.getlime.security.powerauth.lib.nextstep.model.entity.enumeration.UserIdentityStatus;
 import io.getlime.security.powerauth.lib.nextstep.model.enumeration.*;
 import io.getlime.security.powerauth.lib.nextstep.model.exception.UserNotFoundException;
-import io.getlime.security.powerauth.lib.nextstep.model.request.LookupUserRequest;
 import io.getlime.security.powerauth.lib.nextstep.model.response.*;
 import io.getlime.security.powerauth.lib.webflow.authentication.base.AuthStepResponse;
 import io.getlime.security.powerauth.lib.webflow.authentication.controller.AuthMethodController;
@@ -333,7 +332,7 @@ public class LoginScaController extends AuthMethodController<LoginScaAuthRequest
     public AuthStepResponse cancelAuthentication() throws AuthStepException {
         try {
             final GetOperationDetailResponse operation = getOperation();
-            cancelAuthorization(operation.getOperationId(), operation.getUserId(), OperationCancelReason.UNKNOWN, null);
+            cancelAuthorization(operation.getOperationId(), operation.getUserId(), OperationCancelReason.UNKNOWN, null, true);
             final AuthStepResponse response = new AuthStepResponse();
             response.setResult(AuthStepResult.CANCELED);
             response.setMessage("operation.canceled");

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileAppApiController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileAppApiController.java
@@ -281,7 +281,7 @@ public class MobileAppApiController extends AuthMethodController<MobileTokenAuth
                 } else {
                     boolean approvalFailSucceeded = powerAuthOperationService.failApprovalForOperation(operation);
                     if (!approvalFailSucceeded) {
-                        throw new OperationIsAlreadyFailedException("Operation failed approval has failed");
+                        throw new OperationIsAlreadyFailedException("Operation fail approval has failed");
                     }
                     throw new PowerAuthAuthenticationException();
                 }

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOnlineController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOnlineController.java
@@ -161,7 +161,7 @@ public class MobileTokenOnlineController extends AuthMethodController<MobileToke
             logger.info("Operation has timed out, operation ID: {}", operation.getOperationId());
             // Handle operation expiration
             try {
-                cancelAuthorization(operation.getOperationId(), operation.getUserId(), OperationCancelReason.TIMED_OUT_OPERATION, null);
+                cancelAuthorization(operation.getOperationId(), operation.getUserId(), OperationCancelReason.TIMED_OUT_OPERATION, null, true);
             } catch (Exception e) {
                 logger.error(e.getMessage(), e);
             }
@@ -231,7 +231,7 @@ public class MobileTokenOnlineController extends AuthMethodController<MobileToke
             // when AuthMethod is disabled, operation should fail
             try {
                 logger.info("Operation will be canceled because authentication method is no longer available, operation ID: {}, authentication method: {}", operation.getOperationId(), authMethod.toString());
-                cancelAuthorization(operation.getOperationId(), operation.getUserId(), OperationCancelReason.AUTH_METHOD_NOT_AVAILABLE, null);
+                cancelAuthorization(operation.getOperationId(), operation.getUserId(), OperationCancelReason.AUTH_METHOD_NOT_AVAILABLE, null, true);
             } catch (CommunicationFailedException ex) {
                 // Exception is already logged
             }
@@ -265,7 +265,7 @@ public class MobileTokenOnlineController extends AuthMethodController<MobileToke
         try {
             GetOperationDetailResponse operation = getOperation();
             AuthMethod authMethod = getAuthMethodName(operation);
-            cancelAuthorization(operation.getOperationId(), operation.getUserId(), OperationCancelReason.UNKNOWN, null);
+            cancelAuthorization(operation.getOperationId(), operation.getUserId(), OperationCancelReason.UNKNOWN, null, true);
             final MobileTokenAuthenticationResponse response = new MobileTokenAuthenticationResponse();
             response.setResult(AuthStepResult.CANCELED);
             response.setMessage("operation.canceled");

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOnlineController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOnlineController.java
@@ -217,11 +217,25 @@ public class MobileTokenOnlineController extends AuthMethodController<MobileToke
                 clearCurrentBrowserSession();
                 final MobileTokenAuthenticationResponse response = new MobileTokenAuthenticationResponse();
                 response.setResult(AuthStepResult.CANCELED);
-                String reasonTimeout = "canceled." + OperationCancelReason.TIMED_OUT_OPERATION.toString().toLowerCase();
-                if (reasonTimeout.equals(h.getAuthStepResultDescription())) {
-                    response.setMessage("operation.timeout");
+
+                if (h.getAuthStepResultDescription() != null) {
+                    switch (h.getAuthStepResultDescription()) {
+                        // User rejected the operation
+                        case "canceled.incorrect_data":
+                        case "canceled.unexpected_operation":
+                        case "canceled.unknown":
+                            response.setMessage("operation.canceled");
+                            break;
+                        // The operation timed out
+                        case "canceled.timed_out_operation":
+                            response.setMessage("operation.timeout");
+                            break;
+                        default:
+                        // The operation failed for other reason
+                            response.setMessage("operation.alreadyFailed");
+                    }
                 } else {
-                    response.setMessage("operation.alreadyFailed");
+                    response.setMessage("error.unknown");
                 }
                 pushMessageService.sendAuthStepFinishedPushMessage(operation, response.getMessage(), authMethod);
                 cleanHttpSession();

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOnlineController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOnlineController.java
@@ -217,7 +217,12 @@ public class MobileTokenOnlineController extends AuthMethodController<MobileToke
                 clearCurrentBrowserSession();
                 final MobileTokenAuthenticationResponse response = new MobileTokenAuthenticationResponse();
                 response.setResult(AuthStepResult.CANCELED);
-                response.setMessage("operation.canceled");
+                String reasonTimeout = "canceled." + OperationCancelReason.TIMED_OUT_OPERATION.toString().toLowerCase();
+                if (reasonTimeout.equals(h.getAuthStepResultDescription())) {
+                    response.setMessage("operation.timeout");
+                } else {
+                    response.setMessage("operation.alreadyFailed");
+                }
                 pushMessageService.sendAuthStepFinishedPushMessage(operation, response.getMessage(), authMethod);
                 cleanHttpSession();
                 logger.info("Step result: CANCELED, operation ID: {}, authentication method: {}", operation.getOperationId(), authMethod.toString());

--- a/powerauth-webflow-authentication-operation-review/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/operation/controller/OperationReviewController.java
+++ b/powerauth-webflow-authentication-operation-review/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/operation/controller/OperationReviewController.java
@@ -208,7 +208,7 @@ public class OperationReviewController extends AuthMethodController<OperationRev
     public @ResponseBody OperationReviewResponse cancelAuthentication() throws AuthStepException {
         try {
             GetOperationDetailResponse operation = getOperation();
-            cancelAuthorization(operation.getOperationId(), operation.getUserId(), OperationCancelReason.UNKNOWN, null);
+            cancelAuthorization(operation.getOperationId(), operation.getUserId(), OperationCancelReason.UNKNOWN, null, false);
             final OperationReviewResponse response = new OperationReviewResponse();
             response.setResult(AuthStepResult.CANCELED);
             response.setMessage("operation.canceled");

--- a/powerauth-webflow-authentication-sms/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/sms/controller/SmsAuthorizationController.java
+++ b/powerauth-webflow-authentication-sms/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/sms/controller/SmsAuthorizationController.java
@@ -598,7 +598,7 @@ public class SmsAuthorizationController extends AuthMethodController<SmsAuthoriz
             final GetOperationDetailResponse operation = getOperation();
             final AuthMethod authMethod = getAuthMethodName(operation);
             cleanHttpSession();
-            cancelAuthorization(operation.getOperationId(), operation.getUserId(), OperationCancelReason.UNKNOWN, null);
+            cancelAuthorization(operation.getOperationId(), operation.getUserId(), OperationCancelReason.UNKNOWN, null, true);
             final SmsAuthorizationResponse cancelResponse = new SmsAuthorizationResponse();
             cancelResponse.setResult(AuthStepResult.CANCELED);
             cancelResponse.setMessage("operation.canceled");

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/configuration/WebFlowServicesConfiguration.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/configuration/WebFlowServicesConfiguration.java
@@ -71,6 +71,12 @@ public class WebFlowServicesConfiguration {
     private boolean offlineModeAvailable;
 
     /**
+     * Whether PowerAuth operations support is enabled.
+     */
+    @Value("${powerauth.webflow.pa.operations.enabled}")
+    private boolean powerAuthOperationSupportEnabled;
+
+    /**
      * Authentication type which configures how username and password is transferred for verification.
      */
     @Value("${powerauth.webflow.password.protection.type:NO_PROTECTION}")
@@ -196,6 +202,14 @@ public class WebFlowServicesConfiguration {
      */
     public boolean isOfflineModeAvailable() {
         return offlineModeAvailable;
+    }
+
+    /**
+     * Whether PowerAuth operations support is enabled.
+     * @return Whether PowerAuth operations support is enabled.
+     */
+    public boolean isPowerAuthOperationSupportEnabled() {
+        return powerAuthOperationSupportEnabled;
     }
 
     /**

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/listener/WebSocketDisconnectListener.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/listener/WebSocketDisconnectListener.java
@@ -61,7 +61,7 @@ public class WebSocketDisconnectListener implements ApplicationListener<SessionD
         }
         // Cancel operation due to interrupted operation
         try {
-            operationCancellationService.cancelOperation(operationId, AuthMethod.INIT, OperationCancelReason.INTERRUPTED_OPERATION);
+            operationCancellationService.cancelOperation(operationId, AuthMethod.INIT, OperationCancelReason.INTERRUPTED_OPERATION, true);
         } catch (CommunicationFailedException ex) {
             // Exception is already logged
         }

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/OperationCancellationService.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/OperationCancellationService.java
@@ -95,7 +95,7 @@ public class OperationCancellationService {
                 List<OperationHistory> history = operationDetail.getHistory();
                 if (!history.isEmpty()) {
                     OperationHistory h = history.get(history.size() - 1);
-                    if (h.isMobileTokenActive() && h.getPaOperationId() != null) {
+                    if (h.isMobileTokenActive() && h.getPowerAuthOperationId() != null) {
                         paCancelSucceeded = powerAuthOperationService.cancelOperation(operationDetail);
                     }
                 }

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/PowerAuthOperationService.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/PowerAuthOperationService.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2021 Wultra s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getlime.security.powerauth.lib.webflow.authentication.service;
+
+import com.wultra.security.powerauth.client.PowerAuthClient;
+import com.wultra.security.powerauth.client.model.enumeration.OperationStatus;
+import com.wultra.security.powerauth.client.model.enumeration.UserActionResult;
+import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
+import com.wultra.security.powerauth.client.model.request.*;
+import com.wultra.security.powerauth.client.model.response.OperationDetailResponse;
+import com.wultra.security.powerauth.client.model.response.OperationUserActionResponse;
+import com.wultra.security.powerauth.client.v3.ActivationStatus;
+import com.wultra.security.powerauth.client.v3.GetActivationStatusResponse;
+import io.getlime.security.powerauth.lib.nextstep.client.NextStepClient;
+import io.getlime.security.powerauth.lib.nextstep.client.NextStepClientException;
+import io.getlime.security.powerauth.lib.nextstep.model.entity.OperationHistory;
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthInstrument;
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthMethod;
+import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthStepResult;
+import io.getlime.security.powerauth.lib.nextstep.model.response.GetOperationDetailResponse;
+import io.getlime.security.powerauth.lib.webflow.authentication.configuration.WebFlowServicesConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Service for managing operations in PowerAuth server.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Service
+public class PowerAuthOperationService {
+
+    private static final Logger logger = LoggerFactory.getLogger(PowerAuthOperationService.class);
+
+    private final WebFlowServicesConfiguration configuration;
+    private final PowerAuthClient powerAuthClient;
+    private final NextStepClient nextStepClient;
+    private final AuthMethodResolutionService authMethodResolutionService;
+
+    /**
+     * Service constructor.
+     * @param configuration Web Flow configuration.
+     * @param powerAuthClient PowerAuth client.
+     * @param nextStepClient Next Step client.
+     * @param authMethodResolutionService Authentication method resolution service.
+     */
+    @Autowired
+    public PowerAuthOperationService(WebFlowServicesConfiguration configuration, PowerAuthClient powerAuthClient, NextStepClient nextStepClient, AuthMethodResolutionService authMethodResolutionService) {
+        this.configuration = configuration;
+        this.powerAuthClient = powerAuthClient;
+        this.nextStepClient = nextStepClient;
+        this.authMethodResolutionService = authMethodResolutionService;
+    }
+
+    /**
+     * Approve a PowerAuth operation.
+     * @param operation Operation detail.
+     * @param activationId Activation ID.
+     * @param signatureType Used signature type.
+     * @return Whether approval succeeded.
+     */
+    public boolean approveOperation(GetOperationDetailResponse operation, String activationId, String signatureType) {
+        boolean operationEnabled = configuration.isPowerAuthOperationSupportEnabled();
+        if (!operationEnabled) {
+            return true;
+        }
+        List<OperationHistory> history = operation.getHistory();
+        if (history.isEmpty()) {
+            return false;
+        }
+        OperationHistory currentHistory = history.get(history.size() - 1);
+        boolean mobileTokenActive = currentHistory.isMobileTokenActive();
+        String paOperationId = currentHistory.getPaOperationId();
+        if (!mobileTokenActive || paOperationId == null) {
+            return true;
+        }
+
+        try {
+            // Check activation status
+            boolean approvalFailed = false;
+            GetActivationStatusResponse status = powerAuthClient.getActivationStatus(activationId);
+            if (status.getActivationStatus() != ActivationStatus.ACTIVE) {
+                approvalFailed = true;
+            }
+
+            OperationApproveRequest request = new OperationApproveRequest();
+            request.setOperationId(paOperationId);
+            request.setUserId(operation.getUserId());
+            request.setApplicationId(status.getApplicationId());
+            request.setData(operation.getOperationData());
+            request.setSignatureType(signatureType);
+
+            // Approve operation in PowerAuth server
+            OperationUserActionResponse paResponse = powerAuthClient.operationApprove(request);
+
+            // Check result
+            if (paResponse.getResult() != UserActionResult.APPROVED) {
+                approvalFailed = true;
+            }
+            if (approvalFailed) {
+                // Fail Next Step operation because approval failed
+                failNextStepOperation(operation);
+            } else {
+                return true;
+            }
+        } catch (PowerAuthClientException ex) {
+            logger.warn(ex.getMessage(), ex);
+            failNextStepOperation(operation);
+        }
+        return false;
+    }
+
+    /**
+     * Fail an approval of a PowerAuth operation.
+     * @param operation Operation detail.
+     * @return Whether approval fail succeeded.
+     */
+    public boolean failApprovalForOperation(GetOperationDetailResponse operation) {
+        boolean operationEnabled = configuration.isPowerAuthOperationSupportEnabled();
+        if (!operationEnabled) {
+            return true;
+        }
+        List<OperationHistory> history = operation.getHistory();
+        if (history.isEmpty()) {
+            return false;
+        }
+        OperationHistory currentHistory = history.get(history.size() - 1);
+        boolean mobileTokenActive = currentHistory.isMobileTokenActive();
+        String paOperationId = currentHistory.getPaOperationId();
+        if (!mobileTokenActive || paOperationId == null) {
+            return true;
+        }
+
+        try {
+            OperationFailApprovalRequest request = new OperationFailApprovalRequest();
+            request.setOperationId(paOperationId);
+
+            // Fail approval for operation in PowerAuth server
+            OperationUserActionResponse paResponse = powerAuthClient.failApprovalOperation(request);
+            if (paResponse.getResult() == UserActionResult.APPROVAL_FAILED) {
+                // One attempt failed successfully, operation is still pending
+                return true;
+            }
+            // In case PowerAuth operation response is not APPROVAL_FAILED, fail Next Step operation
+            failNextStepOperation(operation);
+        } catch (PowerAuthClientException ex) {
+            logger.warn(ex.getMessage(), ex);
+            failNextStepOperation(operation);
+        }
+        return false;
+    }
+
+    /**
+     * Reject a PowerAuth operation.
+     * @param operation Operation detail.
+     * @param activationId Activation ID.
+     * @return Whether reject succeeded.
+     */
+    public boolean rejectOperation(GetOperationDetailResponse operation, String activationId) {
+        boolean operationEnabled = configuration.isPowerAuthOperationSupportEnabled();
+        if (!operationEnabled) {
+            return true;
+        }
+        List<OperationHistory> history = operation.getHistory();
+        if (history.isEmpty()) {
+            return false;
+        }
+        OperationHistory currentHistory = history.get(history.size() - 1);
+        boolean mobileTokenActive = currentHistory.isMobileTokenActive();
+        String paOperationId = currentHistory.getPaOperationId();
+        if (!mobileTokenActive || paOperationId == null) {
+            return true;
+        }
+
+        try {
+            // Check activation status
+            boolean rejectFailed = false;
+            GetActivationStatusResponse status = powerAuthClient.getActivationStatus(activationId);
+            if (status.getActivationStatus() != ActivationStatus.ACTIVE) {
+                rejectFailed = true;
+            }
+
+            OperationRejectRequest request = new OperationRejectRequest();
+            request.setOperationId(paOperationId);
+            request.setUserId(operation.getUserId());
+            request.setApplicationId(status.getApplicationId());
+
+            // Reject operation in PowerAuth server
+            OperationUserActionResponse paResponse = powerAuthClient.operationReject(request);
+            if (paResponse.getResult() != UserActionResult.REJECTED) {
+                rejectFailed = true;
+            }
+            if (rejectFailed) {
+                // Fail Next Step operation because reject failed
+                failNextStepOperation(operation);
+            } else {
+                return true;
+            }
+        } catch (PowerAuthClientException ex) {
+            logger.warn(ex.getMessage(), ex);
+            failNextStepOperation(operation);
+        }
+        return false;
+    }
+
+    /**
+     * Cancel a PowerAuth operation.
+     * @param operation Operation detail.
+     * @return Whether cancellation succeeded.
+     */
+    public boolean cancelOperation(GetOperationDetailResponse operation) {
+        boolean operationEnabled = configuration.isPowerAuthOperationSupportEnabled();
+        if (!operationEnabled) {
+            return true;
+        }
+        List<OperationHistory> history = operation.getHistory();
+        if (history.isEmpty()) {
+            return false;
+        }
+        OperationHistory currentHistory = history.get(history.size() - 1);
+        boolean mobileTokenActive = currentHistory.isMobileTokenActive();
+        String paOperationId = currentHistory.getPaOperationId();
+        if (!mobileTokenActive || paOperationId == null) {
+            return true;
+        }
+
+        try {
+            OperationCancelRequest request = new OperationCancelRequest();
+            request.setOperationId(paOperationId);
+
+            // Cancel operation in PowerAuth server
+            OperationDetailResponse paResponse = powerAuthClient.operationCancel(request);
+            if (paResponse.getStatus() == OperationStatus.CANCELED) {
+                return true;
+            }
+            // Fail Next Step operation because cancellation failed
+            failNextStepOperation(operation);
+        } catch (PowerAuthClientException ex) {
+            logger.warn(ex.getMessage(), ex);
+            failNextStepOperation(operation);
+        }
+        return false;
+    }
+
+    /**
+     * Cancel a PowerAuth operation.
+     * @param operation Operation detail.
+     * @return PowerAuth operation status.
+     */
+    public OperationStatus getOperationStatus(GetOperationDetailResponse operation) {
+        boolean operationEnabled = configuration.isPowerAuthOperationSupportEnabled();
+        if (!operationEnabled) {
+            return null;
+        }
+        List<OperationHistory> history = operation.getHistory();
+        if (history.isEmpty()) {
+            return null;
+        }
+        OperationHistory currentHistory = history.get(history.size() - 1);
+        boolean mobileTokenActive = currentHistory.isMobileTokenActive();
+        String paOperationId = currentHistory.getPaOperationId();
+        if (!mobileTokenActive || paOperationId == null) {
+            return null;
+        }
+
+        try {
+            OperationDetailRequest request = new OperationDetailRequest();
+            request.setOperationId(paOperationId);
+
+            OperationDetailResponse paResponse = powerAuthClient.operationDetail(request);
+            return paResponse.getStatus();
+        } catch (PowerAuthClientException ex) {
+            logger.warn(ex.getMessage(), ex);
+        }
+        return null;
+    }
+
+    /**
+     * Get current authentication method for an operation.
+     * @param operation Operation detail.
+     * @return Current authentication method.
+     */
+    private AuthMethod getAuthMethod(GetOperationDetailResponse operation) {
+        AuthMethod authMethod = AuthMethod.POWERAUTH_TOKEN;
+        AuthMethod overriddenAuthMethod = authMethodResolutionService.resolveAuthMethodOverride(operation);
+        if (overriddenAuthMethod != null) {
+            authMethod = overriddenAuthMethod;
+        }
+        return authMethod;
+    }
+
+    /**
+     * Fail Next Step operation.
+     * @param operation Operation detail.
+     */
+    private void failNextStepOperation(GetOperationDetailResponse operation) {
+        try {
+            // Fail Next Step operation
+            nextStepClient.updateOperation(operation.getOperationId(), operation.getUserId(),
+                    operation.getOrganizationId(), getAuthMethod(operation), Collections.singletonList(AuthInstrument.POWERAUTH_TOKEN),
+                    AuthStepResult.AUTH_METHOD_FAILED, null, null, operation.getApplicationContext());
+        } catch (NextStepClientException ex) {
+            logger.warn(ex.getMessage(), ex);
+        }
+    }
+
+}

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/PowerAuthOperationService.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/PowerAuthOperationService.java
@@ -88,7 +88,7 @@ public class PowerAuthOperationService {
         }
         OperationHistory currentHistory = history.get(history.size() - 1);
         boolean mobileTokenActive = currentHistory.isMobileTokenActive();
-        String paOperationId = currentHistory.getPaOperationId();
+        String paOperationId = currentHistory.getPowerAuthOperationId();
         if (!mobileTokenActive || paOperationId == null) {
             return true;
         }
@@ -144,7 +144,7 @@ public class PowerAuthOperationService {
         }
         OperationHistory currentHistory = history.get(history.size() - 1);
         boolean mobileTokenActive = currentHistory.isMobileTokenActive();
-        String paOperationId = currentHistory.getPaOperationId();
+        String paOperationId = currentHistory.getPowerAuthOperationId();
         if (!mobileTokenActive || paOperationId == null) {
             return true;
         }
@@ -185,7 +185,7 @@ public class PowerAuthOperationService {
         }
         OperationHistory currentHistory = history.get(history.size() - 1);
         boolean mobileTokenActive = currentHistory.isMobileTokenActive();
-        String paOperationId = currentHistory.getPaOperationId();
+        String paOperationId = currentHistory.getPowerAuthOperationId();
         if (!mobileTokenActive || paOperationId == null) {
             return true;
         }
@@ -237,7 +237,7 @@ public class PowerAuthOperationService {
         }
         OperationHistory currentHistory = history.get(history.size() - 1);
         boolean mobileTokenActive = currentHistory.isMobileTokenActive();
-        String paOperationId = currentHistory.getPaOperationId();
+        String paOperationId = currentHistory.getPowerAuthOperationId();
         if (!mobileTokenActive || paOperationId == null) {
             return true;
         }
@@ -261,7 +261,7 @@ public class PowerAuthOperationService {
     }
 
     /**
-     * Cancel a PowerAuth operation.
+     * Get PowerAuth operation status.
      * @param operation Operation detail.
      * @return PowerAuth operation status.
      */
@@ -276,7 +276,7 @@ public class PowerAuthOperationService {
         }
         OperationHistory currentHistory = history.get(history.size() - 1);
         boolean mobileTokenActive = currentHistory.isMobileTokenActive();
-        String paOperationId = currentHistory.getPaOperationId();
+        String paOperationId = currentHistory.getPowerAuthOperationId();
         if (!mobileTokenActive || paOperationId == null) {
             return null;
         }

--- a/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/configuration/PowerAuthWebServiceConfiguration.java
+++ b/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/configuration/PowerAuthWebServiceConfiguration.java
@@ -47,18 +47,6 @@ public class PowerAuthWebServiceConfiguration {
     private boolean acceptInvalidSslCertificate;
 
     /**
-     * Configuration of the total Unirest parallel connections.
-     */
-    @Value("${powerauth.unirest.concurrency.total:500}")
-    private int unirestConcurrencyTotal;
-
-    /**
-     * Configuration of the per-route Unirest parallel connections.
-     */
-    @Value("${powerauth.unirest.concurrency.perRoute:50}")
-    private int unirestConcurrencyPerRoute;
-
-    /**
      * Configuration constructor.
      * @param sslConfigurationService SSL configuration service.
      */

--- a/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/controller/HomeController.java
+++ b/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/controller/HomeController.java
@@ -316,7 +316,7 @@ public class HomeController {
         if (pendingUserAuthentication != null) {
             String operationId = pendingUserAuthentication.getOperationId();
             try {
-                operationCancellationService.cancelOperation(operationId, AuthMethod.INIT, OperationCancelReason.UNEXPECTED_ERROR);
+                operationCancellationService.cancelOperation(operationId, AuthMethod.INIT, OperationCancelReason.UNEXPECTED_ERROR, true);
             } catch (CommunicationFailedException ex) {
                 // Exception is already logged
                 return "redirect:/oauth/error";

--- a/powerauth-webflow/src/main/js/actions/consentActions.js
+++ b/powerauth-webflow/src/main/js/actions/consentActions.js
@@ -80,7 +80,8 @@ export function authenticate(options, callback) {
                     dispatchAction(dispatch, response);
                     break;
                 }
-                case 'CANCELED': {
+                case 'CANCELED':
+                case 'AUTH_METHOD_FAILED': {
                     callback();
                     dispatch({
                         type: "SHOW_SCREEN_ERROR",

--- a/powerauth-webflow/src/main/js/actions/smsAuthActions.js
+++ b/powerauth-webflow/src/main/js/actions/smsAuthActions.js
@@ -102,7 +102,7 @@ export function resend(component) {
             }
         }).then((response) => {
             if (response.data.result === 'AUTH_FAILED') {
-                // Handle  error when message delivery fails, another SMS message can be sent later.
+                // Handle error when message delivery fails, another SMS message can be sent later.
                 dispatch({
                     type: getActionType(component),
                     payload: {
@@ -182,7 +182,8 @@ export function authenticate(userAuthCode, userPassword, component) {
                         break;
                     }
                 }
-                case 'CANCELED': {
+                case 'CANCELED':
+                case 'AUTH_METHOD_FAILED': {
                     dispatch({
                         type: "SHOW_SCREEN_ERROR",
                         payload: {

--- a/powerauth-webflow/src/main/js/actions/tokenAuthOfflineActions.js
+++ b/powerauth-webflow/src/main/js/actions/tokenAuthOfflineActions.js
@@ -106,7 +106,8 @@ export function authenticateOffline(activationId, authCode, nonce) {
                     dispatchAction(dispatch, response);
                     break;
                 }
-                case 'CANCELED': {
+                case 'CANCELED':
+                case 'AUTH_METHOD_FAILED': {
                     dispatch({
                         type: "SHOW_SCREEN_ERROR",
                         payload: {
@@ -141,6 +142,7 @@ export function authenticateOffline(activationId, authCode, nonce) {
 /**
  * Update operation form data on the server.
  * @param formData Operation form data.
+ * @packag callback Callback function to execute.
  * @returns {Function} No response in case of OK status, otherwise error is dispatched.
  */
 export function updateFormData(formData, callback) {

--- a/powerauth-webflow/src/main/js/actions/tokenAuthOfflineActions.js
+++ b/powerauth-webflow/src/main/js/actions/tokenAuthOfflineActions.js
@@ -142,7 +142,7 @@ export function authenticateOffline(activationId, authCode, nonce) {
 /**
  * Update operation form data on the server.
  * @param formData Operation form data.
- * @packag callback Callback function to execute.
+ * @param callback Callback function to execute.
  * @returns {Function} No response in case of OK status, otherwise error is dispatched.
  */
 export function updateFormData(formData, callback) {

--- a/powerauth-webflow/src/main/js/actions/tokenAuthOnlineActions.js
+++ b/powerauth-webflow/src/main/js/actions/tokenAuthOnlineActions.js
@@ -98,7 +98,8 @@ export function authenticateOnline(callback) {
                     dispatchAction(dispatch, response);
                     break;
                 }
-                case 'CANCELED': {
+                case 'CANCELED':
+                case 'AUTH_METHOD_FAILED': {
                     dispatch({
                         type: "SHOW_SCREEN_ERROR",
                         payload: {

--- a/powerauth-webflow/src/main/resources/application.properties
+++ b/powerauth-webflow/src/main/resources/application.properties
@@ -59,6 +59,9 @@ powerauth.webflow.service.applicationEnvironment=
 # Configuration of Offline Mode
 powerauth.webflow.offlineMode.available=true
 
+# Enable or disable operations support in PowerAuth server
+powerauth.webflow.pa.operations.enabled=false
+
 # Configuration of Android Security Warning
 powerauth.webflow.android.showSecurityWarning=true
 


### PR DESCRIPTION
This pull request integrates PowerAuth operations into Next Step and Web Flow:
- PA operation support is optional, it needs to be enabled in Next Step and Web Flow
- choice of `POWERAUTH_TOKEN` method or mobile token status change in SCA methods triggers creating a new PowerAuth operation
- PA operation ID is stored in operation history
- pending operations are checked for expiration in PA server and expiration time is updated if needed, polling triggered by Web Flow polling is used, callbacks are not provided by PA server yet
- Web Flow mobile API endpoints handle approval, fail approval, and reject requests
- mobile token offline mode also handles PA operation updates
- operations canceled in Web Flow by the user trigger PA operation rejection
- canceled operations due to other reasons (e.g. browser window closed, unexpected errors) trigger a cancel request
- when PA operation calls fail, Next Step operation is failed
- when PA operations expire, Next Step operations are canceled

I suggest we keep PA operations disabled by default in Next Step and Web Flow for this release, because:
- frequent polling for expiration consumes resources of PA server
- mobile token application is not fully ready for custom number of attempts in PA operation
- we need to test this feature properly, it complicates Next Step and Web Flow states