### PR TITLE
Fix #964: Provide GET alternatives in Next Step REST API

### DIFF
--- a/powerauth-nextstep-client/src/main/java/io/getlime/security/powerauth/lib/nextstep/client/NextStepClient.java
+++ b/powerauth-nextstep-client/src/main/java/io/getlime/security/powerauth/lib/nextstep/client/NextStepClient.java
@@ -773,7 +773,9 @@ public class NextStepClient {
      */
     public ObjectResponse<GetUserAuthMethodsResponse> getAuthMethodsForUser(String userId) throws NextStepClientException {
         final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.put("userId", Collections.singletonList(userId));
+        if (userId != null) {
+            params.put("userId", Collections.singletonList(userId));
+        }
         return getObjectImpl("/user/auth-method", params, GetUserAuthMethodsResponse.class);
     }
 
@@ -1456,19 +1458,6 @@ public class NextStepClient {
      * Get user detail.
      *
      * @param userId User ID.
-     * @return Get user detail response.
-     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
-     */
-    public ObjectResponse<GetUserDetailResponse> getUserDetail(@NotNull String userId) throws NextStepClientException {
-        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.put("userId", Collections.singletonList(userId));
-        return getObjectImpl("/user/detail", params, GetUserDetailResponse.class);
-    }
-
-    /**
-     * Get user detail with includeRemoved option.
-     *
-     * @param userId User ID.
      * @param includeRemoved Whether removed user identities should be returned.
      * @return Get user detail response.
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
@@ -1482,19 +1471,6 @@ public class NextStepClient {
 
     /**
      * Get user detail using POST method.
-     *
-     * @param userId User ID.
-     * @return Get user detail response.
-     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
-     */
-    public ObjectResponse<GetUserDetailResponse> getUserDetailPost(@NotNull String userId) throws NextStepClientException {
-        GetUserDetailRequest request = new GetUserDetailRequest();
-        request.setUserId(userId);
-        return postObjectImpl("/user/detail", new ObjectRequest<>(request), GetUserDetailResponse.class);
-    }
-
-    /**
-     * Get user detail using POST method with includeRemoved option.
      *
      * @param userId User ID.
      * @param includeRemoved Whether removed user identities should be returned.
@@ -1805,7 +1781,7 @@ public class NextStepClient {
      */
     public ObjectResponse<GetUserAliasListResponse> getUserAliasList(@NotNull String userId, boolean includeRemoved) throws NextStepClientException {
         final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.put("userId", Collections.singletonList(String.valueOf(includeRemoved)));
+        params.put("userId", Collections.singletonList(userId));
         params.put("includeRemoved", Collections.singletonList(String.valueOf(includeRemoved)));
         return getObjectImpl("/user/alias", params, GetUserAliasListResponse.class);
     }
@@ -2233,8 +2209,12 @@ public class NextStepClient {
      */
     public ObjectResponse<GetOtpDetailResponse> getOtpDetail(String otpId, String operationId) throws NextStepClientException {
         final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.put("otpId", Collections.singletonList(otpId));
-        params.put("operationId", Collections.singletonList(operationId));
+        if (otpId != null) {
+            params.put("otpId", Collections.singletonList(otpId));
+        }
+        if (operationId != null) {
+            params.put("operationId", Collections.singletonList(operationId));
+        }
         return getObjectImpl("/otp/detail", params, GetOtpDetailResponse.class);
     }
 

--- a/powerauth-nextstep-client/src/main/java/io/getlime/security/powerauth/lib/nextstep/client/NextStepClient.java
+++ b/powerauth-nextstep-client/src/main/java/io/getlime/security/powerauth/lib/nextstep/client/NextStepClient.java
@@ -143,7 +143,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<CreateOperationResponse> createOperation(@NotNull String operationName, String operationId, @NotNull String operationData, String organizationId, String externalTransactionId, OperationFormData formData, List<KeyValueParameter> params, ApplicationContext applicationContext) throws NextStepClientException {
-        CreateOperationRequest request = new CreateOperationRequest();
+        final CreateOperationRequest request = new CreateOperationRequest();
         request.setOperationName(operationName);
         request.setOperationId(operationId);
         request.setOperationData(operationData);
@@ -189,7 +189,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<UpdateOperationResponse> updateOperation(@NotNull String operationId, String userId, String organizationId, @NotNull AuthMethod authMethod, List<AuthInstrument> authInstruments, @NotNull AuthStepResult authStepResult, String authStepResultDescription, List<KeyValueParameter> params, ApplicationContext applicationContext) throws NextStepClientException {
-        UpdateOperationRequest request = new UpdateOperationRequest();
+        final UpdateOperationRequest request = new UpdateOperationRequest();
         request.setOperationId(operationId);
         request.setUserId(userId);
         request.setOrganizationId(organizationId);
@@ -220,7 +220,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<UpdateOperationResponse> updateOperationPost(@NotNull String operationId, String userId, String organizationId, @NotNull AuthMethod authMethod, List<AuthInstrument> authInstruments, @NotNull AuthStepResult authStepResult, String authStepResultDescription, List<KeyValueParameter> params, ApplicationContext applicationContext) throws NextStepClientException {
-        UpdateOperationRequest request = new UpdateOperationRequest();
+        final UpdateOperationRequest request = new UpdateOperationRequest();
         request.setOperationId(operationId);
         request.setUserId(userId);
         request.setOrganizationId(organizationId);
@@ -246,7 +246,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public Response updateOperationUser(@NotNull String operationId, @NotNull String userId, String organizationId, UserAccountStatus accountStatus) throws NextStepClientException {
-        UpdateOperationUserRequest request = new UpdateOperationUserRequest();
+        final UpdateOperationUserRequest request = new UpdateOperationUserRequest();
         request.setOperationId(operationId);
         request.setUserId(userId);
         request.setOrganizationId(organizationId);
@@ -265,7 +265,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public Response updateOperationUserPost(@NotNull String operationId, @NotNull String userId, String organizationId, UserAccountStatus accountStatus) throws NextStepClientException {
-        UpdateOperationUserRequest request = new UpdateOperationUserRequest();
+        final UpdateOperationUserRequest request = new UpdateOperationUserRequest();
         request.setOperationId(operationId);
         request.setUserId(userId);
         request.setOrganizationId(organizationId);
@@ -282,7 +282,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public Response updateOperationFormData(@NotNull String operationId, @NotNull OperationFormData formData) throws NextStepClientException {
-        UpdateFormDataRequest request = new UpdateFormDataRequest();
+        final UpdateFormDataRequest request = new UpdateFormDataRequest();
         request.setOperationId(operationId);
         request.setFormData(formData);
         return putObjectImpl("/operation/formData", new ObjectRequest<>(request));
@@ -297,7 +297,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public Response updateOperationFormDataPost(@NotNull String operationId, @NotNull OperationFormData formData) throws NextStepClientException {
-        UpdateFormDataRequest request = new UpdateFormDataRequest();
+        final UpdateFormDataRequest request = new UpdateFormDataRequest();
         request.setOperationId(operationId);
         request.setFormData(formData);
         return postObjectImpl("/operation/formData/update", new ObjectRequest<>(request));
@@ -312,7 +312,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public Response updateChosenAuthMethod(@NotNull String operationId, @NotNull AuthMethod chosenAuthMethod) throws NextStepClientException {
-        UpdateChosenAuthMethodRequest request = new UpdateChosenAuthMethodRequest();
+        final UpdateChosenAuthMethodRequest request = new UpdateChosenAuthMethodRequest();
         request.setOperationId(operationId);
         request.setChosenAuthMethod(chosenAuthMethod);
         return putObjectImpl("/operation/chosenAuthMethod", new ObjectRequest<>(request));
@@ -327,7 +327,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public Response updateChosenAuthMethodPost(@NotNull String operationId, @NotNull AuthMethod chosenAuthMethod) throws NextStepClientException {
-        UpdateChosenAuthMethodRequest request = new UpdateChosenAuthMethodRequest();
+        final UpdateChosenAuthMethodRequest request = new UpdateChosenAuthMethodRequest();
         request.setOperationId(operationId);
         request.setChosenAuthMethod(chosenAuthMethod);
         return postObjectImpl("/operation/chosenAuthMethod/update", new ObjectRequest<>(request));
@@ -342,7 +342,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public Response updateApplicationContext(@NotNull String operationId, @NotNull ApplicationContext applicationContext) throws NextStepClientException {
-        UpdateApplicationContextRequest request = new UpdateApplicationContextRequest();
+        final UpdateApplicationContextRequest request = new UpdateApplicationContextRequest();
         request.setOperationId(operationId);
         request.setApplicationContext(applicationContext);
         return putObjectImpl("/operation/application", new ObjectRequest<>(request));
@@ -357,7 +357,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public Response updateApplicationContextPost(@NotNull String operationId, @NotNull ApplicationContext applicationContext) throws NextStepClientException {
-        UpdateApplicationContextRequest request = new UpdateApplicationContextRequest();
+        final UpdateApplicationContextRequest request = new UpdateApplicationContextRequest();
         request.setOperationId(operationId);
         request.setApplicationContext(applicationContext);
         return postObjectImpl("/operation/application/update", new ObjectRequest<>(request));
@@ -372,7 +372,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public Response updateMobileToken(@NotNull String operationId, boolean mobileTokenActive) throws NextStepClientException {
-        UpdateMobileTokenRequest request = new UpdateMobileTokenRequest();
+        final UpdateMobileTokenRequest request = new UpdateMobileTokenRequest();
         request.setOperationId(operationId);
         request.setMobileTokenActive(mobileTokenActive);
         return putObjectImpl("/operation/mobileToken/status", new ObjectRequest<>(request));
@@ -387,7 +387,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public Response updateMobileTokenPost(@NotNull String operationId, boolean mobileTokenActive) throws NextStepClientException {
-        UpdateMobileTokenRequest request = new UpdateMobileTokenRequest();
+        final UpdateMobileTokenRequest request = new UpdateMobileTokenRequest();
         request.setOperationId(operationId);
         request.setMobileTokenActive(mobileTokenActive);
         return postObjectImpl("/operation/mobileToken/status/update", new ObjectRequest<>(request));
@@ -422,7 +422,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetMobileTokenConfigResponse> getMobileTokenConfigPost(@NotNull String userId, @NotNull String operationName, @NotNull AuthMethod authMethod) throws NextStepClientException {
-        GetMobileTokenConfigRequest request = new GetMobileTokenConfigRequest();
+        final GetMobileTokenConfigRequest request = new GetMobileTokenConfigRequest();
         request.setUserId(userId);
         request.setOperationName(operationName);
         request.setAuthMethod(authMethod);
@@ -450,7 +450,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetOperationDetailResponse> getOperationDetailPost(@NotNull String operationId) throws NextStepClientException {
-        GetOperationDetailRequest request = new GetOperationDetailRequest();
+        final GetOperationDetailRequest request = new GetOperationDetailRequest();
         request.setOperationId(operationId);
         return postObjectImpl("/operation/detail", new ObjectRequest<>(request), GetOperationDetailResponse.class);
     }
@@ -463,7 +463,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<LookupOperationsByExternalIdResponse> lookupOperationByExternalTransactionId(@NotNull String externalTransactionId) throws NextStepClientException {
-        LookupOperationsByExternalIdRequest request = new LookupOperationsByExternalIdRequest();
+        final LookupOperationsByExternalIdRequest request = new LookupOperationsByExternalIdRequest();
         request.setExternalTransactionId(externalTransactionId);
         return postObjectImpl("/operation/lookup/external", new ObjectRequest<>(request), LookupOperationsByExternalIdResponse.class);
     }
@@ -483,7 +483,7 @@ public class NextStepClient {
      */
     public Response createAfsAction(@NotNull String operationId, @NotNull String afsAction, int stepIndex, String requestAfsExtras, String afsLabel,
                                     boolean afsResponseApplied, String responseAfsExtras) throws NextStepClientException {
-        CreateAfsActionRequest request = new CreateAfsActionRequest();
+        final CreateAfsActionRequest request = new CreateAfsActionRequest();
         request.setOperationId(operationId);
         request.setAfsAction(afsAction);
         request.setStepIndex(stepIndex);
@@ -527,7 +527,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetOperationConfigDetailResponse> getOperationConfigDetailPost(@NotNull String operationName) throws NextStepClientException {
-        GetOperationConfigDetailRequest request = new GetOperationConfigDetailRequest();
+        final GetOperationConfigDetailRequest request = new GetOperationConfigDetailRequest();
         request.setOperationName(operationName);
         return postObjectImpl("/operation/config/detail", new ObjectRequest<>(request), GetOperationConfigDetailResponse.class);
     }
@@ -549,7 +549,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetOperationConfigListResponse> getOperationConfigListPost() throws NextStepClientException {
-        GetOperationConfigListRequest request = new GetOperationConfigListRequest();
+        final GetOperationConfigListRequest request = new GetOperationConfigListRequest();
         return postObjectImpl("/operation/config/list", new ObjectRequest<>(request), GetOperationConfigListResponse.class);
     }
 
@@ -561,7 +561,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<DeleteOperationConfigResponse> deleteOperationConfig(@NotNull String operationName) throws NextStepClientException {
-        DeleteOperationConfigRequest request = new DeleteOperationConfigRequest();
+        final DeleteOperationConfigRequest request = new DeleteOperationConfigRequest();
         request.setOperationName(operationName);
         return postObjectImpl("/operation/config/delete", new ObjectRequest<>(request), DeleteOperationConfigResponse.class);
     }
@@ -601,7 +601,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<List<GetOperationDetailResponse>> getPendingOperationsPost(@NotNull String userId, boolean mobileTokenOnly) throws NextStepClientException {
-        GetPendingOperationsRequest request = new GetPendingOperationsRequest();
+        final GetPendingOperationsRequest request = new GetPendingOperationsRequest();
         request.setUserId(userId);
         request.setMobileTokenOnly(mobileTokenOnly);
         return postImpl("/user/operation/list", new ObjectRequest<>(request), new ParameterizedTypeReference<ObjectResponse<List<GetOperationDetailResponse>>>() {});
@@ -621,7 +621,7 @@ public class NextStepClient {
      */
     public ObjectResponse<CreateOrganizationResponse> createOrganization(@NotNull String organizationId, String displayNameKey,
                                                                          boolean isDefault, @NotNull Integer orderNumber) throws NextStepClientException {
-        CreateOrganizationRequest request = new CreateOrganizationRequest();
+        final CreateOrganizationRequest request = new CreateOrganizationRequest();
         request.setOrganizationId(organizationId);
         request.setDisplayNameKey(displayNameKey);
         request.setDefault(isDefault);
@@ -650,7 +650,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetOrganizationDetailResponse> getOrganizationDetailPost(@NotNull String organizationId) throws NextStepClientException {
-        GetOrganizationDetailRequest request = new GetOrganizationDetailRequest();
+        final GetOrganizationDetailRequest request = new GetOrganizationDetailRequest();
         request.setOrganizationId(organizationId);
         return postObjectImpl("/organization/detail", new ObjectRequest<>(request), GetOrganizationDetailResponse.class);
     }
@@ -672,7 +672,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetOrganizationListResponse> getOrganizationListPost() throws NextStepClientException {
-        GetOrganizationListRequest request = new GetOrganizationListRequest();
+        final GetOrganizationListRequest request = new GetOrganizationListRequest();
         return postObjectImpl("/organization/list", new ObjectRequest<>(request), GetOrganizationListResponse.class);
     }
 
@@ -684,7 +684,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<DeleteOrganizationResponse> deleteOrganization(@NotNull String organizationId) throws NextStepClientException {
-        DeleteOrganizationRequest request = new DeleteOrganizationRequest();
+        final DeleteOrganizationRequest request = new DeleteOrganizationRequest();
         request.setOrganizationId(organizationId);
         return postObjectImpl("/organization/delete", new ObjectRequest<>(request), DeleteOrganizationResponse.class);
     }
@@ -710,7 +710,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<DeleteStepDefinitionResponse> deleteStepDefinition(long stepDefinitionId) throws NextStepClientException {
-        DeleteStepDefinitionRequest request = new DeleteStepDefinitionRequest();
+        final DeleteStepDefinitionRequest request = new DeleteStepDefinitionRequest();
         request.setStepDefinitionId(stepDefinitionId);
         return postObjectImpl("/step/definition/delete", new ObjectRequest<>(request), DeleteStepDefinitionResponse.class);
     }
@@ -746,7 +746,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetAuthMethodsResponse> getAuthMethodListPost() throws NextStepClientException {
-        GetAuthMethodListRequest request = new GetAuthMethodListRequest();
+        final GetAuthMethodListRequest request = new GetAuthMethodListRequest();
         return postObjectImpl("/auth-method/list", new ObjectRequest<>(request), GetAuthMethodsResponse.class);
     }
 
@@ -758,7 +758,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<DeleteAuthMethodResponse> deleteAuthMethod(AuthMethod authMethod) throws NextStepClientException {
-        DeleteAuthMethodRequest request = new DeleteAuthMethodRequest();
+        final DeleteAuthMethodRequest request = new DeleteAuthMethodRequest();
         request.setAuthMethod(authMethod);
         return postObjectImpl("/auth-method/delete", new ObjectRequest<>(request), DeleteAuthMethodResponse.class);
     }
@@ -788,7 +788,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetUserAuthMethodsResponse> getAuthMethodsForUserPost(String userId) throws NextStepClientException {
-        GetUserAuthMethodsRequest request = new GetUserAuthMethodsRequest();
+        final GetUserAuthMethodsRequest request = new GetUserAuthMethodsRequest();
         request.setUserId(userId);
         return postObjectImpl("/user/auth-method/list", new ObjectRequest<>(request), GetUserAuthMethodsResponse.class);
     }
@@ -821,7 +821,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetEnabledMethodListResponse> getAuthMethodsEnabledForUserPost(@NotNull String userId, @NotNull String operationName) throws NextStepClientException {
-        GetEnabledMethodListRequest request = new GetEnabledMethodListRequest();
+        final GetEnabledMethodListRequest request = new GetEnabledMethodListRequest();
         request.setUserId(userId);
         request.setOperationName(operationName);
         return postObjectImpl("/user/auth-method/enabled/list", new ObjectRequest<>(request), GetEnabledMethodListResponse.class);
@@ -837,7 +837,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetAuthMethodsResponse> enableAuthMethodForUser(@NotNull String userId, @NotNull AuthMethod authMethod, Map<String, String> config) throws NextStepClientException {
-        UpdateAuthMethodRequest request = new UpdateAuthMethodRequest();
+        final UpdateAuthMethodRequest request = new UpdateAuthMethodRequest();
         request.setUserId(userId);
         request.setAuthMethod(authMethod);
         if (config != null) {
@@ -856,7 +856,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetAuthMethodsResponse> disableAuthMethodForUser(@NotNull String userId, @NotNull AuthMethod authMethod, Map<String, String> config) throws NextStepClientException {
-        UpdateAuthMethodRequest request = new UpdateAuthMethodRequest();
+        final UpdateAuthMethodRequest request = new UpdateAuthMethodRequest();
         request.setUserId(userId);
         request.setAuthMethod(authMethod);
         if (config != null) {
@@ -876,7 +876,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<CreateApplicationResponse> createApplication(@NotNull String applicationName, String description) throws NextStepClientException {
-        CreateApplicationRequest request = new CreateApplicationRequest();
+        final CreateApplicationRequest request = new CreateApplicationRequest();
         request.setApplicationName(applicationName);
         request.setDescription(description);
         return postObjectImpl("/application", new ObjectRequest<>(request), CreateApplicationResponse.class);
@@ -892,7 +892,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<UpdateApplicationResponse> updateApplication(@NotNull String applicationName, String description, ApplicationStatus status) throws NextStepClientException {
-        UpdateApplicationRequest request = new UpdateApplicationRequest();
+        final UpdateApplicationRequest request = new UpdateApplicationRequest();
         request.setApplicationName(applicationName);
         request.setDescription(description);
         request.setApplicationStatus(status);
@@ -909,7 +909,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<UpdateApplicationResponse> updateApplicationPost(@NotNull String applicationName, String description, ApplicationStatus status) throws NextStepClientException {
-        UpdateApplicationRequest request = new UpdateApplicationRequest();
+        final UpdateApplicationRequest request = new UpdateApplicationRequest();
         request.setApplicationName(applicationName);
         request.setDescription(description);
         request.setApplicationStatus(status);
@@ -937,7 +937,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetApplicationListResponse> getApplicationListPost(boolean includeRemoved) throws NextStepClientException {
-        GetApplicationListRequest request = new GetApplicationListRequest();
+        final GetApplicationListRequest request = new GetApplicationListRequest();
         request.setIncludeRemoved(includeRemoved);
         return postObjectImpl("/application/list", new ObjectRequest<>(request), GetApplicationListResponse.class);
     }
@@ -950,7 +950,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<DeleteApplicationResponse> deleteApplication(@NotNull String applicationName) throws NextStepClientException {
-        DeleteApplicationRequest request = new DeleteApplicationRequest();
+        final DeleteApplicationRequest request = new DeleteApplicationRequest();
         request.setApplicationName(applicationName);
         return postObjectImpl("/application/delete", new ObjectRequest<>(request), DeleteApplicationResponse.class);
     }
@@ -966,7 +966,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<CreateRoleResponse> createRole(@NotNull String roleName, String description) throws NextStepClientException {
-        CreateRoleRequest request = new CreateRoleRequest();
+        final CreateRoleRequest request = new CreateRoleRequest();
         request.setRoleName(roleName);
         request.setDescription(description);
         return postObjectImpl("/role", new ObjectRequest<>(request), CreateRoleResponse.class);
@@ -989,7 +989,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetRoleListResponse> getRoleListPost() throws NextStepClientException {
-        GetRoleListRequest request = new GetRoleListRequest();
+        final GetRoleListRequest request = new GetRoleListRequest();
         return postObjectImpl("/role/list", new ObjectRequest<>(request), GetRoleListResponse.class);
     }
 
@@ -1001,7 +1001,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<DeleteRoleResponse> deleteRole(@NotNull String roleName) throws NextStepClientException {
-        DeleteRoleRequest request = new DeleteRoleRequest();
+        final DeleteRoleRequest request = new DeleteRoleRequest();
         request.setRoleName(roleName);
         return postObjectImpl("/role/delete", new ObjectRequest<>(request), DeleteRoleResponse.class);
     }
@@ -1018,7 +1018,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<CreateHashConfigResponse> createHashConfig(@NotNull String hashConfigName, @NotNull HashAlgorithm algorithm, Map<String, String> parameters) throws NextStepClientException {
-        CreateHashConfigRequest request = new CreateHashConfigRequest();
+        final CreateHashConfigRequest request = new CreateHashConfigRequest();
         request.setHashConfigName(hashConfigName);
         request.setAlgorithm(algorithm);
         if (parameters != null) {
@@ -1038,7 +1038,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<UpdateHashConfigResponse> updateHashConfig(@NotNull String hashConfigName, @NotNull HashAlgorithm algorithm, Map<String, String> parameters, HashConfigStatus status) throws NextStepClientException {
-        UpdateHashConfigRequest request = new UpdateHashConfigRequest();
+        final UpdateHashConfigRequest request = new UpdateHashConfigRequest();
         request.setHashConfigName(hashConfigName);
         request.setAlgorithm(algorithm);
         if (parameters != null) {
@@ -1059,7 +1059,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<UpdateHashConfigResponse> updateHashConfigPost(@NotNull String hashConfigName, @NotNull HashAlgorithm algorithm, Map<String, String> parameters, HashConfigStatus status) throws NextStepClientException {
-        UpdateHashConfigRequest request = new UpdateHashConfigRequest();
+        final UpdateHashConfigRequest request = new UpdateHashConfigRequest();
         request.setHashConfigName(hashConfigName);
         request.setAlgorithm(algorithm);
         if (parameters != null) {
@@ -1090,7 +1090,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetHashConfigListResponse> getHashConfigListPost(boolean includeRemoved) throws NextStepClientException {
-        GetHashConfigListRequest request = new GetHashConfigListRequest();
+        final GetHashConfigListRequest request = new GetHashConfigListRequest();
         request.setIncludeRemoved(includeRemoved);
         return postObjectImpl("/hashconfig/list", new ObjectRequest<>(request), GetHashConfigListResponse.class);
     }
@@ -1103,7 +1103,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<DeleteHashConfigResponse> deleteHashConfig(@NotNull String hashConfigName) throws NextStepClientException {
-        DeleteHashConfigRequest request = new DeleteHashConfigRequest();
+        final DeleteHashConfigRequest request = new DeleteHashConfigRequest();
         request.setHashConfigName(hashConfigName);
         return postObjectImpl("/hashconfig/delete", new ObjectRequest<>(request), DeleteHashConfigResponse.class);
     }
@@ -1164,7 +1164,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetCredentialPolicyListResponse> getCredentialPolicyListPost(boolean includeRemoved) throws NextStepClientException {
-        GetCredentialPolicyListRequest request = new GetCredentialPolicyListRequest();
+        final GetCredentialPolicyListRequest request = new GetCredentialPolicyListRequest();
         request.setIncludeRemoved(includeRemoved);
         return postObjectImpl("/credential/policy/list", new ObjectRequest<>(request), GetCredentialPolicyListResponse.class);
     }
@@ -1177,7 +1177,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<DeleteCredentialPolicyResponse> deleteCredentialPolicy(@NotNull String credentialPolicyName) throws NextStepClientException {
-        DeleteCredentialPolicyRequest request = new DeleteCredentialPolicyRequest();
+        final DeleteCredentialPolicyRequest request = new DeleteCredentialPolicyRequest();
         request.setCredentialPolicyName(credentialPolicyName);
         return postObjectImpl("/credential/policy/delete", new ObjectRequest<>(request), DeleteCredentialPolicyResponse.class);
     }
@@ -1238,7 +1238,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetCredentialDefinitionListResponse> getCredentialDefinitionListPost(boolean includeRemoved) throws NextStepClientException {
-        GetCredentialDefinitionListRequest request = new GetCredentialDefinitionListRequest();
+        final GetCredentialDefinitionListRequest request = new GetCredentialDefinitionListRequest();
         request.setIncludeRemoved(includeRemoved);
         return postObjectImpl("/credential/definition/list", new ObjectRequest<>(request), GetCredentialDefinitionListResponse.class);
     }
@@ -1251,7 +1251,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<DeleteCredentialDefinitionResponse> deleteCredentialDefinition(@NotNull String credentialDefinitionName) throws NextStepClientException {
-        DeleteCredentialDefinitionRequest request = new DeleteCredentialDefinitionRequest();
+        final DeleteCredentialDefinitionRequest request = new DeleteCredentialDefinitionRequest();
         request.setCredentialDefinitionName(credentialDefinitionName);
         return postObjectImpl("/credential/definition/delete", new ObjectRequest<>(request), DeleteCredentialDefinitionResponse.class);
     }
@@ -1312,7 +1312,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetOtpPolicyListResponse> getOtpPolicyListPost(boolean includeRemoved) throws NextStepClientException {
-        GetOtpPolicyListRequest request = new GetOtpPolicyListRequest();
+        final GetOtpPolicyListRequest request = new GetOtpPolicyListRequest();
         request.setIncludeRemoved(includeRemoved);
         return postObjectImpl("/otp/policy/list", new ObjectRequest<>(request), GetOtpPolicyListResponse.class);
     }
@@ -1325,7 +1325,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<DeleteOtpPolicyResponse> deleteOtpPolicy(@NotNull String otpPolicyName) throws NextStepClientException {
-        DeleteOtpPolicyRequest request = new DeleteOtpPolicyRequest();
+        final DeleteOtpPolicyRequest request = new DeleteOtpPolicyRequest();
         request.setOtpPolicyName(otpPolicyName);
         return postObjectImpl("/otp/policy/delete", new ObjectRequest<>(request), DeleteOtpPolicyResponse.class);
     }
@@ -1386,7 +1386,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetOtpDefinitionListResponse> getOtpDefinitionListPost(boolean includeRemoved) throws NextStepClientException {
-        GetOtpDefinitionListRequest request = new GetOtpDefinitionListRequest();
+        final GetOtpDefinitionListRequest request = new GetOtpDefinitionListRequest();
         request.setIncludeRemoved(includeRemoved);
         return postObjectImpl("/otp/definition/list", new ObjectRequest<>(request), GetOtpDefinitionListResponse.class);
     }
@@ -1399,7 +1399,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<DeleteOtpDefinitionResponse> deleteOtpDefinition(@NotNull String otpDefinitionName) throws NextStepClientException {
-        DeleteOtpDefinitionRequest request = new DeleteOtpDefinitionRequest();
+        final DeleteOtpDefinitionRequest request = new DeleteOtpDefinitionRequest();
         request.setOtpDefinitionName(otpDefinitionName);
         return postObjectImpl("/otp/definition/delete", new ObjectRequest<>(request), DeleteOtpDefinitionResponse.class);
     }
@@ -1448,7 +1448,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<UpdateUsersResponse> updateUsers(@NotNull List<String> userIds, @NotNull UserIdentityStatus status) throws NextStepClientException {
-        UpdateUsersRequest request = new UpdateUsersRequest();
+        final UpdateUsersRequest request = new UpdateUsersRequest();
         request.getUserIds().addAll(userIds);
         request.setUserIdentityStatus(status);
         return postObjectImpl("/user/update/multi", new ObjectRequest<>(request), UpdateUsersResponse.class);
@@ -1478,7 +1478,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetUserDetailResponse> getUserDetailPost(@NotNull String userId, boolean includeRemoved) throws NextStepClientException {
-        GetUserDetailRequest request = new GetUserDetailRequest();
+        final GetUserDetailRequest request = new GetUserDetailRequest();
         request.setUserId(userId);
         request.setIncludeRemoved(includeRemoved);
         return postObjectImpl("/user/detail", new ObjectRequest<>(request), GetUserDetailResponse.class);
@@ -1504,7 +1504,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<LookupUserResponse> lookupUser(@NotNull String username, @NotNull String credentialName) throws NextStepClientException {
-        LookupUserRequest request = new LookupUserRequest();
+        final LookupUserRequest request = new LookupUserRequest();
         request.setUsername(username);
         request.setCredentialName(credentialName);
         return postObjectImpl("/user/lookup/single", new ObjectRequest<>(request), LookupUserResponse.class);
@@ -1520,7 +1520,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<LookupUserResponse> lookupUser(@NotNull String username, @NotNull String credentialName, String operationId) throws NextStepClientException {
-        LookupUserRequest request = new LookupUserRequest();
+        final LookupUserRequest request = new LookupUserRequest();
         request.setUsername(username);
         request.setCredentialName(credentialName);
         request.setOperationId(operationId);
@@ -1535,7 +1535,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<BlockUserResponse> blockUser(@NotNull String userId) throws NextStepClientException {
-        BlockUserRequest request = new BlockUserRequest();
+        final BlockUserRequest request = new BlockUserRequest();
         request.setUserId(userId);
         return postObjectImpl("/user/block", new ObjectRequest<>(request), BlockUserResponse.class);
     }
@@ -1548,7 +1548,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<UnblockUserResponse> unblockUser(@NotNull String userId) throws NextStepClientException {
-        UnblockUserRequest request = new UnblockUserRequest();
+        final UnblockUserRequest request = new UnblockUserRequest();
         request.setUserId(userId);
         return postObjectImpl("/user/unblock", new ObjectRequest<>(request), UnblockUserResponse.class);
     }
@@ -1561,7 +1561,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<DeleteUserResponse> deleteUser(@NotNull String userId) throws NextStepClientException {
-        DeleteUserRequest request = new DeleteUserRequest();
+        final DeleteUserRequest request = new DeleteUserRequest();
         request.setUserId(userId);
         return postObjectImpl("/user/delete", new ObjectRequest<>(request), DeleteUserResponse.class);
     }
@@ -1575,7 +1575,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<AddUserRoleResponse> addUserRole(@NotNull String userId, @NotNull String roleName) throws NextStepClientException {
-        AddUserRoleRequest request = new AddUserRoleRequest();
+        final AddUserRoleRequest request = new AddUserRoleRequest();
         request.setUserId(userId);
         request.setRoleName(roleName);
         return postObjectImpl("/user/role", new ObjectRequest<>(request), AddUserRoleResponse.class);
@@ -1590,7 +1590,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<RemoveUserRoleResponse> removeUserRole(@NotNull String userId, @NotNull String roleName) throws NextStepClientException {
-        RemoveUserRoleRequest request = new RemoveUserRoleRequest();
+        final RemoveUserRoleRequest request = new RemoveUserRoleRequest();
         request.setUserId(userId);
         request.setRoleName(roleName);
         return postObjectImpl("/user/role/remove", new ObjectRequest<>(request), RemoveUserRoleResponse.class);
@@ -1609,7 +1609,7 @@ public class NextStepClient {
      */
     public ObjectResponse<CreateUserContactResponse> createUserContact(@NotNull String userId, @NotNull String contactName, @NotNull ContactType contactType,
                                                                        @NotNull String contactValue, boolean primary) throws NextStepClientException {
-        CreateUserContactRequest request = new CreateUserContactRequest();
+        final CreateUserContactRequest request = new CreateUserContactRequest();
         request.setUserId(userId);
         request.setContactName(contactName);
         request.setContactType(contactType);
@@ -1631,7 +1631,7 @@ public class NextStepClient {
      */
     public ObjectResponse<UpdateUserContactResponse> updateUserContact(@NotNull String userId, @NotNull String contactName, @NotNull ContactType contactType,
                                                                        @NotNull String contactValue, boolean primary) throws NextStepClientException {
-        UpdateUserContactRequest request = new UpdateUserContactRequest();
+        final UpdateUserContactRequest request = new UpdateUserContactRequest();
         request.setUserId(userId);
         request.setContactName(contactName);
         request.setContactType(contactType);
@@ -1653,7 +1653,7 @@ public class NextStepClient {
      */
     public ObjectResponse<UpdateUserContactResponse> updateUserContactPost(@NotNull String userId, @NotNull String contactName, @NotNull ContactType contactType,
                                                                            @NotNull String contactValue, boolean primary) throws NextStepClientException {
-        UpdateUserContactRequest request = new UpdateUserContactRequest();
+        final UpdateUserContactRequest request = new UpdateUserContactRequest();
         request.setUserId(userId);
         request.setContactName(contactName);
         request.setContactType(contactType);
@@ -1683,7 +1683,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetUserContactListResponse> getUserContactListPost(@NotNull String userId) throws NextStepClientException {
-        GetUserContactListRequest request = new GetUserContactListRequest();
+        final GetUserContactListRequest request = new GetUserContactListRequest();
         request.setUserId(userId);
         return postObjectImpl("/user/contact/list", new ObjectRequest<>(request), GetUserContactListResponse.class);
     }
@@ -1698,7 +1698,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<DeleteUserContactResponse> deleteUserContact(@NotNull String userId, @NotNull String contactName, @NotNull ContactType contactType) throws NextStepClientException {
-        DeleteUserContactRequest request = new DeleteUserContactRequest();
+        final DeleteUserContactRequest request = new DeleteUserContactRequest();
         request.setUserId(userId);
         request.setContactName(contactName);
         request.setContactType(contactType);
@@ -1717,7 +1717,7 @@ public class NextStepClient {
      */
     public ObjectResponse<CreateUserAliasResponse> createUserAlias(@NotNull String userId, @NotNull String aliasName, @NotNull String aliasValue,
                                                                    Map<String, Object> extras) throws NextStepClientException {
-        CreateUserAliasRequest request = new CreateUserAliasRequest();
+        final CreateUserAliasRequest request = new CreateUserAliasRequest();
         request.setUserId(userId);
         request.setAliasName(aliasName);
         request.setAliasValue(aliasValue);
@@ -1739,7 +1739,7 @@ public class NextStepClient {
      */
     public ObjectResponse<UpdateUserAliasResponse> updateUserAlias(@NotNull String userId, @NotNull String aliasName, @NotNull String aliasValue,
                                                                    Map<String, Object> extras) throws NextStepClientException {
-        UpdateUserAliasRequest request = new UpdateUserAliasRequest();
+        final UpdateUserAliasRequest request = new UpdateUserAliasRequest();
         request.setUserId(userId);
         request.setAliasName(aliasName);
         request.setAliasValue(aliasValue);
@@ -1761,7 +1761,7 @@ public class NextStepClient {
      */
     public ObjectResponse<UpdateUserAliasResponse> updateUserAliasPost(@NotNull String userId, @NotNull String aliasName, @NotNull String aliasValue,
                                                                        Map<String, Object> extras) throws NextStepClientException {
-        UpdateUserAliasRequest request = new UpdateUserAliasRequest();
+        final UpdateUserAliasRequest request = new UpdateUserAliasRequest();
         request.setUserId(userId);
         request.setAliasName(aliasName);
         request.setAliasValue(aliasValue);
@@ -1795,7 +1795,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetUserAliasListResponse> getUserAliasListPost(@NotNull String userId, boolean includeRemoved) throws NextStepClientException {
-        GetUserAliasListRequest request = new GetUserAliasListRequest();
+        final GetUserAliasListRequest request = new GetUserAliasListRequest();
         request.setUserId(userId);
         request.setIncludeRemoved(includeRemoved);
         return postObjectImpl("/user/alias/list", new ObjectRequest<>(request), GetUserAliasListResponse.class);
@@ -1810,7 +1810,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<DeleteUserAliasResponse> deleteUserAlias(@NotNull String userId, @NotNull String aliasName) throws NextStepClientException {
-        DeleteUserAliasRequest request = new DeleteUserAliasRequest();
+        final DeleteUserAliasRequest request = new DeleteUserAliasRequest();
         request.setUserId(userId);
         request.setAliasName(aliasName);
         return postObjectImpl("/user/alias/delete", new ObjectRequest<>(request), DeleteUserAliasResponse.class);
@@ -1840,7 +1840,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetUserCredentialListResponse> getUserCredentialListPost(@NotNull String userId, boolean includeRemoved) throws NextStepClientException {
-        GetUserCredentialListRequest request = new GetUserCredentialListRequest();
+        final GetUserCredentialListRequest request = new GetUserCredentialListRequest();
         request.setUserId(userId);
         request.setIncludeRemoved(includeRemoved);
         return postObjectImpl("/user/credential/list", new ObjectRequest<>(request), GetUserCredentialListResponse.class);
@@ -1877,7 +1877,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetUserAuthenticationListResponse> getUserAuthenticationListPost(@NotNull String userId, Date createdStartDate, Date createdEndDate) throws NextStepClientException {
-        GetUserAuthenticationListRequest request = new GetUserAuthenticationListRequest();
+        final GetUserAuthenticationListRequest request = new GetUserAuthenticationListRequest();
         request.setUserId(userId);
         request.setCreatedStartDate(createdStartDate);
         request.setCreatedEndDate(createdEndDate);
@@ -1899,7 +1899,7 @@ public class NextStepClient {
      */
     public ObjectResponse<CreateCredentialResponse> createCredential(@NotNull String userId, @NotNull String credentialName, @NotNull CredentialType credentialType,
                                                                      String username, String credentialValue) throws NextStepClientException {
-        CreateCredentialRequest request = new CreateCredentialRequest();
+        final CreateCredentialRequest request = new CreateCredentialRequest();
         request.setUserId(userId);
         request.setCredentialName(credentialName);
         request.setCredentialType(credentialType);
@@ -1924,7 +1924,7 @@ public class NextStepClient {
     public ObjectResponse<CreateCredentialResponse> createCredential(@NotNull String userId, @NotNull String credentialName, @NotNull CredentialType credentialType,
                                                                      String username, String credentialValue, CredentialValidationMode validationMode,
                                                                      List<KeyValueParameter> credentialHistory) throws NextStepClientException {
-        CreateCredentialRequest request = new CreateCredentialRequest();
+        final CreateCredentialRequest request = new CreateCredentialRequest();
         request.setUserId(userId);
         request.setCredentialName(credentialName);
         request.setCredentialType(credentialType);
@@ -1956,7 +1956,7 @@ public class NextStepClient {
      */
     public ObjectResponse<UpdateCredentialResponse> updateCredential(@NotNull String userId, @NotNull String credentialName, CredentialType credentialType,
                                                                      String username, String credentialValue, CredentialStatus credentialStatus) throws NextStepClientException {
-        UpdateCredentialRequest request = new UpdateCredentialRequest();
+        final UpdateCredentialRequest request = new UpdateCredentialRequest();
         request.setUserId(userId);
         request.setCredentialName(credentialName);
         request.setCredentialType(credentialType);
@@ -1980,7 +1980,7 @@ public class NextStepClient {
      */
     public ObjectResponse<UpdateCredentialResponse> updateCredentialPost(@NotNull String userId, @NotNull String credentialName, CredentialType credentialType,
                                                                          String username, String credentialValue, CredentialStatus credentialStatus) throws NextStepClientException {
-        UpdateCredentialRequest request = new UpdateCredentialRequest();
+        final UpdateCredentialRequest request = new UpdateCredentialRequest();
         request.setUserId(userId);
         request.setCredentialName(credentialName);
         request.setCredentialType(credentialType);
@@ -2003,7 +2003,7 @@ public class NextStepClient {
      */
     public ObjectResponse<ValidateCredentialResponse> validateCredential(@NotNull String userId, @NotNull String credentialName, String username,
                                                                          String credentialValue, @NotNull CredentialValidationMode validationMode) throws NextStepClientException {
-        ValidateCredentialRequest request = new ValidateCredentialRequest();
+        final ValidateCredentialRequest request = new ValidateCredentialRequest();
         request.setUserId(userId);
         request.setCredentialName(credentialName);
         request.setUsername(username);
@@ -2022,7 +2022,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<ResetCredentialResponse> resetCredential(@NotNull String userId, @NotNull String credentialName, CredentialType credentialType) throws NextStepClientException {
-        ResetCredentialRequest request = new ResetCredentialRequest();
+        final ResetCredentialRequest request = new ResetCredentialRequest();
         request.setUserId(userId);
         request.setCredentialName(credentialName);
         request.setCredentialType(credentialType);
@@ -2038,7 +2038,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<BlockCredentialResponse> blockCredential(@NotNull String userId, @NotNull String credentialName) throws NextStepClientException {
-        BlockCredentialRequest request = new BlockCredentialRequest();
+        final BlockCredentialRequest request = new BlockCredentialRequest();
         request.setUserId(userId);
         request.setCredentialName(credentialName);
         return postObjectImpl("/credential/block", new ObjectRequest<>(request), BlockCredentialResponse.class);
@@ -2053,7 +2053,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<UnblockCredentialResponse> unblockCredential(@NotNull String userId, @NotNull String credentialName) throws NextStepClientException {
-        UnblockCredentialRequest request = new UnblockCredentialRequest();
+        final UnblockCredentialRequest request = new UnblockCredentialRequest();
         request.setUserId(userId);
         request.setCredentialName(credentialName);
         return postObjectImpl("/credential/unblock", new ObjectRequest<>(request), UnblockCredentialResponse.class);
@@ -2068,7 +2068,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<DeleteCredentialResponse> deleteCredential(@NotNull String userId, @NotNull String credentialName) throws NextStepClientException {
-        DeleteCredentialRequest request = new DeleteCredentialRequest();
+        final DeleteCredentialRequest request = new DeleteCredentialRequest();
         request.setUserId(userId);
         request.setCredentialName(credentialName);
         return postObjectImpl("/credential/delete", new ObjectRequest<>(request), DeleteCredentialResponse.class);
@@ -2086,7 +2086,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<UpdateCounterResponse> updateCredentialCounter(@NotNull String userId, @NotNull String credentialName, @NotNull AuthenticationResult authenticationResult) throws NextStepClientException {
-        UpdateCounterRequest request = new UpdateCounterRequest();
+        final UpdateCounterRequest request = new UpdateCounterRequest();
         request.setUserId(userId);
         request.setCredentialName(credentialName);
         request.setAuthenticationResult(authenticationResult);
@@ -2100,7 +2100,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<ResetCountersResponse> resetAllCounters() throws NextStepClientException {
-        ResetCountersRequest request = new ResetCountersRequest();
+        final ResetCountersRequest request = new ResetCountersRequest();
         return postObjectImpl("/credential/counter/reset-all", new ObjectRequest<>(request), ResetCountersResponse.class);
     }
 
@@ -2118,7 +2118,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<CreateOtpResponse> createOtp(String userId, @NotNull String otpName, String credentialName, String otpData, String operationId) throws NextStepClientException {
-        CreateOtpRequest request = new CreateOtpRequest();
+        final CreateOtpRequest request = new CreateOtpRequest();
         request.setUserId(userId);
         request.setOtpName(otpName);
         request.setCredentialName(credentialName);
@@ -2138,7 +2138,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<CreateOtpResponse> createOtp(String userId, @NotNull String otpName, String credentialName, String otpData) throws NextStepClientException {
-        CreateOtpRequest request = new CreateOtpRequest();
+        final CreateOtpRequest request = new CreateOtpRequest();
         request.setUserId(userId);
         request.setOtpName(otpName);
         request.setCredentialName(credentialName);
@@ -2159,7 +2159,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<CreateAndSendOtpResponse> createAndSendOtp(String userId, @NotNull String otpName, String credentialName, String otpData, String operationId, String language) throws NextStepClientException {
-        CreateAndSendOtpRequest request = new CreateAndSendOtpRequest();
+        final CreateAndSendOtpRequest request = new CreateAndSendOtpRequest();
         request.setUserId(userId);
         request.setOtpName(otpName);
         request.setCredentialName(credentialName);
@@ -2193,7 +2193,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetOtpListResponse> getOtpListPost(@NotNull String operationId, boolean includeRemoved) throws NextStepClientException {
-        GetOtpListRequest request = new GetOtpListRequest();
+        final GetOtpListRequest request = new GetOtpListRequest();
         request.setOperationId(operationId);
         request.setIncludeRemoved(includeRemoved);
         return postObjectImpl("/otp/list", new ObjectRequest<>(request), GetOtpListResponse.class);
@@ -2227,7 +2227,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetOtpDetailResponse> getOtpDetailPost(String otpId, String operationId) throws NextStepClientException {
-        GetOtpDetailRequest request = new GetOtpDetailRequest();
+        final GetOtpDetailRequest request = new GetOtpDetailRequest();
         request.setOtpId(otpId);
         request.setOperationId(operationId);
         return postObjectImpl("/otp/detail", new ObjectRequest<>(request), GetOtpDetailResponse.class);
@@ -2242,7 +2242,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<DeleteOtpResponse> deleteOtp(String otpId, String operationId) throws NextStepClientException {
-        DeleteOtpRequest request = new DeleteOtpRequest();
+        final DeleteOtpRequest request = new DeleteOtpRequest();
         request.setOtpId(otpId);
         request.setOperationId(operationId);
         return postObjectImpl("/otp/delete", new ObjectRequest<>(request), DeleteOtpResponse.class);
@@ -2259,7 +2259,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<OtpAuthenticationResponse> authenticateWithOtp(String otpId, @NotNull String otpValue) throws NextStepClientException {
-        OtpAuthenticationRequest request = new OtpAuthenticationRequest();
+        final OtpAuthenticationRequest request = new OtpAuthenticationRequest();
         request.setOtpId(otpId);
         request.setOtpValue(otpValue);
         return postObjectImpl("/auth/otp", new ObjectRequest<>(request), OtpAuthenticationResponse.class);
@@ -2278,7 +2278,7 @@ public class NextStepClient {
      */
     public ObjectResponse<OtpAuthenticationResponse> authenticateWithOtp(String otpId, String operationId, @NotNull String otpValue,
                                                                            boolean updateOperation, AuthMethod authMethod) throws NextStepClientException {
-        OtpAuthenticationRequest request = new OtpAuthenticationRequest();
+        final OtpAuthenticationRequest request = new OtpAuthenticationRequest();
         request.setOtpId(otpId);
         request.setOperationId(operationId);
         request.setOtpValue(otpValue);
@@ -2297,7 +2297,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<CredentialAuthenticationResponse> authenticateWithCredential(@NotNull String credentialName, @NotNull String userId, @NotNull String credentialValue) throws NextStepClientException {
-        CredentialAuthenticationRequest request = new CredentialAuthenticationRequest();
+        final CredentialAuthenticationRequest request = new CredentialAuthenticationRequest();
         request.setCredentialName(credentialName);
         request.setUserId(userId);
         request.setCredentialValue(credentialValue);
@@ -2317,7 +2317,7 @@ public class NextStepClient {
      */
     public ObjectResponse<CredentialAuthenticationResponse> authenticateWithCredential(@NotNull String credentialName, @NotNull String userId, @NotNull String credentialValue,
                                                                                          CredentialAuthenticationMode authenticationMode, List<Integer> credentialPositionsToVerify) throws NextStepClientException {
-        CredentialAuthenticationRequest request = new CredentialAuthenticationRequest();
+        final CredentialAuthenticationRequest request = new CredentialAuthenticationRequest();
         request.setCredentialName(credentialName);
         request.setUserId(userId);
         request.setCredentialValue(credentialValue);
@@ -2340,7 +2340,7 @@ public class NextStepClient {
      */
     public ObjectResponse<CredentialAuthenticationResponse> authenticateWithCredential(@NotNull String credentialName, @NotNull String userId, @NotNull String credentialValue,
                                                                                          String operationId, boolean updateOperation, AuthMethod authMethod) throws NextStepClientException {
-        CredentialAuthenticationRequest request = new CredentialAuthenticationRequest();
+        final CredentialAuthenticationRequest request = new CredentialAuthenticationRequest();
         request.setCredentialName(credentialName);
         request.setUserId(userId);
         request.setCredentialValue(credentialValue);
@@ -2367,7 +2367,7 @@ public class NextStepClient {
     public ObjectResponse<CredentialAuthenticationResponse> authenticateWithCredential(@NotNull String credentialName, @NotNull String userId, @NotNull String credentialValue,
                                                                                          CredentialAuthenticationMode authenticationMode, List<Integer> credentialPositionsToVerify,
                                                                                          String operationId, boolean updateOperation, AuthMethod authMethod) throws NextStepClientException {
-        CredentialAuthenticationRequest request = new CredentialAuthenticationRequest();
+        final CredentialAuthenticationRequest request = new CredentialAuthenticationRequest();
         request.setCredentialName(credentialName);
         request.setUserId(userId);
         request.setCredentialValue(credentialValue);
@@ -2393,7 +2393,7 @@ public class NextStepClient {
      */
     public ObjectResponse<CombinedAuthenticationResponse> authenticateCombined(@NotNull String credentialName, @NotNull String userId, @NotNull String credentialValue,
                                                                                  String otpId, @NotNull String otpValue) throws NextStepClientException {
-        CombinedAuthenticationRequest request = new CombinedAuthenticationRequest();
+        final CombinedAuthenticationRequest request = new CombinedAuthenticationRequest();
         request.setCredentialName(credentialName);
         request.setUserId(userId);
         request.setCredentialValue(credentialValue);
@@ -2418,7 +2418,7 @@ public class NextStepClient {
     public ObjectResponse<CombinedAuthenticationResponse> authenticateCombined(@NotNull String credentialName, @NotNull String userId, @NotNull String credentialValue,
                                                                                  CredentialAuthenticationMode authenticationMode, List<Integer> credentialPositionsToVerify,
                                                                                  String otpId, @NotNull String otpValue) throws NextStepClientException {
-        CombinedAuthenticationRequest request = new CombinedAuthenticationRequest();
+        final CombinedAuthenticationRequest request = new CombinedAuthenticationRequest();
         request.setCredentialName(credentialName);
         request.setUserId(userId);
         request.setCredentialValue(credentialValue);
@@ -2446,7 +2446,7 @@ public class NextStepClient {
     public ObjectResponse<CombinedAuthenticationResponse> authenticateCombined(@NotNull String credentialName, @NotNull String userId, @NotNull String credentialValue,
                                                                                  String otpId, String operationId, @NotNull String otpValue,
                                                                                  boolean updateOperation, AuthMethod authMethod) throws NextStepClientException {
-        CombinedAuthenticationRequest request = new CombinedAuthenticationRequest();
+        final CombinedAuthenticationRequest request = new CombinedAuthenticationRequest();
         request.setCredentialName(credentialName);
         request.setUserId(userId);
         request.setCredentialValue(credentialValue);
@@ -2478,7 +2478,7 @@ public class NextStepClient {
                                                                                  CredentialAuthenticationMode authenticationMode, List<Integer> credentialPositionsToVerify,
                                                                                  String otpId, String operationId, @NotNull String otpValue,
                                                                                  boolean updateOperation, AuthMethod authMethod) throws NextStepClientException {
-        CombinedAuthenticationRequest request = new CombinedAuthenticationRequest();
+        final CombinedAuthenticationRequest request = new CombinedAuthenticationRequest();
         request.setCredentialName(credentialName);
         request.setUserId(userId);
         request.setCredentialValue(credentialValue);
@@ -2503,7 +2503,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<CreateAuditResponse> createAudit(@NotNull String action, String data) throws NextStepClientException {
-        CreateAuditRequest request = new CreateAuditRequest();
+        final CreateAuditRequest request = new CreateAuditRequest();
         request.setAction(action);
         request.setData(data);
         return postObjectImpl("/audit", new ObjectRequest<>(request), CreateAuditResponse.class);
@@ -2537,7 +2537,7 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetAuditListResponse> getAuditListPost(@NotNull Date startDate, @NotNull Date endDate) throws NextStepClientException {
-        GetAuditListRequest request = new GetAuditListRequest();
+        final GetAuditListRequest request = new GetAuditListRequest();
         request.setStartDate(startDate);
         request.setEndDate(endDate);
         return postObjectImpl("/audit/list", new ObjectRequest<>(request), GetAuditListResponse.class);

--- a/powerauth-nextstep-client/src/main/java/io/getlime/security/powerauth/lib/nextstep/client/NextStepClient.java
+++ b/powerauth-nextstep-client/src/main/java/io/getlime/security/powerauth/lib/nextstep/client/NextStepClient.java
@@ -37,8 +37,11 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import javax.validation.constraints.NotNull;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -400,6 +403,25 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetMobileTokenConfigResponse> getMobileTokenConfig(@NotNull String userId, @NotNull String operationName, @NotNull AuthMethod authMethod) throws NextStepClientException {
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.put("userId", Collections.singletonList(userId));
+        params.put("operationName", Collections.singletonList(operationName));
+        if (authMethod != null) {
+            params.put("authMethod", Collections.singletonList(authMethod.toString()));
+        }
+        return getObjectImpl("/operation/mobileToken/config/detail", params, GetMobileTokenConfigResponse.class);
+    }
+
+    /**
+     * Get mobile token configuration configuration using POST method.
+     *
+     * @param userId User ID.
+     * @param operationName Operation name.
+     * @param authMethod Authentication method.
+     * @return Mobile token configuration.
+     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
+     */
+    public ObjectResponse<GetMobileTokenConfigResponse> getMobileTokenConfigPost(@NotNull String userId, @NotNull String operationName, @NotNull AuthMethod authMethod) throws NextStepClientException {
         GetMobileTokenConfigRequest request = new GetMobileTokenConfigRequest();
         request.setUserId(userId);
         request.setOperationName(operationName);
@@ -415,6 +437,19 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetOperationDetailResponse> getOperationDetail(@NotNull String operationId) throws NextStepClientException {
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.put("operationId", Collections.singletonList(operationId));
+        return getObjectImpl("/operation/detail", params, GetOperationDetailResponse.class);
+    }
+
+    /**
+     * Calls the operation details endpoint via POST method to get operation details.
+     *
+     * @param operationId Operation ID.
+     * @return A Response with {@link GetOperationDetailResponse} object.
+     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
+     */
+    public ObjectResponse<GetOperationDetailResponse> getOperationDetailPost(@NotNull String operationId) throws NextStepClientException {
         GetOperationDetailRequest request = new GetOperationDetailRequest();
         request.setOperationId(operationId);
         return postObjectImpl("/operation/detail", new ObjectRequest<>(request), GetOperationDetailResponse.class);
@@ -479,6 +514,19 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetOperationConfigDetailResponse> getOperationConfigDetail(@NotNull String operationName) throws NextStepClientException {
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.put("operationName", Collections.singletonList(operationName));
+        return getObjectImpl("/operation/config/detail", params, GetOperationConfigDetailResponse.class);
+    }
+
+    /**
+     * Get operation configuration using POST method.
+     *
+     * @param operationName Operation name.
+     * @return Operation configuration.
+     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
+     */
+    public ObjectResponse<GetOperationConfigDetailResponse> getOperationConfigDetailPost(@NotNull String operationName) throws NextStepClientException {
         GetOperationConfigDetailRequest request = new GetOperationConfigDetailRequest();
         request.setOperationName(operationName);
         return postObjectImpl("/operation/config/detail", new ObjectRequest<>(request), GetOperationConfigDetailResponse.class);
@@ -491,6 +539,16 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetOperationConfigListResponse> getOperationConfigList() throws NextStepClientException {
+        return getObjectImpl("/operation/config",  GetOperationConfigListResponse.class);
+    }
+
+    /**
+     * Get all operation configurations using POST method.
+     *
+     * @return All operation configurations.
+     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
+     */
+    public ObjectResponse<GetOperationConfigListResponse> getOperationConfigListPost() throws NextStepClientException {
         GetOperationConfigListRequest request = new GetOperationConfigListRequest();
         return postObjectImpl("/operation/config/list", new ObjectRequest<>(request), GetOperationConfigListResponse.class);
     }
@@ -528,6 +586,21 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<List<GetOperationDetailResponse>> getPendingOperations(@NotNull String userId, boolean mobileTokenOnly) throws NextStepClientException {
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.put("userId", Collections.singletonList(userId));
+        params.put("mobileTokenOnly", Collections.singletonList(String.valueOf(mobileTokenOnly)));
+        return getImpl("/user/operation", params, new ParameterizedTypeReference<ObjectResponse<List<GetOperationDetailResponse>>>() {});
+    }
+
+    /**
+     * Get list of pending operations for given user and authentication method using POST method.
+     *
+     * @param userId User ID.
+     * @param mobileTokenOnly Whether pending operation list should be filtered for only next step with mobile token support.
+     * @return A Response with list of {@link GetOperationDetailResponse}.
+     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
+     */
+    public ObjectResponse<List<GetOperationDetailResponse>> getPendingOperationsPost(@NotNull String userId, boolean mobileTokenOnly) throws NextStepClientException {
         GetPendingOperationsRequest request = new GetPendingOperationsRequest();
         request.setUserId(userId);
         request.setMobileTokenOnly(mobileTokenOnly);
@@ -564,6 +637,19 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetOrganizationDetailResponse> getOrganizationDetail(@NotNull String organizationId) throws NextStepClientException {
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.put("organizationId", Collections.singletonList(organizationId));
+        return getObjectImpl("/organization/detail", params, GetOrganizationDetailResponse.class);
+    }
+
+    /**
+     * Get organization detail using POST method.
+     *
+     * @param organizationId Organization ID.
+     * @return Organization detail.
+     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
+     */
+    public ObjectResponse<GetOrganizationDetailResponse> getOrganizationDetailPost(@NotNull String organizationId) throws NextStepClientException {
         GetOrganizationDetailRequest request = new GetOrganizationDetailRequest();
         request.setOrganizationId(organizationId);
         return postObjectImpl("/organization/detail", new ObjectRequest<>(request), GetOrganizationDetailResponse.class);
@@ -576,6 +662,16 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetOrganizationListResponse> getOrganizationList() throws NextStepClientException {
+        return getObjectImpl("/organization", GetOrganizationListResponse.class);
+    }
+
+    /**
+     * Get all organizations using POST method.
+     *
+     * @return All organizations.
+     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
+     */
+    public ObjectResponse<GetOrganizationListResponse> getOrganizationListPost() throws NextStepClientException {
         GetOrganizationListRequest request = new GetOrganizationListRequest();
         return postObjectImpl("/organization/list", new ObjectRequest<>(request), GetOrganizationListResponse.class);
     }
@@ -639,6 +735,17 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetAuthMethodsResponse> getAuthMethodList() throws NextStepClientException {
+        return getObjectImpl("/auth-method", GetAuthMethodsResponse.class);
+    }
+
+
+    /**
+     * Get all authentication methods supported by Next Step server using POST method.
+     *
+     * @return List of authentication methods wrapped in GetAuthMethodsResponse.
+     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
+     */
+    public ObjectResponse<GetAuthMethodsResponse> getAuthMethodListPost() throws NextStepClientException {
         GetAuthMethodListRequest request = new GetAuthMethodListRequest();
         return postObjectImpl("/auth-method/list", new ObjectRequest<>(request), GetAuthMethodsResponse.class);
     }
@@ -665,6 +772,20 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetUserAuthMethodsResponse> getAuthMethodsForUser(String userId) throws NextStepClientException {
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.put("userId", Collections.singletonList(userId));
+        return getObjectImpl("/user/auth-method", params, GetUserAuthMethodsResponse.class);
+    }
+
+    /**
+     * Get all globally enabled authentication methods for given user using POST method. Do not perform checks of individual
+     * authentication methods whether they are currently available for authentication.
+     *
+     * @param userId User ID.
+     * @return List of globally enabled authentication methods for given user wrapped in GetAuthMethodsResponse.
+     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
+     */
+    public ObjectResponse<GetUserAuthMethodsResponse> getAuthMethodsForUserPost(String userId) throws NextStepClientException {
         GetUserAuthMethodsRequest request = new GetUserAuthMethodsRequest();
         request.setUserId(userId);
         return postObjectImpl("/user/auth-method/list", new ObjectRequest<>(request), GetUserAuthMethodsResponse.class);
@@ -681,6 +802,23 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetEnabledMethodListResponse> getAuthMethodsEnabledForUser(@NotNull String userId, @NotNull String operationName) throws NextStepClientException {
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.put("userId", Collections.singletonList(userId));
+        params.put("operationName", Collections.singletonList(operationName));
+        return getObjectImpl("/user/auth-method/enabled", params, GetEnabledMethodListResponse.class);
+    }
+
+    /**
+     * Get all currently enabled authentication methods for given user and operation name using POST method. Perform an actual check of each
+     * authentication method at the current moment to make they are currently available for authentication. Filter the
+     * authentication method list by the steps in given operation.
+     *
+     * @param userId User ID.
+     * @param operationName Operation name.
+     * @return List of currently enabled and available authentication methods for given user wrapped in GetEnabledMethodListResponse.
+     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
+     */
+    public ObjectResponse<GetEnabledMethodListResponse> getAuthMethodsEnabledForUserPost(@NotNull String userId, @NotNull String operationName) throws NextStepClientException {
         GetEnabledMethodListRequest request = new GetEnabledMethodListRequest();
         request.setUserId(userId);
         request.setOperationName(operationName);
@@ -784,6 +922,19 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetApplicationListResponse> getApplicationList(boolean includeRemoved) throws NextStepClientException {
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.put("includeRemoved", Collections.singletonList(String.valueOf(includeRemoved)));
+        return getObjectImpl("/application", params, GetApplicationListResponse.class);
+    }
+
+    /**
+     * Get Next Step application list using POST method.
+     *
+     * @param includeRemoved Whether removed applications should be included in the application list.
+     * @return Get application list response.
+     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
+     */
+    public ObjectResponse<GetApplicationListResponse> getApplicationListPost(boolean includeRemoved) throws NextStepClientException {
         GetApplicationListRequest request = new GetApplicationListRequest();
         request.setIncludeRemoved(includeRemoved);
         return postObjectImpl("/application/list", new ObjectRequest<>(request), GetApplicationListResponse.class);
@@ -826,6 +977,16 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetRoleListResponse> getRoleList() throws NextStepClientException {
+        return getObjectImpl("/role", GetRoleListResponse.class);
+    }
+
+    /**
+     * Get the list of user roles using POST method.
+     *
+     * @return Get user role list response.
+     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
+     */
+    public ObjectResponse<GetRoleListResponse> getRoleListPost() throws NextStepClientException {
         GetRoleListRequest request = new GetRoleListRequest();
         return postObjectImpl("/role/list", new ObjectRequest<>(request), GetRoleListResponse.class);
     }
@@ -914,6 +1075,19 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetHashConfigListResponse> getHashConfigList(boolean includeRemoved) throws NextStepClientException {
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.put("includeRemoved", Collections.singletonList(String.valueOf(includeRemoved)));
+        return getObjectImpl("/hashconfig", params, GetHashConfigListResponse.class);
+    }
+
+    /**
+     * Get list of hashing configurations using POST method.
+     *
+     * @param includeRemoved Whether removed hashing configurations should be included.
+     * @return Get hashing configuration list response.
+     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
+     */
+    public ObjectResponse<GetHashConfigListResponse> getHashConfigListPost(boolean includeRemoved) throws NextStepClientException {
         GetHashConfigListRequest request = new GetHashConfigListRequest();
         request.setIncludeRemoved(includeRemoved);
         return postObjectImpl("/hashconfig/list", new ObjectRequest<>(request), GetHashConfigListResponse.class);
@@ -975,6 +1149,19 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetCredentialPolicyListResponse> getCredentialPolicyList(boolean includeRemoved) throws NextStepClientException {
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.put("includeRemoved", Collections.singletonList(String.valueOf(includeRemoved)));
+        return getObjectImpl("/credential/policy", params, GetCredentialPolicyListResponse.class);
+    }
+
+    /**
+     * Get credential policy list using POST method.
+     *
+     * @param includeRemoved Whether removed credential policies should be included.
+     * @return Get credential policy list response.
+     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
+     */
+    public ObjectResponse<GetCredentialPolicyListResponse> getCredentialPolicyListPost(boolean includeRemoved) throws NextStepClientException {
         GetCredentialPolicyListRequest request = new GetCredentialPolicyListRequest();
         request.setIncludeRemoved(includeRemoved);
         return postObjectImpl("/credential/policy/list", new ObjectRequest<>(request), GetCredentialPolicyListResponse.class);
@@ -1036,6 +1223,19 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetCredentialDefinitionListResponse> getCredentialDefinitionList(boolean includeRemoved) throws NextStepClientException {
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.put("includeRemoved", Collections.singletonList(String.valueOf(includeRemoved)));
+        return getObjectImpl("/credential/definition", params, GetCredentialDefinitionListResponse.class);
+    }
+
+    /**
+     * Get credential definition list using POST method.
+     *
+     * @param includeRemoved Whether removed credential definitions should be included.
+     * @return Get credential definition list response.
+     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
+     */
+    public ObjectResponse<GetCredentialDefinitionListResponse> getCredentialDefinitionListPost(boolean includeRemoved) throws NextStepClientException {
         GetCredentialDefinitionListRequest request = new GetCredentialDefinitionListRequest();
         request.setIncludeRemoved(includeRemoved);
         return postObjectImpl("/credential/definition/list", new ObjectRequest<>(request), GetCredentialDefinitionListResponse.class);
@@ -1097,6 +1297,19 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetOtpPolicyListResponse> getOtpPolicyList(boolean includeRemoved) throws NextStepClientException {
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.put("includeRemoved", Collections.singletonList(String.valueOf(includeRemoved)));
+        return getObjectImpl("/otp/policy", params, GetOtpPolicyListResponse.class);
+    }
+
+    /**
+     * Get OTP policy list using POST method.
+     *
+     * @param includeRemoved Whether removed OTP policies should be included.
+     * @return Get OTP policy list response.
+     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
+     */
+    public ObjectResponse<GetOtpPolicyListResponse> getOtpPolicyListPost(boolean includeRemoved) throws NextStepClientException {
         GetOtpPolicyListRequest request = new GetOtpPolicyListRequest();
         request.setIncludeRemoved(includeRemoved);
         return postObjectImpl("/otp/policy/list", new ObjectRequest<>(request), GetOtpPolicyListResponse.class);
@@ -1158,6 +1371,19 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetOtpDefinitionListResponse> getOtpDefinitionList(boolean includeRemoved) throws NextStepClientException {
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.put("includeRemoved", Collections.singletonList(String.valueOf(includeRemoved)));
+        return getObjectImpl("/otp/definition", params, GetOtpDefinitionListResponse.class);
+    }
+
+    /**
+     * Get OTP definition list using POST method.
+     *
+     * @param includeRemoved Whether removed OTP definitions should be included.
+     * @return Get OTP definition list response.
+     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
+     */
+    public ObjectResponse<GetOtpDefinitionListResponse> getOtpDefinitionListPost(boolean includeRemoved) throws NextStepClientException {
         GetOtpDefinitionListRequest request = new GetOtpDefinitionListRequest();
         request.setIncludeRemoved(includeRemoved);
         return postObjectImpl("/otp/definition/list", new ObjectRequest<>(request), GetOtpDefinitionListResponse.class);
@@ -1234,9 +1460,9 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetUserDetailResponse> getUserDetail(@NotNull String userId) throws NextStepClientException {
-        GetUserDetailRequest request = new GetUserDetailRequest();
-        request.setUserId(userId);
-        return postObjectImpl("/user/detail", new ObjectRequest<>(request), GetUserDetailResponse.class);
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.put("userId", Collections.singletonList(userId));
+        return getObjectImpl("/user/detail", params, GetUserDetailResponse.class);
     }
 
     /**
@@ -1248,6 +1474,34 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetUserDetailResponse> getUserDetail(@NotNull String userId, boolean includeRemoved) throws NextStepClientException {
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.put("userId", Collections.singletonList(userId));
+        params.put("includeRemoved", Collections.singletonList(String.valueOf(includeRemoved)));
+        return getObjectImpl("/user/detail", params, GetUserDetailResponse.class);
+    }
+
+    /**
+     * Get user detail using POST method.
+     *
+     * @param userId User ID.
+     * @return Get user detail response.
+     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
+     */
+    public ObjectResponse<GetUserDetailResponse> getUserDetailPost(@NotNull String userId) throws NextStepClientException {
+        GetUserDetailRequest request = new GetUserDetailRequest();
+        request.setUserId(userId);
+        return postObjectImpl("/user/detail", new ObjectRequest<>(request), GetUserDetailResponse.class);
+    }
+
+    /**
+     * Get user detail using POST method with includeRemoved option.
+     *
+     * @param userId User ID.
+     * @param includeRemoved Whether removed user identities should be returned.
+     * @return Get user detail response.
+     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
+     */
+    public ObjectResponse<GetUserDetailResponse> getUserDetailPost(@NotNull String userId, boolean includeRemoved) throws NextStepClientException {
         GetUserDetailRequest request = new GetUserDetailRequest();
         request.setUserId(userId);
         request.setIncludeRemoved(includeRemoved);
@@ -1440,6 +1694,19 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetUserContactListResponse> getUserContactList(@NotNull String userId) throws NextStepClientException {
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.put("userId", Collections.singletonList(userId));
+        return getObjectImpl("/user/contact", params, GetUserContactListResponse.class);
+    }
+
+    /**
+     * Get user contact list using POST method.
+     *
+     * @param userId User ID.
+     * @return Get user contact list response.
+     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
+     */
+    public ObjectResponse<GetUserContactListResponse> getUserContactListPost(@NotNull String userId) throws NextStepClientException {
         GetUserContactListRequest request = new GetUserContactListRequest();
         request.setUserId(userId);
         return postObjectImpl("/user/contact/list", new ObjectRequest<>(request), GetUserContactListResponse.class);
@@ -1532,12 +1799,29 @@ public class NextStepClient {
      * Get user alias list.
      *
      * @param userId User ID.
+     * @param includeRemoved Whether removed aliases should be included.
      * @return Get user alias list response.
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
-    public ObjectResponse<GetUserAliasListResponse> getUserAliasList(@NotNull String userId) throws NextStepClientException {
+    public ObjectResponse<GetUserAliasListResponse> getUserAliasList(@NotNull String userId, boolean includeRemoved) throws NextStepClientException {
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.put("userId", Collections.singletonList(String.valueOf(includeRemoved)));
+        params.put("includeRemoved", Collections.singletonList(String.valueOf(includeRemoved)));
+        return getObjectImpl("/user/alias", params, GetUserAliasListResponse.class);
+    }
+
+    /**
+     * Get user alias list using POST method.
+     *
+     * @param userId User ID.
+     * @param includeRemoved Whether removed aliases should be included.
+     * @return Get user alias list response.
+     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
+     */
+    public ObjectResponse<GetUserAliasListResponse> getUserAliasListPost(@NotNull String userId, boolean includeRemoved) throws NextStepClientException {
         GetUserAliasListRequest request = new GetUserAliasListRequest();
         request.setUserId(userId);
+        request.setIncludeRemoved(includeRemoved);
         return postObjectImpl("/user/alias/list", new ObjectRequest<>(request), GetUserAliasListResponse.class);
     }
 
@@ -1565,6 +1849,21 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetUserCredentialListResponse> getUserCredentialList(@NotNull String userId, boolean includeRemoved) throws NextStepClientException {
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.put("userId", Collections.singletonList(userId));
+        params.put("includeRemoved", Collections.singletonList(String.valueOf(includeRemoved)));
+        return getObjectImpl("/user/credential", params, GetUserCredentialListResponse.class);
+    }
+
+    /**
+     * Get user credential list using POST method.
+     *
+     * @param userId User ID.
+     * @param includeRemoved Whether removed credentials should be included.
+     * @return Get user credential list response.
+     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
+     */
+    public ObjectResponse<GetUserCredentialListResponse> getUserCredentialListPost(@NotNull String userId, boolean includeRemoved) throws NextStepClientException {
         GetUserCredentialListRequest request = new GetUserCredentialListRequest();
         request.setUserId(userId);
         request.setIncludeRemoved(includeRemoved);
@@ -1581,6 +1880,27 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetUserAuthenticationListResponse> getUserAuthenticationList(@NotNull String userId, Date createdStartDate, Date createdEndDate) throws NextStepClientException {
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.put("userId", Collections.singletonList(userId));
+        if (createdStartDate != null) {
+            params.put("createdStartDate", Collections.singletonList(createdStartDate.toString()));
+        }
+        if (createdEndDate != null) {
+            params.put("createdEndDate", Collections.singletonList(createdEndDate.toString()));
+        }
+        return getObjectImpl("/user/authentication", params, GetUserAuthenticationListResponse.class);
+    }
+
+    /**
+     * Get user authentication list.
+     *
+     * @param userId User ID.
+     * @param createdStartDate Start of interval to use for date filter.
+     * @param createdEndDate End of interval to use for date filter.
+     * @return Get user authentication list response.
+     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
+     */
+    public ObjectResponse<GetUserAuthenticationListResponse> getUserAuthenticationListPost(@NotNull String userId, Date createdStartDate, Date createdEndDate) throws NextStepClientException {
         GetUserAuthenticationListRequest request = new GetUserAuthenticationListRequest();
         request.setUserId(userId);
         request.setCreatedStartDate(createdStartDate);
@@ -1882,6 +2202,21 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetOtpListResponse> getOtpList(@NotNull String operationId, boolean includeRemoved) throws NextStepClientException {
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.put("operationId", Collections.singletonList(operationId));
+        params.put("includeRemoved", Collections.singletonList(String.valueOf(includeRemoved)));
+        return getObjectImpl("/otp", params, GetOtpListResponse.class);
+    }
+
+    /**
+     * Get OTP list using POST method.
+     *
+     * @param operationId Operation ID.
+     * @param includeRemoved Whether removed OTPs should be included.
+     * @return Get OTP list response.
+     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
+     */
+    public ObjectResponse<GetOtpListResponse> getOtpListPost(@NotNull String operationId, boolean includeRemoved) throws NextStepClientException {
         GetOtpListRequest request = new GetOtpListRequest();
         request.setOperationId(operationId);
         request.setIncludeRemoved(includeRemoved);
@@ -1897,6 +2232,21 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetOtpDetailResponse> getOtpDetail(String otpId, String operationId) throws NextStepClientException {
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.put("otpId", Collections.singletonList(otpId));
+        params.put("operationId", Collections.singletonList(operationId));
+        return getObjectImpl("/otp/detail", params, GetOtpDetailResponse.class);
+    }
+
+    /**
+     * Get OTP detail using POST method.
+     *
+     * @param otpId OTP ID.
+     * @param operationId Operation ID.
+     * @return Get OTP list response.
+     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
+     */
+    public ObjectResponse<GetOtpDetailResponse> getOtpDetailPost(String otpId, String operationId) throws NextStepClientException {
         GetOtpDetailRequest request = new GetOtpDetailRequest();
         request.setOtpId(otpId);
         request.setOperationId(operationId);
@@ -2188,6 +2538,25 @@ public class NextStepClient {
      * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
      */
     public ObjectResponse<GetAuditListResponse> getAuditList(@NotNull Date startDate, @NotNull Date endDate) throws NextStepClientException {
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        if (startDate != null) {
+            params.put("startDate", Collections.singletonList(startDate.toString()));
+        }
+        if (endDate != null) {
+            params.put("endDate", Collections.singletonList(endDate.toString()));
+        }
+        return getObjectImpl("/audit", params, GetAuditListResponse.class);
+    }
+
+    /**
+     * Get audit log list using POST method.
+     *
+     * @param startDate Audit log interval start date.
+     * @param endDate Audit log interval end date.
+     * @return Delete audit log response.
+     * @throws NextStepClientException Thrown when REST API call fails, including {@link ErrorResponse} with error code.
+     */
+    public ObjectResponse<GetAuditListResponse> getAuditListPost(@NotNull Date startDate, @NotNull Date endDate) throws NextStepClientException {
         GetAuditListRequest request = new GetAuditListRequest();
         request.setStartDate(startDate);
         request.setEndDate(endDate);
@@ -2195,6 +2564,59 @@ public class NextStepClient {
     }
 
     // Generic HTTP client methods
+
+    /**
+     * Prepare GET object response.
+     *
+     * @param path Resource path.
+     * @param queryParams Query parameters.
+     * @param typeReference Type reference.
+     * @return Object obtained after processing the response JSON.
+     * @throws NextStepClientException In case of network, response / JSON processing, or other IO error.
+     */
+    private <T> T getImpl(String path, MultiValueMap<String, String> queryParams, ParameterizedTypeReference<T> typeReference) throws NextStepClientException {
+        try {
+            return restClient.get(path, queryParams, null, typeReference).getBody();
+        } catch (RestClientException ex) {
+            logger.warn(ex.getMessage(), ex);
+            throw new NextStepClientException(ex, new NextStepError(resolveErrorCode(ex), "HTTP POST request failed."));
+        }
+    }
+
+    /**
+     * Prepare GET object response.
+     *
+     * @param path Resource path.
+     * @param responseType Response type.
+     * @return Object obtained after processing the response JSON.
+     * @throws NextStepClientException In case of network, response / JSON processing, or other IO error.
+     */
+    private <T> ObjectResponse<T> getObjectImpl(String path, Class<T> responseType) throws NextStepClientException {
+        try {
+            return restClient.getObject(path, responseType);
+        } catch (RestClientException ex) {
+            logger.warn(ex.getMessage(), ex);
+            throw new NextStepClientException(ex, new NextStepError(resolveErrorCode(ex), "HTTP POST request failed."));
+        }
+    }
+
+    /**
+     * Prepare GET object response.
+     *
+     * @param path Resource path.
+     * @param queryParams Query parameters.
+     * @param responseType Response type.
+     * @return Object obtained after processing the response JSON.
+     * @throws NextStepClientException In case of network, response / JSON processing, or other IO error.
+     */
+    private <T> ObjectResponse<T> getObjectImpl(String path, MultiValueMap<String, String> queryParams, Class<T> responseType) throws NextStepClientException {
+        try {
+            return restClient.getObject(path, queryParams, null, responseType);
+        } catch (RestClientException ex) {
+            logger.warn(ex.getMessage(), ex);
+            throw new NextStepClientException(ex, new NextStepError(resolveErrorCode(ex), "HTTP POST request failed."));
+        }
+    }
 
     /**
      * Prepare a generic POST response.

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/ApplicationController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/ApplicationController.java
@@ -31,10 +31,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.UpdateApplicati
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -104,14 +101,29 @@ public class ApplicationController {
 
     /**
      * Get application list.
+     * @param includeRemoved Whether removed applications should be included.
+     * @return Get application list response.
+     */
+    @RequestMapping(method = RequestMethod.GET)
+    public ObjectResponse<GetApplicationListResponse> getApplicationList(@RequestParam boolean includeRemoved) {
+        logger.info("Received getApplicationList request");
+        GetApplicationListRequest request = new GetApplicationListRequest();
+        request.setIncludeRemoved(includeRemoved);
+        final GetApplicationListResponse response = applicationService.getApplicationList(request);
+        logger.info("The getApplicationList request succeeded");
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Get application list using POST method.
      * @param request Get application list request.
      * @return Get application list response.
      */
     @RequestMapping(value = "list", method = RequestMethod.POST)
-    public ObjectResponse<GetApplicationListResponse> getApplicationList(@Valid @RequestBody ObjectRequest<GetApplicationListRequest> request) {
-        logger.info("Received getApplicationList request");
+    public ObjectResponse<GetApplicationListResponse> getApplicationListPost(@Valid @RequestBody ObjectRequest<GetApplicationListRequest> request) {
+        logger.info("Received getApplicationListPost request");
         final GetApplicationListResponse response = applicationService.getApplicationList(request.getRequestObject());
-        logger.info("The getApplicationList request succeeded");
+        logger.info("The getApplicationListPost request succeeded");
         return new ObjectResponse<>(response);
     }
 

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/ApplicationController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/ApplicationController.java
@@ -31,6 +31,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.UpdateApplicati
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -42,6 +43,7 @@ import javax.validation.Valid;
  */
 @RestController
 @RequestMapping("application")
+@Validated
 public class ApplicationController {
 
     private static final Logger logger = LoggerFactory.getLogger(ApplicationController.class);
@@ -105,7 +107,7 @@ public class ApplicationController {
      * @return Get application list response.
      */
     @RequestMapping(method = RequestMethod.GET)
-    public ObjectResponse<GetApplicationListResponse> getApplicationList(@RequestParam boolean includeRemoved) {
+    public ObjectResponse<GetApplicationListResponse> getApplicationList(@RequestParam  boolean includeRemoved) {
         logger.info("Received getApplicationList request");
         GetApplicationListRequest request = new GetApplicationListRequest();
         request.setIncludeRemoved(includeRemoved);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/ApplicationController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/ApplicationController.java
@@ -107,7 +107,7 @@ public class ApplicationController {
      * @return Get application list response.
      */
     @RequestMapping(method = RequestMethod.GET)
-    public ObjectResponse<GetApplicationListResponse> getApplicationList(@RequestParam  boolean includeRemoved) {
+    public ObjectResponse<GetApplicationListResponse> getApplicationList(@RequestParam boolean includeRemoved) {
         logger.info("Received getApplicationList request");
         GetApplicationListRequest request = new GetApplicationListRequest();
         request.setIncludeRemoved(includeRemoved);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/AuditController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/AuditController.java
@@ -25,12 +25,11 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.GetAuditListRes
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.Date;
 
 /**
  * REST controller for auditing.
@@ -69,14 +68,31 @@ public class AuditController {
 
     /**
      * Get audit log list.
+     * @param startDate Start date filter for created timestamp.
+     * @param endDate End date filter for created timestamp.
+     * @return Get audit log list response.
+     */
+    @RequestMapping(method = RequestMethod.GET)
+    public ObjectResponse<GetAuditListResponse> getAuditList(@RequestParam @NotNull Date startDate, @RequestParam @NotNull Date endDate) {
+        GetAuditListRequest request = new GetAuditListRequest();
+        request.setStartDate(startDate);
+        request.setEndDate(endDate);
+        logger.info("Received getAuditList request");
+        final GetAuditListResponse response = auditLogService.getAuditLogList(request);
+        logger.info("The getAuditList request succeeded");
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Get audit log list using POST method.
      * @param request Get audit log list request.
      * @return Get audit log list response.
      */
     @RequestMapping(value = "list", method = RequestMethod.POST)
-    public ObjectResponse<GetAuditListResponse> getAuditList(@Valid @RequestBody ObjectRequest<GetAuditListRequest> request) {
-        logger.info("Received getAuditList request");
+    public ObjectResponse<GetAuditListResponse> getAuditListPost(@Valid @RequestBody ObjectRequest<GetAuditListRequest> request) {
+        logger.info("Received getAuditListPost request");
         final GetAuditListResponse response = auditLogService.getAuditLogList(request.getRequestObject());
-        logger.info("The getAuditList request succeeded");
+        logger.info("The getAuditListPost request succeeded");
         return new ObjectResponse<>(response);
     }
 

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/AuditController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/AuditController.java
@@ -25,6 +25,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.GetAuditListRes
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -38,6 +39,7 @@ import java.util.Date;
  */
 @RestController
 @RequestMapping("audit")
+@Validated
 public class AuditController {
 
     private static final Logger logger = LoggerFactory.getLogger(AuditController.class);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/AuthMethodController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/AuthMethodController.java
@@ -28,12 +28,11 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
 import java.util.List;
 import java.util.Map;
 
@@ -75,12 +74,11 @@ public class AuthMethodController {
     /**
      * Get all authentication methods supported by Next Step server.
      *
-     * @param request Get auth methods request. Use null user ID in request.
      * @return List of authentication methods wrapped in GetAuthMethodResponse.
      * @throws InvalidConfigurationException Thrown when Next Step configuration is invalid.
      */
-    @RequestMapping(value = "auth-method/list", method = RequestMethod.POST)
-    public ObjectResponse<GetAuthMethodsResponse> getAuthMethodList(@Valid @RequestBody ObjectRequest<GetAuthMethodListRequest> request) throws InvalidConfigurationException {
+    @RequestMapping(value = "auth-method", method = RequestMethod.GET)
+    public ObjectResponse<GetAuthMethodsResponse> getAuthMethodList() throws InvalidConfigurationException {
         logger.info("Received getAuthMethodList request");
         final List<AuthMethodDetail> authMethods = authMethodService.listAuthMethods();
         if (authMethods == null || authMethods.isEmpty()) {
@@ -94,23 +92,63 @@ public class AuthMethodController {
     }
 
     /**
-     * Get all enabled authentication methods for given user.
+     * Get all authentication methods supported by Next Step server using POST method.
+     *
+     * @param request Get auth methods request.
+     * @return List of authentication methods wrapped in GetAuthMethodResponse.
+     * @throws InvalidConfigurationException Thrown when Next Step configuration is invalid.
+     */
+    @RequestMapping(value = "auth-method/list", method = RequestMethod.POST)
+    public ObjectResponse<GetAuthMethodsResponse> getAuthMethodListPost(@Valid @RequestBody ObjectRequest<GetAuthMethodListRequest> request) throws InvalidConfigurationException {
+        logger.info("Received getAuthMethodListPost request");
+        final List<AuthMethodDetail> authMethods = authMethodService.listAuthMethods();
+        if (authMethods == null || authMethods.isEmpty()) {
+            logger.error("No authentication method is configured in Next Step server");
+            throw new InvalidConfigurationException("No authentication method is configured in Next Step server.");
+        }
+        final GetAuthMethodsResponse response = new GetAuthMethodsResponse();
+        response.getAuthMethods().addAll(authMethods);
+        logger.debug("The getAuthMethodListPost request succeeded, available authentication method list size: {}", authMethods.size());
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Get all enabled authentication methods for given user. In case user ID is null, list of auth methods enabled by default is returned.
+     *
+     * @param userId User ID.
+     * @return List of enabled authentication methods for given user wrapped in GetAuthMethodResponse.
+     * @throws InvalidConfigurationException Thrown when Next Step configuration is invalid.
+     */
+    @RequestMapping(value = "user/auth-method", method = RequestMethod.GET)
+    public ObjectResponse<GetUserAuthMethodsResponse> getAuthMethodsEnabledForUser(@RequestParam @Size(min = 1, max = 256) String userId) throws InvalidConfigurationException {
+        // Log level is FINE to avoid flooding logs, this endpoint is used all the time.
+        logger.debug("Received getAuthMethodsEnabledForUser request, user ID: {}", userId);
+        // userId can be null - in this case default setting is returned when user is not known
+        final List<UserAuthMethodDetail> userAuthMethods = authMethodService.listAuthMethodsEnabledForUser(userId);
+        final GetUserAuthMethodsResponse response = new GetUserAuthMethodsResponse();
+        response.getUserAuthMethods().addAll(userAuthMethods);
+        logger.debug("The getAuthMethodsEnabledForUser request succeeded, available authentication list size: {}", userAuthMethods.size());
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Get all enabled authentication methods for given user using POST method.
      *
      * @param request Get auth methods request. In case user ID is null, list of auth methods enabled by default is returned.
      * @return List of enabled authentication methods for given user wrapped in GetAuthMethodResponse.
      * @throws InvalidConfigurationException Thrown when Next Step configuration is invalid.
      */
     @RequestMapping(value = "user/auth-method/list", method = RequestMethod.POST)
-    public ObjectResponse<GetUserAuthMethodsResponse> getAuthMethodsEnabledForUser(@Valid @RequestBody ObjectRequest<GetUserAuthMethodsRequest> request) throws InvalidConfigurationException {
+    public ObjectResponse<GetUserAuthMethodsResponse> getAuthMethodsEnabledForUserPost(@Valid @RequestBody ObjectRequest<GetUserAuthMethodsRequest> request) throws InvalidConfigurationException {
         // Log level is FINE to avoid flooding logs, this endpoint is used all the time.
-        logger.debug("Received getAuthMethodsEnabledForUser request, user ID: {}", request.getRequestObject().getUserId());
+        logger.debug("Received getAuthMethodsEnabledForUserPost request, user ID: {}", request.getRequestObject().getUserId());
         final GetUserAuthMethodsRequest requestObject = request.getRequestObject();
         // userId can be null - in this case default setting is returned when user is not known
         final String userId = requestObject.getUserId();
         final List<UserAuthMethodDetail> userAuthMethods = authMethodService.listAuthMethodsEnabledForUser(userId);
         final GetUserAuthMethodsResponse response = new GetUserAuthMethodsResponse();
         response.getUserAuthMethods().addAll(userAuthMethods);
-        logger.debug("The getAuthMethodsEnabledForUser request succeeded, available authentication list size: {}", userAuthMethods.size());
+        logger.debug("The getAuthMethodsEnabledForUserPost request succeeded, available authentication list size: {}", userAuthMethods.size());
         return new ObjectResponse<>(response);
     }
 
@@ -182,16 +220,35 @@ public class AuthMethodController {
 
     /**
      * Get enabled method list.
+     * @param userId User ID.
+     * @param operationName Operation name.
+     * @return Get enabled method list response.
+     * @throws InvalidConfigurationException Thrown when configuration is invalid.
+     */
+    @RequestMapping(value = "user/auth-method/enabled", method = RequestMethod.GET)
+    public ObjectResponse<GetEnabledMethodListResponse> getEnabledMethodList(@RequestParam @NotBlank @Size(min = 1, max = 256) String userId, @RequestParam @NotBlank @Size(min = 2, max = 256) String operationName) throws InvalidConfigurationException {
+        // Log level is FINE to avoid flooding logs, this endpoint is used all the time.
+        logger.debug("Received getEnabledMethodList request, user ID: {}", userId);
+        GetEnabledMethodListRequest request = new GetEnabledMethodListRequest();
+        request.setUserId(userId);
+        request.setOperationName(operationName);
+        final GetEnabledMethodListResponse response = authMethodService.getEnabledMethodList(request);
+        logger.debug("The getEnabledMethodList request succeeded, available authentication method list size: {}", response.getEnabledAuthMethods().size());
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Get enabled method list using POST method.
      * @param request Get enabled method list request.
      * @return Get enabled method list response.
      * @throws InvalidConfigurationException Thrown when configuration is invalid.
      */
     @RequestMapping(value = "user/auth-method/enabled/list", method = RequestMethod.POST)
-    public ObjectResponse<GetEnabledMethodListResponse> getEnabledMethodList(@Valid @RequestBody ObjectRequest<GetEnabledMethodListRequest> request) throws InvalidConfigurationException {
+    public ObjectResponse<GetEnabledMethodListResponse> getEnabledMethodListPost(@Valid @RequestBody ObjectRequest<GetEnabledMethodListRequest> request) throws InvalidConfigurationException {
         // Log level is FINE to avoid flooding logs, this endpoint is used all the time.
-        logger.debug("Received getEnabledMethodList request, user ID: {}", request.getRequestObject().getUserId());
+        logger.debug("Received getEnabledMethodListPost request, user ID: {}", request.getRequestObject().getUserId());
         final GetEnabledMethodListResponse response = authMethodService.getEnabledMethodList(request.getRequestObject());
-        logger.debug("The getEnabledMethodList request succeeded, available authentication method list size: {}", response.getEnabledAuthMethods().size());
+        logger.debug("The getEnabledMethodListPost request succeeded, available authentication method list size: {}", response.getEnabledAuthMethods().size());
         return new ObjectResponse<>(response);
     }
 

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/AuthMethodController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/AuthMethodController.java
@@ -28,8 +28,10 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import javax.annotation.Nullable;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
@@ -42,6 +44,7 @@ import java.util.Map;
  * @author Roman Strobl, roman.strobl@wultra.com
  */
 @RestController
+@Validated
 public class AuthMethodController {
 
     private static final Logger logger = LoggerFactory.getLogger(AuthMethodController.class);
@@ -120,7 +123,7 @@ public class AuthMethodController {
      * @throws InvalidConfigurationException Thrown when Next Step configuration is invalid.
      */
     @RequestMapping(value = "user/auth-method", method = RequestMethod.GET)
-    public ObjectResponse<GetUserAuthMethodsResponse> getAuthMethodsEnabledForUser(@RequestParam @Size(min = 1, max = 256) String userId) throws InvalidConfigurationException {
+    public ObjectResponse<GetUserAuthMethodsResponse> getAuthMethodsEnabledForUser(@RequestParam @Nullable @Size(min = 1, max = 256) String userId) throws InvalidConfigurationException {
         // Log level is FINE to avoid flooding logs, this endpoint is used all the time.
         logger.debug("Received getAuthMethodsEnabledForUser request, user ID: {}", userId);
         // userId can be null - in this case default setting is returned when user is not known

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/AuthenticationController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/AuthenticationController.java
@@ -29,6 +29,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.OtpAuthenticati
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -43,6 +44,7 @@ import javax.validation.Valid;
  */
 @RestController
 @RequestMapping("auth")
+@Validated
 public class AuthenticationController {
 
     private static final Logger logger = LoggerFactory.getLogger(AuthenticationController.class);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/CredentialController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/CredentialController.java
@@ -25,6 +25,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -39,6 +40,7 @@ import javax.validation.Valid;
  */
 @RestController
 @RequestMapping("credential")
+@Validated
 public class CredentialController {
 
     private static final Logger logger = LoggerFactory.getLogger(CredentialController.class);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/CredentialCounterController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/CredentialCounterController.java
@@ -27,6 +27,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.UpdateCounterRe
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -41,6 +42,7 @@ import javax.validation.Valid;
  */
 @RestController
 @RequestMapping("credential/counter")
+@Validated
 public class CredentialCounterController {
 
     private static final Logger logger = LoggerFactory.getLogger(CredentialCounterController.class);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/CredentialDefinitionController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/CredentialDefinitionController.java
@@ -119,7 +119,7 @@ public class CredentialDefinitionController {
      * @return Get credential definition list response.
      */
     @RequestMapping(method = RequestMethod.GET)
-    public ObjectResponse<GetCredentialDefinitionListResponse> getCredentialDefinitionList(@RequestParam  boolean includeRemoved) {
+    public ObjectResponse<GetCredentialDefinitionListResponse> getCredentialDefinitionList(@RequestParam boolean includeRemoved) {
         GetCredentialDefinitionListRequest request = new GetCredentialDefinitionListRequest();
         request.setIncludeRemoved(includeRemoved);
         logger.info("Received getCredentialDefinitionList request");

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/CredentialDefinitionController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/CredentialDefinitionController.java
@@ -31,6 +31,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.UpdateCredentia
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -42,6 +43,7 @@ import javax.validation.Valid;
  */
 @RestController
 @RequestMapping("credential/definition")
+@Validated
 public class CredentialDefinitionController {
 
     private static final Logger logger = LoggerFactory.getLogger(CredentialDefinitionController.class);
@@ -117,7 +119,7 @@ public class CredentialDefinitionController {
      * @return Get credential definition list response.
      */
     @RequestMapping(method = RequestMethod.GET)
-    public ObjectResponse<GetCredentialDefinitionListResponse> getCredentialDefinitionList(@RequestParam boolean includeRemoved) {
+    public ObjectResponse<GetCredentialDefinitionListResponse> getCredentialDefinitionList(@RequestParam  boolean includeRemoved) {
         GetCredentialDefinitionListRequest request = new GetCredentialDefinitionListRequest();
         request.setIncludeRemoved(includeRemoved);
         logger.info("Received getCredentialDefinitionList request");

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/CredentialDefinitionController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/CredentialDefinitionController.java
@@ -31,10 +31,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.UpdateCredentia
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -116,14 +113,29 @@ public class CredentialDefinitionController {
 
     /**
      * Get credential definition list.
+     * @param includeRemoved Whether removed credentials should be included.
+     * @return Get credential definition list response.
+     */
+    @RequestMapping(method = RequestMethod.GET)
+    public ObjectResponse<GetCredentialDefinitionListResponse> getCredentialDefinitionList(@RequestParam boolean includeRemoved) {
+        GetCredentialDefinitionListRequest request = new GetCredentialDefinitionListRequest();
+        request.setIncludeRemoved(includeRemoved);
+        logger.info("Received getCredentialDefinitionList request");
+        final GetCredentialDefinitionListResponse response = credentialDefinitionService.getCredentialDefinitionList(request);
+        logger.info("The getCredentialDefinitionList request succeeded");
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Get credential definition list using POST method.
      * @param request Get credential definition list request.
      * @return Get credential definition list response.
      */
     @RequestMapping(value = "list", method = RequestMethod.POST)
-    public ObjectResponse<GetCredentialDefinitionListResponse> getCredentialDefinitionList(@Valid @RequestBody ObjectRequest<GetCredentialDefinitionListRequest> request) {
-        logger.info("Received getCredentialDefinitionList request");
+    public ObjectResponse<GetCredentialDefinitionListResponse> getCredentialDefinitionListPost(@Valid @RequestBody ObjectRequest<GetCredentialDefinitionListRequest> request) {
+        logger.info("Received getCredentialDefinitionListPost request");
         final GetCredentialDefinitionListResponse response = credentialDefinitionService.getCredentialDefinitionList(request.getRequestObject());
-        logger.info("The getCredentialDefinitionList request succeeded");
+        logger.info("The getCredentialDefinitionListPost request succeeded");
         return new ObjectResponse<>(response);
     }
 

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/CredentialPolicyController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/CredentialPolicyController.java
@@ -34,6 +34,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.UpdateCredentia
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -45,6 +46,7 @@ import javax.validation.Valid;
  */
 @RestController
 @RequestMapping("credential/policy")
+@Validated
 public class CredentialPolicyController {
 
     private static final Logger logger = LoggerFactory.getLogger(CredentialPolicyController.class);
@@ -112,7 +114,7 @@ public class CredentialPolicyController {
      * @throws InvalidConfigurationException Thrown when Next Step configuration is invalid.
      */
     @RequestMapping(method = RequestMethod.GET)
-    public ObjectResponse<GetCredentialPolicyListResponse> getCredentialPolicyList(@RequestParam boolean includeRemoved) throws InvalidConfigurationException {
+    public ObjectResponse<GetCredentialPolicyListResponse> getCredentialPolicyList(@RequestParam  boolean includeRemoved) throws InvalidConfigurationException {
         logger.info("Received getCredentialPolicyList request");
         GetCredentialPolicyListRequest request = new GetCredentialPolicyListRequest();
         request.setIncludeRemoved(includeRemoved);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/CredentialPolicyController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/CredentialPolicyController.java
@@ -34,10 +34,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.UpdateCredentia
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -110,15 +107,31 @@ public class CredentialPolicyController {
 
     /**
      * Get credential policy list.
+     * @param includeRemoved Whether removed credential policies should be included.
+     * @return Get credential policy list response.
+     * @throws InvalidConfigurationException Thrown when Next Step configuration is invalid.
+     */
+    @RequestMapping(method = RequestMethod.GET)
+    public ObjectResponse<GetCredentialPolicyListResponse> getCredentialPolicyList(@RequestParam boolean includeRemoved) throws InvalidConfigurationException {
+        logger.info("Received getCredentialPolicyList request");
+        GetCredentialPolicyListRequest request = new GetCredentialPolicyListRequest();
+        request.setIncludeRemoved(includeRemoved);
+        final GetCredentialPolicyListResponse response = credentialPolicyService.getCredentialPolicyList(request);
+        logger.info("The getCredentialPolicyList request succeeded");
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Get credential policy list using POST method.
      * @param request Get credential policy list request.
      * @return Get credential policy list response.
      * @throws InvalidConfigurationException Thrown when Next Step configuration is invalid.
      */
     @RequestMapping(value = "list", method = RequestMethod.POST)
-    public ObjectResponse<GetCredentialPolicyListResponse> getCredentialPolicyList(@Valid @RequestBody ObjectRequest<GetCredentialPolicyListRequest> request) throws InvalidConfigurationException {
-        logger.info("Received getCredentialPolicyList request");
+    public ObjectResponse<GetCredentialPolicyListResponse> getCredentialPolicyListPost(@Valid @RequestBody ObjectRequest<GetCredentialPolicyListRequest> request) throws InvalidConfigurationException {
+        logger.info("Received getCredentialPolicyListPost request");
         final GetCredentialPolicyListResponse response = credentialPolicyService.getCredentialPolicyList(request.getRequestObject());
-        logger.info("The getCredentialPolicyList request succeeded");
+        logger.info("The getCredentialPolicyListPost request succeeded");
         return new ObjectResponse<>(response);
     }
 

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/CredentialPolicyController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/CredentialPolicyController.java
@@ -114,7 +114,7 @@ public class CredentialPolicyController {
      * @throws InvalidConfigurationException Thrown when Next Step configuration is invalid.
      */
     @RequestMapping(method = RequestMethod.GET)
-    public ObjectResponse<GetCredentialPolicyListResponse> getCredentialPolicyList(@RequestParam  boolean includeRemoved) throws InvalidConfigurationException {
+    public ObjectResponse<GetCredentialPolicyListResponse> getCredentialPolicyList(@RequestParam boolean includeRemoved) throws InvalidConfigurationException {
         logger.info("Received getCredentialPolicyList request");
         GetCredentialPolicyListRequest request = new GetCredentialPolicyListRequest();
         request.setIncludeRemoved(includeRemoved);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/HashConfigController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/HashConfigController.java
@@ -34,10 +34,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.UpdateHashConfi
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -110,15 +107,31 @@ public class HashConfigController {
 
     /**
      * Get hashing configuration list.
+     * @param includeRemoved Whether removed hashing configurations should be included.
+     * @return Get hashing configuration list response.
+     * @throws InvalidConfigurationException Thrown when Next Step configuration is invalid.
+     */
+    @RequestMapping(method = RequestMethod.GET)
+    public ObjectResponse<GetHashConfigListResponse> getHashConfigList(@RequestParam boolean includeRemoved) throws InvalidConfigurationException {
+        logger.info("Received getHashConfigListPost request");
+        GetHashConfigListRequest request = new GetHashConfigListRequest();
+        request.setIncludeRemoved(includeRemoved);
+        final GetHashConfigListResponse response = hashConfigService.getHashConfigList(request);
+        logger.info("The getHashConfigListPost request succeeded");
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Get hashing configuration list using POST.
      * @param request Get hashing configuration list request.
      * @return Get hashing configuration list response.
      * @throws InvalidConfigurationException Thrown when Next Step configuration is invalid.
      */
     @RequestMapping(value = "list", method = RequestMethod.POST)
-    public ObjectResponse<GetHashConfigListResponse> getHashConfigList(@Valid @RequestBody ObjectRequest<GetHashConfigListRequest> request) throws InvalidConfigurationException {
-        logger.info("Received getHashConfigList request");
+    public ObjectResponse<GetHashConfigListResponse> getHashConfigListPost(@Valid @RequestBody ObjectRequest<GetHashConfigListRequest> request) throws InvalidConfigurationException {
+        logger.info("Received getHashConfigListPost request");
         final GetHashConfigListResponse response = hashConfigService.getHashConfigList(request.getRequestObject());
-        logger.info("The getHashConfigList request succeeded");
+        logger.info("The getHashConfigListPost request succeeded");
         return new ObjectResponse<>(response);
     }
 

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/HashConfigController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/HashConfigController.java
@@ -34,6 +34,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.UpdateHashConfi
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -45,6 +46,7 @@ import javax.validation.Valid;
  */
 @RestController
 @RequestMapping("hashconfig")
+@Validated
 public class HashConfigController {
 
     private static final Logger logger = LoggerFactory.getLogger(HashConfigController.class);
@@ -112,7 +114,7 @@ public class HashConfigController {
      * @throws InvalidConfigurationException Thrown when Next Step configuration is invalid.
      */
     @RequestMapping(method = RequestMethod.GET)
-    public ObjectResponse<GetHashConfigListResponse> getHashConfigList(@RequestParam boolean includeRemoved) throws InvalidConfigurationException {
+    public ObjectResponse<GetHashConfigListResponse> getHashConfigList(@RequestParam  boolean includeRemoved) throws InvalidConfigurationException {
         logger.info("Received getHashConfigListPost request");
         GetHashConfigListRequest request = new GetHashConfigListRequest();
         request.setIncludeRemoved(includeRemoved);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/HashConfigController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/HashConfigController.java
@@ -114,7 +114,7 @@ public class HashConfigController {
      * @throws InvalidConfigurationException Thrown when Next Step configuration is invalid.
      */
     @RequestMapping(method = RequestMethod.GET)
-    public ObjectResponse<GetHashConfigListResponse> getHashConfigList(@RequestParam  boolean includeRemoved) throws InvalidConfigurationException {
+    public ObjectResponse<GetHashConfigListResponse> getHashConfigList(@RequestParam boolean includeRemoved) throws InvalidConfigurationException {
         logger.info("Received getHashConfigListPost request");
         GetHashConfigListRequest request = new GetHashConfigListRequest();
         request.setIncludeRemoved(includeRemoved);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OperationController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OperationController.java
@@ -34,6 +34,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -49,6 +50,7 @@ import java.util.List;
  * @author Petr Dvorak, petr@wultra.com
  */
 @RestController
+@Validated
 public class OperationController {
 
     private static final Logger logger = LoggerFactory.getLogger(OperationController.class);
@@ -330,7 +332,7 @@ public class OperationController {
      * @return List with operation details.
      */
     @RequestMapping(value = "user/operation", method = RequestMethod.GET)
-    public ObjectResponse<List<GetOperationDetailResponse>> getPendingOperations(@RequestParam @NotBlank @Size(min = 1, max = 256) String userId, @RequestParam boolean mobileTokenOnly) {
+    public ObjectResponse<List<GetOperationDetailResponse>> getPendingOperations(@RequestParam @NotBlank @Size(min = 1, max = 256) String userId, @RequestParam  boolean mobileTokenOnly) {
         // Log level is FINE to avoid flooding logs, this endpoint is used all the time.
         logger.debug("Received getPendingOperations request, user ID: {}", userId);
 

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OperationController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OperationController.java
@@ -332,7 +332,7 @@ public class OperationController {
      * @return List with operation details.
      */
     @RequestMapping(value = "user/operation", method = RequestMethod.GET)
-    public ObjectResponse<List<GetOperationDetailResponse>> getPendingOperations(@RequestParam @NotBlank @Size(min = 1, max = 256) String userId, @RequestParam  boolean mobileTokenOnly) {
+    public ObjectResponse<List<GetOperationDetailResponse>> getPendingOperations(@RequestParam @NotBlank @Size(min = 1, max = 256) String userId, @RequestParam boolean mobileTokenOnly) {
         // Log level is FINE to avoid flooding logs, this endpoint is used all the time.
         logger.debug("Received getPendingOperations request, user ID: {}", userId);
 

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OrganizationController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OrganizationController.java
@@ -33,6 +33,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.GetOrganization
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -46,6 +47,7 @@ import javax.validation.constraints.Size;
  */
 @RestController
 @RequestMapping(value = "organization")
+@Validated
 public class OrganizationController {
 
     private static final Logger logger = LoggerFactory.getLogger(OrganizationController.class);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OrganizationController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OrganizationController.java
@@ -33,12 +33,11 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.GetOrganization
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
 
 /**
  * REST controller class related to Next Step organizations.
@@ -79,28 +78,57 @@ public class OrganizationController {
     /**
      * Get organization detail.
      *
+     * @param organizationId Organization ID.
+     * @return Get organization detail response.
+     * @throws OrganizationNotFoundException Thrown in case organization does not exist.
+     */
+    @RequestMapping(value = "detail", method = RequestMethod.GET)
+    public ObjectResponse<GetOrganizationDetailResponse> getOrganizationDetail(@RequestParam @NotBlank @Size(min = 2, max = 256) String organizationId) throws OrganizationNotFoundException {
+        logger.info("Received getOrganizationDetail request, organization ID: {}", organizationId);
+        GetOrganizationDetailRequest request = new GetOrganizationDetailRequest();
+        final GetOrganizationDetailResponse response = organizationService.getOrganizationDetail(request);
+        logger.info("The getOrganizationDetail request succeeded, organization ID: {}", organizationId);
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Get organization detail using POST method.
+     *
      * @param request Get organization detail request.
      * @return Get organization detail response.
      * @throws OrganizationNotFoundException Thrown in case organization does not exist.
      */
     @RequestMapping(value = "detail", method = RequestMethod.POST)
-    public ObjectResponse<GetOrganizationDetailResponse> getOrganizationDetail(@Valid @RequestBody ObjectRequest<GetOrganizationDetailRequest> request) throws OrganizationNotFoundException {
-        logger.info("Received getOrganizationDetail request, organization ID: {}", request.getRequestObject().getOrganizationId());
+    public ObjectResponse<GetOrganizationDetailResponse> getOrganizationDetailPost(@Valid @RequestBody ObjectRequest<GetOrganizationDetailRequest> request) throws OrganizationNotFoundException {
+        logger.info("Received getOrganizationDetailPost request, organization ID: {}", request.getRequestObject().getOrganizationId());
         final GetOrganizationDetailResponse response = organizationService.getOrganizationDetail(request.getRequestObject());
-        logger.info("The getOrganizationDetail request succeeded, organization ID: {}", request.getRequestObject().getOrganizationId());
+        logger.info("The getOrganizationDetailPost request succeeded, organization ID: {}", request.getRequestObject().getOrganizationId());
         return new ObjectResponse<>(response);
     }
 
     /**
      * List organizations defined in Next Step service.
      *
+     * @return Get organizations response.
+     */
+    @RequestMapping(method = RequestMethod.GET)
+    public ObjectResponse<GetOrganizationListResponse> getOrganizationList() {
+        logger.info("Received getOrganizationList request");
+        final GetOrganizationListResponse response = organizationService.getOrganizationList();
+        logger.info("The getOrganizationList request succeeded, number of organizations: {}", response.getOrganizations().size());
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * List organizations defined in Next Step service using POST method.
+     *
      * @param request Get organizations request.
      * @return Get organizations response.
      */
     @RequestMapping(value = "list", method = RequestMethod.POST)
-    public ObjectResponse<GetOrganizationListResponse> getOrganizationList(@Valid @RequestBody ObjectRequest<GetOrganizationListRequest> request) {
+    public ObjectResponse<GetOrganizationListResponse> getOrganizationListPost(@Valid @RequestBody ObjectRequest<GetOrganizationListRequest> request) {
         logger.info("Received getOrganizationList request");
-        final GetOrganizationListResponse response = organizationService.getOrganizationList(request.getRequestObject());
+        final GetOrganizationListResponse response = organizationService.getOrganizationList();
         logger.info("The getOrganizationList request succeeded, number of organizations: {}", response.getOrganizations().size());
         return new ObjectResponse<>(response);
     }

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OrganizationController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OrganizationController.java
@@ -88,6 +88,7 @@ public class OrganizationController {
     public ObjectResponse<GetOrganizationDetailResponse> getOrganizationDetail(@RequestParam @NotBlank @Size(min = 2, max = 256) String organizationId) throws OrganizationNotFoundException {
         logger.info("Received getOrganizationDetail request, organization ID: {}", organizationId);
         GetOrganizationDetailRequest request = new GetOrganizationDetailRequest();
+        request.setOrganizationId(organizationId);
         final GetOrganizationDetailResponse response = organizationService.getOrganizationDetail(request);
         logger.info("The getOrganizationDetail request succeeded, organization ID: {}", organizationId);
         return new ObjectResponse<>(response);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OtpController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OtpController.java
@@ -28,6 +28,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
 
 /**
  * REST controller for OTP management.
@@ -103,16 +105,56 @@ public class OtpController {
 
     /**
      * Get OTP list for an operation.
+     * @param operationId Operation ID.
+     * @param includeRemoved Whether removed OTPs should be included.
+     * @return Get OTP list response.
+     * @throws OperationNotFoundException Thrown when operation is not found.
+     * @throws EncryptionException Thrown when decryption fails.
+     */
+    @RequestMapping(method = RequestMethod.GET)
+    public ObjectResponse<GetOtpListResponse> getOptList(@RequestParam @NotBlank @Size(min = 1, max = 256) String operationId, @RequestParam boolean includeRemoved) throws OperationNotFoundException, InvalidConfigurationException, EncryptionException {
+        logger.info("Received getOptList request, operation ID: {}", operationId);
+        GetOtpListRequest request = new GetOtpListRequest();
+        request.setOperationId(operationId);
+        request.setIncludeRemoved(includeRemoved);
+        final GetOtpListResponse response = otpService.getOtpList(request);
+        logger.info("The getOptList request succeeded, operation ID: {}", operationId);
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Get OTP list for an operation using POST method.
      * @param request Get OTP list request.
      * @return Get OTP list response.
      * @throws OperationNotFoundException Thrown when operation is not found.
      * @throws EncryptionException Thrown when decryption fails.
      */
     @RequestMapping(value = "list", method = RequestMethod.POST)
-    public ObjectResponse<GetOtpListResponse> getOptList(@Valid @RequestBody ObjectRequest<GetOtpListRequest> request) throws OperationNotFoundException, InvalidConfigurationException, EncryptionException {
-        logger.info("Received getOptList request, operation ID: {}", request.getRequestObject().getOperationId());
+    public ObjectResponse<GetOtpListResponse> getOptListPost(@Valid @RequestBody ObjectRequest<GetOtpListRequest> request) throws OperationNotFoundException, InvalidConfigurationException, EncryptionException {
+        logger.info("Received getOptListPost request, operation ID: {}", request.getRequestObject().getOperationId());
         final GetOtpListResponse response = otpService.getOtpList(request.getRequestObject());
-        logger.info("The getOptList request succeeded, operation ID: {}", request.getRequestObject().getOperationId());
+        logger.info("The getOptListPost request succeeded, operation ID: {}", request.getRequestObject().getOperationId());
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Get OTP detail for an OTP or operation.
+     * @param otpId OTP ID, use null if operation ID should be used instead.
+     * @param operationId Operation ID, use null if OTP ID should be used instead.
+     * @return Get OTP detail response.
+     * @throws OperationNotFoundException Thrown when operation is not found.
+     * @throws InvalidRequestException Thrown when request is invalid.
+     * @throws OtpNotFoundException Thrown when OTP is not found.
+     * @throws EncryptionException Thrown when decryption fails.
+     */
+    @RequestMapping(value = "detail", method = RequestMethod.GET)
+    public ObjectResponse<GetOtpDetailResponse> getOtpDetail(@RequestParam @Size(min = 36, max = 36) String otpId, @RequestParam @Size(min = 1, max = 256) String operationId) throws OperationNotFoundException, InvalidRequestException, OtpNotFoundException, InvalidConfigurationException, EncryptionException {
+        logger.info("Received getOtpDetail request, OTP ID: {}, operation ID: {}", otpId, operationId);
+        GetOtpDetailRequest request = new GetOtpDetailRequest();
+        request.setOtpId(otpId);
+        request.setOperationId(operationId);
+        final GetOtpDetailResponse response = otpService.getOtpDetail(request);
+        logger.info("The getOtpDetail request succeeded, OTP ID: {}, operation ID: {}", otpId, operationId);
         return new ObjectResponse<>(response);
     }
 
@@ -126,10 +168,10 @@ public class OtpController {
      * @throws EncryptionException Thrown when decryption fails.
      */
     @RequestMapping(value = "detail", method = RequestMethod.POST)
-    public ObjectResponse<GetOtpDetailResponse> getOtpDetail(@Valid @RequestBody ObjectRequest<GetOtpDetailRequest> request) throws OperationNotFoundException, InvalidRequestException, OtpNotFoundException, InvalidConfigurationException, EncryptionException {
-        logger.info("Received getOtpDetail request, OTP ID: {}, operation ID: {}", request.getRequestObject().getOtpId(), request.getRequestObject().getOperationId());
+    public ObjectResponse<GetOtpDetailResponse> getOtpDetailPost(@Valid @RequestBody ObjectRequest<GetOtpDetailRequest> request) throws OperationNotFoundException, InvalidRequestException, OtpNotFoundException, InvalidConfigurationException, EncryptionException {
+        logger.info("Received getOtpDetailPost request, OTP ID: {}, operation ID: {}", request.getRequestObject().getOtpId(), request.getRequestObject().getOperationId());
         final GetOtpDetailResponse response = otpService.getOtpDetail(request.getRequestObject());
-        logger.info("The getOtpDetail request succeeded, OTP ID: {}, operation ID: {}", request.getRequestObject().getOtpId(), request.getRequestObject().getOperationId());
+        logger.info("The getOtpDetailPost request succeeded, OTP ID: {}, operation ID: {}", request.getRequestObject().getOtpId(), request.getRequestObject().getOperationId());
         return new ObjectResponse<>(response);
     }
 

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OtpController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OtpController.java
@@ -115,7 +115,7 @@ public class OtpController {
      * @throws EncryptionException Thrown when decryption fails.
      */
     @RequestMapping(method = RequestMethod.GET)
-    public ObjectResponse<GetOtpListResponse> getOptList(@RequestParam @NotBlank @Size(min = 1, max = 256) String operationId, @RequestParam  boolean includeRemoved) throws OperationNotFoundException, InvalidConfigurationException, EncryptionException {
+    public ObjectResponse<GetOtpListResponse> getOptList(@RequestParam @NotBlank @Size(min = 1, max = 256) String operationId, @RequestParam boolean includeRemoved) throws OperationNotFoundException, InvalidConfigurationException, EncryptionException {
         logger.info("Received getOptList request, operation ID: {}", operationId);
         GetOtpListRequest request = new GetOtpListRequest();
         request.setOperationId(operationId);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OtpController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OtpController.java
@@ -25,8 +25,10 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import javax.annotation.Nullable;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
@@ -38,6 +40,7 @@ import javax.validation.constraints.Size;
  */
 @RestController
 @RequestMapping("otp")
+@Validated
 public class OtpController {
 
     private static final Logger logger = LoggerFactory.getLogger(OtpController.class);
@@ -112,7 +115,7 @@ public class OtpController {
      * @throws EncryptionException Thrown when decryption fails.
      */
     @RequestMapping(method = RequestMethod.GET)
-    public ObjectResponse<GetOtpListResponse> getOptList(@RequestParam @NotBlank @Size(min = 1, max = 256) String operationId, @RequestParam boolean includeRemoved) throws OperationNotFoundException, InvalidConfigurationException, EncryptionException {
+    public ObjectResponse<GetOtpListResponse> getOptList(@RequestParam @NotBlank @Size(min = 1, max = 256) String operationId, @RequestParam  boolean includeRemoved) throws OperationNotFoundException, InvalidConfigurationException, EncryptionException {
         logger.info("Received getOptList request, operation ID: {}", operationId);
         GetOtpListRequest request = new GetOtpListRequest();
         request.setOperationId(operationId);
@@ -148,7 +151,7 @@ public class OtpController {
      * @throws EncryptionException Thrown when decryption fails.
      */
     @RequestMapping(value = "detail", method = RequestMethod.GET)
-    public ObjectResponse<GetOtpDetailResponse> getOtpDetail(@RequestParam @Size(min = 36, max = 36) String otpId, @RequestParam @Size(min = 1, max = 256) String operationId) throws OperationNotFoundException, InvalidRequestException, OtpNotFoundException, InvalidConfigurationException, EncryptionException {
+    public ObjectResponse<GetOtpDetailResponse> getOtpDetail(@RequestParam @Nullable @Size(min = 36, max = 36) String otpId, @RequestParam @Nullable @Size(min = 1, max = 256) String operationId) throws OperationNotFoundException, InvalidRequestException, OtpNotFoundException, InvalidConfigurationException, EncryptionException {
         logger.info("Received getOtpDetail request, OTP ID: {}, operation ID: {}", otpId, operationId);
         GetOtpDetailRequest request = new GetOtpDetailRequest();
         request.setOtpId(otpId);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OtpDefinitionController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OtpDefinitionController.java
@@ -34,6 +34,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.UpdateOtpDefini
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -45,6 +46,7 @@ import javax.validation.Valid;
  */
 @RestController
 @RequestMapping("otp/definition")
+@Validated
 public class OtpDefinitionController {
 
     private static final Logger logger = LoggerFactory.getLogger(OtpDefinitionController.class);
@@ -114,7 +116,7 @@ public class OtpDefinitionController {
      * @return Get OTP definition list response.
      */
     @RequestMapping(method = RequestMethod.GET)
-    public ObjectResponse<GetOtpDefinitionListResponse> getOtpDefinitionList(@RequestParam boolean includeRemoved) {
+    public ObjectResponse<GetOtpDefinitionListResponse> getOtpDefinitionList(@RequestParam  boolean includeRemoved) {
         logger.info("Received getOtpDefinitionList request");
         GetOtpDefinitionListRequest request = new GetOtpDefinitionListRequest();
         request.setIncludeRemoved(includeRemoved);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OtpDefinitionController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OtpDefinitionController.java
@@ -34,10 +34,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.UpdateOtpDefini
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -113,14 +110,29 @@ public class OtpDefinitionController {
 
     /**
      * Get OTP definition list.
+     * @param includeRemoved Whether removed OTP definitions should be included.
+     * @return Get OTP definition list response.
+     */
+    @RequestMapping(method = RequestMethod.GET)
+    public ObjectResponse<GetOtpDefinitionListResponse> getOtpDefinitionList(@RequestParam boolean includeRemoved) {
+        logger.info("Received getOtpDefinitionList request");
+        GetOtpDefinitionListRequest request = new GetOtpDefinitionListRequest();
+        request.setIncludeRemoved(includeRemoved);
+        final GetOtpDefinitionListResponse response = otpDefinitionService.getOtpDefinitionList(request);
+        logger.info("The getOtpDefinitionList request succeeded");
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Get OTP definition list using POST method.
      * @param request Get OTP definition list request.
      * @return Get OTP definition list response.
      */
     @RequestMapping(value = "list", method = RequestMethod.POST)
-    public ObjectResponse<GetOtpDefinitionListResponse> getOtpDefinitionList(@Valid @RequestBody ObjectRequest<GetOtpDefinitionListRequest> request) {
-        logger.info("Received getOtpDefinitionList request");
+    public ObjectResponse<GetOtpDefinitionListResponse> getOtpDefinitionListPost(@Valid @RequestBody ObjectRequest<GetOtpDefinitionListRequest> request) {
+        logger.info("Received getOtpDefinitionListPost request");
         final GetOtpDefinitionListResponse response = otpDefinitionService.getOtpDefinitionList(request.getRequestObject());
-        logger.info("The getOtpDefinitionList request succeeded");
+        logger.info("The getOtpDefinitionListPost request succeeded");
         return new ObjectResponse<>(response);
     }
 

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OtpDefinitionController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OtpDefinitionController.java
@@ -116,7 +116,7 @@ public class OtpDefinitionController {
      * @return Get OTP definition list response.
      */
     @RequestMapping(method = RequestMethod.GET)
-    public ObjectResponse<GetOtpDefinitionListResponse> getOtpDefinitionList(@RequestParam  boolean includeRemoved) {
+    public ObjectResponse<GetOtpDefinitionListResponse> getOtpDefinitionList(@RequestParam boolean includeRemoved) {
         logger.info("Received getOtpDefinitionList request");
         GetOtpDefinitionListRequest request = new GetOtpDefinitionListRequest();
         request.setIncludeRemoved(includeRemoved);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OtpPolicyController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OtpPolicyController.java
@@ -34,6 +34,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.UpdateOtpPolicy
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -45,6 +46,7 @@ import javax.validation.Valid;
  */
 @RestController
 @RequestMapping("otp/policy")
+@Validated
 public class OtpPolicyController {
 
     private static final Logger logger = LoggerFactory.getLogger(OtpPolicyController.class);
@@ -112,7 +114,7 @@ public class OtpPolicyController {
      * @throws InvalidConfigurationException Thrown when Next Step configuration is invalid.
      */
     @RequestMapping(method = RequestMethod.GET)
-    public ObjectResponse<GetOtpPolicyListResponse> getOtpPolicyList(@RequestParam boolean includeRemoved) throws InvalidConfigurationException {
+    public ObjectResponse<GetOtpPolicyListResponse> getOtpPolicyList(@RequestParam  boolean includeRemoved) throws InvalidConfigurationException {
         logger.info("Received getOtpPolicyListPost request");
         GetOtpPolicyListRequest request = new GetOtpPolicyListRequest();
         request.setIncludeRemoved(includeRemoved);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OtpPolicyController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OtpPolicyController.java
@@ -34,10 +34,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.UpdateOtpPolicy
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -110,15 +107,31 @@ public class OtpPolicyController {
 
     /**
      * Get OTP policy list.
+     * @param includeRemoved Whether removed OTP policies should be included.
+     * @return Get OTP policy list response.
+     * @throws InvalidConfigurationException Thrown when Next Step configuration is invalid.
+     */
+    @RequestMapping(method = RequestMethod.GET)
+    public ObjectResponse<GetOtpPolicyListResponse> getOtpPolicyList(@RequestParam boolean includeRemoved) throws InvalidConfigurationException {
+        logger.info("Received getOtpPolicyListPost request");
+        GetOtpPolicyListRequest request = new GetOtpPolicyListRequest();
+        request.setIncludeRemoved(includeRemoved);
+        final GetOtpPolicyListResponse response = otpPolicyService.getOtpPolicyList(request);
+        logger.info("The getOtpPolicyListPost request succeeded");
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Get OTP policy list using POST method.
      * @param request Get OTP policy list request.
      * @return Get OTP policy list response.
      * @throws InvalidConfigurationException Thrown when Next Step configuration is invalid.
      */
     @RequestMapping(value = "list", method = RequestMethod.POST)
-    public ObjectResponse<GetOtpPolicyListResponse> getOtpPolicyList(@Valid @RequestBody ObjectRequest<GetOtpPolicyListRequest> request) throws InvalidConfigurationException {
-        logger.info("Received getOtpPolicyList request");
+    public ObjectResponse<GetOtpPolicyListResponse> getOtpPolicyListPost(@Valid @RequestBody ObjectRequest<GetOtpPolicyListRequest> request) throws InvalidConfigurationException {
+        logger.info("Received getOtpPolicyListPost request");
         final GetOtpPolicyListResponse response = otpPolicyService.getOtpPolicyList(request.getRequestObject());
-        logger.info("The getOtpPolicyList request succeeded");
+        logger.info("The getOtpPolicyListPost request succeeded");
         return new ObjectResponse<>(response);
     }
 

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OtpPolicyController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OtpPolicyController.java
@@ -114,7 +114,7 @@ public class OtpPolicyController {
      * @throws InvalidConfigurationException Thrown when Next Step configuration is invalid.
      */
     @RequestMapping(method = RequestMethod.GET)
-    public ObjectResponse<GetOtpPolicyListResponse> getOtpPolicyList(@RequestParam  boolean includeRemoved) throws InvalidConfigurationException {
+    public ObjectResponse<GetOtpPolicyListResponse> getOtpPolicyList(@RequestParam boolean includeRemoved) throws InvalidConfigurationException {
         logger.info("Received getOtpPolicyListPost request");
         GetOtpPolicyListRequest request = new GetOtpPolicyListRequest();
         request.setIncludeRemoved(includeRemoved);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/RoleController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/RoleController.java
@@ -31,6 +31,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.GetRoleListResp
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -45,6 +46,7 @@ import javax.validation.Valid;
  */
 @RestController
 @RequestMapping("role")
+@Validated
 public class RoleController {
 
     private static final Logger logger = LoggerFactory.getLogger(RoleController.class);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/RoleController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/RoleController.java
@@ -76,14 +76,26 @@ public class RoleController {
 
     /**
      * Get role list.
+     * @return Get role list response.
+     */
+    @RequestMapping(method = RequestMethod.GET)
+    public ObjectResponse<GetRoleListResponse> getRoleList() {
+        logger.info("Received getRoleList request");
+        final GetRoleListResponse response = roleService.getRoleList();
+        logger.info("The getRoleList request succeeded");
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Get role list using POST method.
      * @param request Get role list request.
      * @return Get role list response.
      */
     @RequestMapping(value = "list", method = RequestMethod.POST)
-    public ObjectResponse<GetRoleListResponse> getRoleList(@Valid @RequestBody ObjectRequest<GetRoleListRequest> request) {
-        logger.info("Received getRoleList request");
-        final GetRoleListResponse response = roleService.getRoleList(request.getRequestObject());
-        logger.info("The getRoleList request succeeded");
+    public ObjectResponse<GetRoleListResponse> getRoleListPost(@Valid @RequestBody ObjectRequest<GetRoleListRequest> request) {
+        logger.info("Received getRoleListPost request");
+        final GetRoleListResponse response = roleService.getRoleList();
+        logger.info("The getRoleListPost request succeeded");
         return new ObjectResponse<>(response);
     }
 

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/ServiceController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/ServiceController.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.info.BuildProperties;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
@@ -36,6 +37,7 @@ import java.util.Date;
  */
 @RestController
 @RequestMapping("api/service")
+@Validated
 public class ServiceController {
 
     private static final Logger logger = LoggerFactory.getLogger(ServiceController.class);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/StepDefinitionController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/StepDefinitionController.java
@@ -28,6 +28,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.DeleteStepDefin
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -42,6 +43,7 @@ import javax.validation.Valid;
  */
 @RestController
 @RequestMapping(value = "step/definition")
+@Validated
 public class StepDefinitionController {
 
     private static final Logger logger = LoggerFactory.getLogger(StepDefinitionController.class);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/UserController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/UserController.java
@@ -145,7 +145,7 @@ public class UserController {
      * @throws CredentialDefinitionNotFoundException Thrown when credential definition is not found.
      */
     @RequestMapping(value = "detail", method = RequestMethod.GET)
-    public ObjectResponse<GetUserDetailResponse> getUserDetail(@RequestParam @NotBlank @Size(min = 1, max = 256) String userId, @RequestParam @Nullable @Size(min = 2, max = 256) String credentialName, @RequestParam  boolean includeRemoved) throws UserNotFoundException, InvalidRequestException, InvalidConfigurationException, EncryptionException, CredentialDefinitionNotFoundException {
+    public ObjectResponse<GetUserDetailResponse> getUserDetail(@RequestParam @NotBlank @Size(min = 1, max = 256) String userId, @RequestParam @Nullable @Size(min = 2, max = 256) String credentialName, @RequestParam boolean includeRemoved) throws UserNotFoundException, InvalidRequestException, InvalidConfigurationException, EncryptionException, CredentialDefinitionNotFoundException {
         GetUserDetailRequest request = new GetUserDetailRequest();
         request.setUserId(userId);
         request.setCredentialName(credentialName);
@@ -384,7 +384,7 @@ public class UserController {
      * @throws UserNotFoundException Thrown when user identity is not found.
      */
     @RequestMapping(value = "alias", method = RequestMethod.GET)
-    public ObjectResponse<GetUserAliasListResponse> getUserAliasList(@RequestParam @NotBlank @Size(min = 1, max = 256) String userId, @RequestParam  boolean includeRemoved) throws InvalidRequestException, UserNotFoundException {
+    public ObjectResponse<GetUserAliasListResponse> getUserAliasList(@RequestParam @NotBlank @Size(min = 1, max = 256) String userId, @RequestParam boolean includeRemoved) throws InvalidRequestException, UserNotFoundException {
         logger.info("Received getUserAliasList request, user ID: {}", userId);
         GetUserAliasListRequest request = new GetUserAliasListRequest();
         request.setUserId(userId);
@@ -466,7 +466,7 @@ public class UserController {
      * @throws EncryptionException Thrown when decryption fails.
      */
     @RequestMapping(value = "credential", method = RequestMethod.GET)
-    public ObjectResponse<GetUserCredentialListResponse> getUserCredentialList(@RequestParam @NotBlank @Size(min = 1, max = 256) String userId, @RequestParam  boolean includeRemoved) throws UserNotFoundException, InvalidConfigurationException, EncryptionException {
+    public ObjectResponse<GetUserCredentialListResponse> getUserCredentialList(@RequestParam @NotBlank @Size(min = 1, max = 256) String userId, @RequestParam boolean includeRemoved) throws UserNotFoundException, InvalidConfigurationException, EncryptionException {
         logger.info("Received getUserCredentialList request, user ID: {}", userId);
         GetUserCredentialListRequest request = new GetUserCredentialListRequest();
         request.setUserId(userId);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/UserController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/UserController.java
@@ -25,12 +25,12 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+import java.util.Date;
 
 /**
  * REST controller for user identities.
@@ -131,6 +131,30 @@ public class UserController {
 
     /**
      * Get user identity detail.
+     * @param userId User ID.
+     * @param credentialName Credential definition name in case response should only include specific credential.
+     * @param includeRemoved Whether removed objects should be included.
+     * @return Get user detail response.
+     * @throws UserNotFoundException Thrown when user identity is not found.
+     * @throws InvalidRequestException Thrown when request is invalid.
+     * @throws InvalidConfigurationException Thrown when Next Step configuration is invalid.
+     * @throws EncryptionException Thrown when decryption fails.
+     * @throws CredentialDefinitionNotFoundException Thrown when credential definition is not found.
+     */
+    @RequestMapping(value = "detail", method = RequestMethod.GET)
+    public ObjectResponse<GetUserDetailResponse> getUserDetail(@RequestParam @NotBlank @Size(min = 1, max = 256) String userId, @RequestParam @Size(min = 2, max = 256) String credentialName, @RequestParam boolean includeRemoved) throws UserNotFoundException, InvalidRequestException, InvalidConfigurationException, EncryptionException, CredentialDefinitionNotFoundException {
+        GetUserDetailRequest request = new GetUserDetailRequest();
+        request.setUserId(userId);
+        request.setCredentialName(credentialName);
+        request.setIncludeRemoved(includeRemoved);
+        logger.debug("Received getUserDetail request, user ID: {}", userId);
+        final GetUserDetailResponse response = userIdentityService.getUserDetail(request);
+        logger.debug("The getUserDetail request succeeded, user ID: {}", userId);
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Get user identity detail using POST method.
      * @param request Get user detail request.
      * @return Get user detail response.
      * @throws UserNotFoundException Thrown when user identity is not found.
@@ -140,10 +164,10 @@ public class UserController {
      * @throws CredentialDefinitionNotFoundException Thrown when credential definition is not found.
      */
     @RequestMapping(value = "detail", method = RequestMethod.POST)
-    public ObjectResponse<GetUserDetailResponse> getUserDetail(@Valid @RequestBody ObjectRequest<GetUserDetailRequest> request) throws UserNotFoundException, InvalidRequestException, InvalidConfigurationException, EncryptionException, CredentialDefinitionNotFoundException {
-        logger.debug("Received getUserDetail request, user ID: {}", request.getRequestObject().getUserId());
+    public ObjectResponse<GetUserDetailResponse> getUserDetailPost(@Valid @RequestBody ObjectRequest<GetUserDetailRequest> request) throws UserNotFoundException, InvalidRequestException, InvalidConfigurationException, EncryptionException, CredentialDefinitionNotFoundException {
+        logger.debug("Received getUserDetailPost request, user ID: {}", request.getRequestObject().getUserId());
         final GetUserDetailResponse response = userIdentityService.getUserDetail(request.getRequestObject());
-        logger.debug("The getUserDetail request succeeded, user ID: {}", request.getRequestObject().getUserId());
+        logger.debug("The getUserDetailPost request succeeded, user ID: {}", request.getRequestObject().getUserId());
         return new ObjectResponse<>(response);
     }
 
@@ -259,15 +283,31 @@ public class UserController {
 
     /**
      * Get list of contacts for a user identity.
+     * @param userId User ID.
+     * @return Get user contact list response.
+     * @throws UserNotFoundException Thrown when user identity is not found.
+     */
+    @RequestMapping(value = "contact", method = RequestMethod.GET)
+    public ObjectResponse<GetUserContactListResponse> getUserContactList(@RequestParam @NotBlank @Size(min = 1, max = 256) String userId) throws UserNotFoundException {
+        logger.info("Received getUserContactList request, user ID: {}", userId);
+        GetUserContactListRequest request = new GetUserContactListRequest();
+        request.setUserId(userId);
+        final GetUserContactListResponse response = userContactService.getUserContactList(request);
+        logger.info("The getUserContactList request succeeded, user ID: {}, contact list size: {}", userId, response.getContacts().size());
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Get list of contacts for a user identity using POST method.
      * @param request Get user contact list request.
      * @return Get user contact list response.
      * @throws UserNotFoundException Thrown when user identity is not found.
      */
     @RequestMapping(value = "contact/list", method = RequestMethod.POST)
-    public ObjectResponse<GetUserContactListResponse> getUserContactList(@Valid @RequestBody ObjectRequest<GetUserContactListRequest> request) throws UserNotFoundException {
-        logger.info("Received getUserContactList request, user ID: {}", request.getRequestObject().getUserId());
+    public ObjectResponse<GetUserContactListResponse> getUserContactListPost(@Valid @RequestBody ObjectRequest<GetUserContactListRequest> request) throws UserNotFoundException {
+        logger.info("Received getUserContactListPost request, user ID: {}", request.getRequestObject().getUserId());
         final GetUserContactListResponse response = userContactService.getUserContactList(request.getRequestObject());
-        logger.info("The getUserContactList request succeeded, user ID: {}, contact list size: {}", request.getRequestObject().getUserId(), response.getContacts().size());
+        logger.info("The getUserContactListPost request succeeded, user ID: {}, contact list size: {}", request.getRequestObject().getUserId(), response.getContacts().size());
         return new ObjectResponse<>(response);
     }
 
@@ -334,16 +374,35 @@ public class UserController {
 
     /**
      * Get alias list for a user identity.
+     * @param userId User ID.
+     * @param includeRemoved Whether removed aliases should be included.
+     * @return Get user alias list response.
+     * @throws InvalidRequestException Thrown when request is invalid.
+     * @throws UserNotFoundException Thrown when user identity is not found.
+     */
+    @RequestMapping(value = "alias", method = RequestMethod.GET)
+    public ObjectResponse<GetUserAliasListResponse> getUserAliasList(@RequestParam @NotBlank @Size(min = 1, max = 256) String userId, @RequestParam boolean includeRemoved) throws InvalidRequestException, UserNotFoundException {
+        logger.info("Received getUserAliasList request, user ID: {}", userId);
+        GetUserAliasListRequest request = new GetUserAliasListRequest();
+        request.setUserId(userId);
+        request.setIncludeRemoved(includeRemoved);
+        final GetUserAliasListResponse response = userAliasService.getUserAliasList(request);
+        logger.info("The getUserAliasList request succeeded, user ID: {}, alias list size: {}", userId, response.getAliases().size());
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Get alias list for a user identity using POST method.
      * @param request Get user alias list request.
      * @return Get user alias list response.
      * @throws InvalidRequestException Thrown when request is invalid.
      * @throws UserNotFoundException Thrown when user identity is not found.
      */
     @RequestMapping(value = "alias/list", method = RequestMethod.POST)
-    public ObjectResponse<GetUserAliasListResponse> getUserAliasList(@Valid @RequestBody ObjectRequest<GetUserAliasListRequest> request) throws InvalidRequestException, UserNotFoundException {
-        logger.info("Received getUserAliasList request, user ID: {}", request.getRequestObject().getUserId());
+    public ObjectResponse<GetUserAliasListResponse> getUserAliasListPost(@Valid @RequestBody ObjectRequest<GetUserAliasListRequest> request) throws InvalidRequestException, UserNotFoundException {
+        logger.info("Received getUserAliasListPost request, user ID: {}", request.getRequestObject().getUserId());
         final GetUserAliasListResponse response = userAliasService.getUserAliasList(request.getRequestObject());
-        logger.info("The getUserAliasList request succeeded, user ID: {}, alias list size: {}", request.getRequestObject().getUserId(), response.getAliases().size());
+        logger.info("The getUserAliasListPost request succeeded, user ID: {}, alias list size: {}", request.getRequestObject().getUserId(), response.getAliases().size());
         return new ObjectResponse<>(response);
     }
 
@@ -396,6 +455,26 @@ public class UserController {
 
     /**
      * Get credential list for a user identity.
+     * @param userId User ID.
+     * @param includeRemoved Whether removed credentials should be included.
+     * @return Get user credential list response.
+     * @throws UserNotFoundException Thrown when user identity is not found.
+     * @throws InvalidConfigurationException Thrown when Next Step configuration is invalid.
+     * @throws EncryptionException Thrown when decryption fails.
+     */
+    @RequestMapping(value = "credential", method = RequestMethod.GET)
+    public ObjectResponse<GetUserCredentialListResponse> getUserCredentialList(@RequestParam @NotBlank @Size(min = 1, max = 256) String userId, @RequestParam boolean includeRemoved) throws UserNotFoundException, InvalidConfigurationException, EncryptionException {
+        logger.info("Received getUserCredentialList request, user ID: {}", userId);
+        GetUserCredentialListRequest request = new GetUserCredentialListRequest();
+        request.setUserId(userId);
+        request.setIncludeRemoved(includeRemoved);
+        final GetUserCredentialListResponse response = credentialService.getCredentialList(request);
+        logger.info("The getUserCredentialList request succeeded, user ID: {}, credential list size: {}", userId, response.getCredentials().size());
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Get credential list for a user identity using POST method.
      * @param request Get user credential list request.
      * @return Get user credential list response.
      * @throws UserNotFoundException Thrown when user identity is not found.
@@ -403,24 +482,44 @@ public class UserController {
      * @throws EncryptionException Thrown when decryption fails.
      */
     @RequestMapping(value = "credential/list", method = RequestMethod.POST)
-    public ObjectResponse<GetUserCredentialListResponse> getUserCredentialList(@Valid @RequestBody ObjectRequest<GetUserCredentialListRequest> request) throws UserNotFoundException, InvalidConfigurationException, EncryptionException {
-        logger.info("Received getUserCredentialList request, user ID: {}", request.getRequestObject().getUserId());
+    public ObjectResponse<GetUserCredentialListResponse> getUserCredentialListPost(@Valid @RequestBody ObjectRequest<GetUserCredentialListRequest> request) throws UserNotFoundException, InvalidConfigurationException, EncryptionException {
+        logger.info("Received getUserCredentialListPost request, user ID: {}", request.getRequestObject().getUserId());
         final GetUserCredentialListResponse response = credentialService.getCredentialList(request.getRequestObject());
-        logger.info("The getUserCredentialList request succeeded, user ID: {}, credential list size: {}", request.getRequestObject().getUserId(), response.getCredentials().size());
+        logger.info("The getUserCredentialListPost request succeeded, user ID: {}, credential list size: {}", request.getRequestObject().getUserId(), response.getCredentials().size());
         return new ObjectResponse<>(response);
     }
 
     /**
-     * Get authentication list for a user identity.
+     * Get authentication list for a user identity using.
+     * @param userId User ID.
+     * @param createdStartDate Credential start date.
+     * @param createdEndDate Credential end date.
+     * @return Get user authentication list response.
+     * @throws UserNotFoundException Thrown when user identity is not found.
+     */
+    @RequestMapping(value = "authentication", method = RequestMethod.GET)
+    public ObjectResponse<GetUserAuthenticationListResponse> getUserAuthenticationList(@RequestParam @NotBlank @Size(min = 1, max = 256) String userId, @RequestParam Date createdStartDate, @RequestParam Date createdEndDate) throws UserNotFoundException {
+        logger.info("Received getUserAuthenticationList request, user ID: {}", userId);
+        GetUserAuthenticationListRequest request = new GetUserAuthenticationListRequest();
+        request.setUserId(userId);
+        request.setCreatedStartDate(createdStartDate);
+        request.setCreatedEndDate(createdEndDate);
+        final GetUserAuthenticationListResponse response = authenticationService.getUserAuthenticationList(request);
+        logger.info("The getUserAuthenticationList request succeeded, user ID: {}, authentication list size: {}", userId, response.getAuthentications().size());
+        return new ObjectResponse<>(response);
+    }
+
+    /**
+     * Get authentication list for a user identity using POST method.
      * @param request Get user authentication list request.
      * @return Get user authentication list response.
      * @throws UserNotFoundException Thrown when user identity is not found.
      */
     @RequestMapping(value = "authentication/list", method = RequestMethod.POST)
-    public ObjectResponse<GetUserAuthenticationListResponse> getUserAuthenticationList(@Valid @RequestBody ObjectRequest<GetUserAuthenticationListRequest> request) throws UserNotFoundException {
-        logger.info("Received getUserAuthenticationList request, user ID: {}", request.getRequestObject().getUserId());
+    public ObjectResponse<GetUserAuthenticationListResponse> getUserAuthenticationListPost(@Valid @RequestBody ObjectRequest<GetUserAuthenticationListRequest> request) throws UserNotFoundException {
+        logger.info("Received getUserAuthenticationListPost request, user ID: {}", request.getRequestObject().getUserId());
         final GetUserAuthenticationListResponse response = authenticationService.getUserAuthenticationList(request.getRequestObject());
-        logger.info("The getUserAuthenticationList request succeeded, user ID: {}, authentication list size: {}", request.getRequestObject().getUserId(), response.getAuthentications().size());
+        logger.info("The getUserAuthenticationListPost request succeeded, user ID: {}, authentication list size: {}", request.getRequestObject().getUserId(), response.getAuthentications().size());
         return new ObjectResponse<>(response);
     }
 

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/UserController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/UserController.java
@@ -25,8 +25,10 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import javax.annotation.Nullable;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
@@ -39,6 +41,7 @@ import java.util.Date;
  */
 @RestController
 @RequestMapping("user")
+@Validated
 public class UserController {
 
     private static final Logger logger = LoggerFactory.getLogger(UserController.class);
@@ -142,7 +145,7 @@ public class UserController {
      * @throws CredentialDefinitionNotFoundException Thrown when credential definition is not found.
      */
     @RequestMapping(value = "detail", method = RequestMethod.GET)
-    public ObjectResponse<GetUserDetailResponse> getUserDetail(@RequestParam @NotBlank @Size(min = 1, max = 256) String userId, @RequestParam @Size(min = 2, max = 256) String credentialName, @RequestParam boolean includeRemoved) throws UserNotFoundException, InvalidRequestException, InvalidConfigurationException, EncryptionException, CredentialDefinitionNotFoundException {
+    public ObjectResponse<GetUserDetailResponse> getUserDetail(@RequestParam @NotBlank @Size(min = 1, max = 256) String userId, @RequestParam @Nullable @Size(min = 2, max = 256) String credentialName, @RequestParam  boolean includeRemoved) throws UserNotFoundException, InvalidRequestException, InvalidConfigurationException, EncryptionException, CredentialDefinitionNotFoundException {
         GetUserDetailRequest request = new GetUserDetailRequest();
         request.setUserId(userId);
         request.setCredentialName(credentialName);
@@ -381,7 +384,7 @@ public class UserController {
      * @throws UserNotFoundException Thrown when user identity is not found.
      */
     @RequestMapping(value = "alias", method = RequestMethod.GET)
-    public ObjectResponse<GetUserAliasListResponse> getUserAliasList(@RequestParam @NotBlank @Size(min = 1, max = 256) String userId, @RequestParam boolean includeRemoved) throws InvalidRequestException, UserNotFoundException {
+    public ObjectResponse<GetUserAliasListResponse> getUserAliasList(@RequestParam @NotBlank @Size(min = 1, max = 256) String userId, @RequestParam  boolean includeRemoved) throws InvalidRequestException, UserNotFoundException {
         logger.info("Received getUserAliasList request, user ID: {}", userId);
         GetUserAliasListRequest request = new GetUserAliasListRequest();
         request.setUserId(userId);
@@ -463,7 +466,7 @@ public class UserController {
      * @throws EncryptionException Thrown when decryption fails.
      */
     @RequestMapping(value = "credential", method = RequestMethod.GET)
-    public ObjectResponse<GetUserCredentialListResponse> getUserCredentialList(@RequestParam @NotBlank @Size(min = 1, max = 256) String userId, @RequestParam boolean includeRemoved) throws UserNotFoundException, InvalidConfigurationException, EncryptionException {
+    public ObjectResponse<GetUserCredentialListResponse> getUserCredentialList(@RequestParam @NotBlank @Size(min = 1, max = 256) String userId, @RequestParam  boolean includeRemoved) throws UserNotFoundException, InvalidConfigurationException, EncryptionException {
         logger.info("Received getUserCredentialList request, user ID: {}", userId);
         GetUserCredentialListRequest request = new GetUserCredentialListRequest();
         request.setUserId(userId);
@@ -498,7 +501,7 @@ public class UserController {
      * @throws UserNotFoundException Thrown when user identity is not found.
      */
     @RequestMapping(value = "authentication", method = RequestMethod.GET)
-    public ObjectResponse<GetUserAuthenticationListResponse> getUserAuthenticationList(@RequestParam @NotBlank @Size(min = 1, max = 256) String userId, @RequestParam Date createdStartDate, @RequestParam Date createdEndDate) throws UserNotFoundException {
+    public ObjectResponse<GetUserAuthenticationListResponse> getUserAuthenticationList(@RequestParam @NotBlank @Size(min = 1, max = 256) String userId, @RequestParam @Nullable Date createdStartDate, @RequestParam @Nullable Date createdEndDate) throws UserNotFoundException {
         logger.info("Received getUserAuthenticationList request, user ID: {}", userId);
         GetUserAuthenticationListRequest request = new GetUserAuthenticationListRequest();
         request.setUserId(userId);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/OrganizationService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/OrganizationService.java
@@ -25,7 +25,6 @@ import io.getlime.security.powerauth.lib.nextstep.model.exception.OrganizationNo
 import io.getlime.security.powerauth.lib.nextstep.model.request.CreateOrganizationRequest;
 import io.getlime.security.powerauth.lib.nextstep.model.request.DeleteOrganizationRequest;
 import io.getlime.security.powerauth.lib.nextstep.model.request.GetOrganizationDetailRequest;
-import io.getlime.security.powerauth.lib.nextstep.model.request.GetOrganizationListRequest;
 import io.getlime.security.powerauth.lib.nextstep.model.response.CreateOrganizationResponse;
 import io.getlime.security.powerauth.lib.nextstep.model.response.DeleteOrganizationResponse;
 import io.getlime.security.powerauth.lib.nextstep.model.response.GetOrganizationDetailResponse;
@@ -110,11 +109,10 @@ public class OrganizationService {
 
     /**
      * Get organization list.
-     * @param requestObject Get organization list request.
      * @return Get organization list response.
      */
     @Transactional
-    public GetOrganizationListResponse getOrganizationList(GetOrganizationListRequest requestObject) {
+    public GetOrganizationListResponse getOrganizationList() {
         final GetOrganizationListResponse response = new GetOrganizationListResponse();
         final List<OrganizationEntity> organizations = organizationRepository.findAllByOrderByOrderNumber();
         for (OrganizationEntity organization: organizations) {

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/RoleService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/RoleService.java
@@ -25,7 +25,6 @@ import io.getlime.security.powerauth.lib.nextstep.model.exception.RoleAlreadyExi
 import io.getlime.security.powerauth.lib.nextstep.model.exception.RoleNotFoundException;
 import io.getlime.security.powerauth.lib.nextstep.model.request.CreateRoleRequest;
 import io.getlime.security.powerauth.lib.nextstep.model.request.DeleteRoleRequest;
-import io.getlime.security.powerauth.lib.nextstep.model.request.GetRoleListRequest;
 import io.getlime.security.powerauth.lib.nextstep.model.response.CreateRoleResponse;
 import io.getlime.security.powerauth.lib.nextstep.model.response.DeleteRoleResponse;
 import io.getlime.security.powerauth.lib.nextstep.model.response.GetRoleListResponse;
@@ -89,11 +88,10 @@ public class RoleService {
 
     /**
      * Get list of roles.
-     * @param request Get role list request.
      * @return Get role list response.
      */
     @Transactional
-    public GetRoleListResponse getRoleList(GetRoleListRequest request) {
+    public GetRoleListResponse getRoleList() {
         final Iterable<RoleEntity> roles = roleRepository.findAll();
         final GetRoleListResponse response = new GetRoleListResponse();
         for (RoleEntity role : roles) {

--- a/powerauth-nextstep/src/test/java/io/getlime/security/powerauth/app/nextstep/NextStepUserIdentityTest.java
+++ b/powerauth-nextstep/src/test/java/io/getlime/security/powerauth/app/nextstep/NextStepUserIdentityTest.java
@@ -80,7 +80,7 @@ public class NextStepUserIdentityTest extends NextStepTest {
         CredentialAuthenticationResponse r3 = nextStepClient.authenticateWithCredential("TEST_CREDENTIAL", r2.getUser().getUserId(), credentialValue).getResponseObject();
         assertEquals(AuthenticationResult.SUCCEEDED, r3.getAuthenticationResult());
         assertEquals(CredentialStatus.ACTIVE, r3.getCredentialStatus());
-        GetUserDetailResponse r4 = nextStepClient.getUserDetail(userId).getResponseObject();
+        GetUserDetailResponse r4 = nextStepClient.getUserDetail(userId, false).getResponseObject();
         assertEquals(userId, r4.getUserId());
         assertEquals(1, r4.getCredentials().size());
         assertEquals(1, r4.getContacts().size());
@@ -116,7 +116,7 @@ public class NextStepUserIdentityTest extends NextStepTest {
         assertEquals(UserIdentityStatus.ACTIVE, r10.getUserIdentityStatus());
         assertNotNull(r10.getCredentials().get(0).getCredentialValue());
         assertFalse(r10.getCredentials().get(0).isCredentialChangeRequired());
-        GetUserDetailResponse r11 = nextStepClient.getUserDetail(userId).getResponseObject();
+        GetUserDetailResponse r11 = nextStepClient.getUserDetail(userId, false).getResponseObject();
         // Check that the credential is active
         assertEquals(CredentialStatus.ACTIVE, r11.getCredentials().get(0).getCredentialStatus());
         assertNotNull(r11.getTimestampLastUpdated());
@@ -197,14 +197,14 @@ public class NextStepUserIdentityTest extends NextStepTest {
         assertEquals(userId, r2.getUserId());
         assertEquals("TEST_ROLE", r2.getRoleName());
         assertEquals(UserRoleStatus.ACTIVE, r2.getUserRoleStatus());
-        GetUserDetailResponse r3 = nextStepClient.getUserDetail(userId).getResponseObject();
+        GetUserDetailResponse r3 = nextStepClient.getUserDetail(userId, false).getResponseObject();
         assertEquals(1, r3.getRoles().size());
         assertEquals("TEST_ROLE", r3.getRoles().get(0));
         RemoveUserRoleResponse r4 = nextStepClient.removeUserRole(userId, "TEST_ROLE").getResponseObject();
         assertEquals(userId, r4.getUserId());
         assertEquals("TEST_ROLE", r4.getRoleName());
         assertEquals(UserRoleStatus.REMOVED, r4.getUserRoleStatus());
-        GetUserDetailResponse r5 = nextStepClient.getUserDetail(userId).getResponseObject();
+        GetUserDetailResponse r5 = nextStepClient.getUserDetail(userId, false).getResponseObject();
         assertTrue(r5.getRoles().isEmpty());
     }
 
@@ -222,7 +222,7 @@ public class NextStepUserIdentityTest extends NextStepTest {
         assertEquals("TEST_ALIAS", r2.getAliasName());
         assertEquals("TEST_VALUE", r2.getAliasValue());
         assertTrue(r2.getExtras().isEmpty());
-        GetUserAliasListResponse r3 = nextStepClient.getUserAliasList(userId).getResponseObject();
+        GetUserAliasListResponse r3 = nextStepClient.getUserAliasList(userId, false).getResponseObject();
         assertEquals(userId, r3.getUserId());
         assertEquals(1, r3.getAliases().size());
         assertEquals("TEST_ALIAS", r3.getAliases().get(0).getAliasName());
@@ -232,14 +232,14 @@ public class NextStepUserIdentityTest extends NextStepTest {
         assertEquals("TEST_ALIAS", r4.getAliasName());
         assertEquals("TEST_VALUE_2", r4.getAliasValue());
         assertTrue(r4.getExtras().isEmpty());
-        GetUserAliasListResponse r5 = nextStepClient.getUserAliasList(userId).getResponseObject();
+        GetUserAliasListResponse r5 = nextStepClient.getUserAliasList(userId, false).getResponseObject();
         assertEquals(userId, r5.getUserId());
         assertEquals(1, r5.getAliases().size());
         assertEquals("TEST_ALIAS", r5.getAliases().get(0).getAliasName());
         assertEquals("TEST_VALUE_2", r5.getAliases().get(0).getAliasValue());
         DeleteUserAliasResponse r6 = nextStepClient.deleteUserAlias(userId, "TEST_ALIAS").getResponseObject();
         assertEquals(UserAliasStatus.REMOVED, r6.getUserAliasStatus());
-        GetUserAliasListResponse r7 = nextStepClient.getUserAliasList(userId).getResponseObject();
+        GetUserAliasListResponse r7 = nextStepClient.getUserAliasList(userId, false).getResponseObject();
         assertEquals(userId, r7.getUserId());
         assertTrue(r7.getAliases().isEmpty());
     }


### PR DESCRIPTION
I added `GET` method alternatives for REST API methods used for getting lists and details.