### PR TITLE
Fix #987: Use null value in NO_USERNAME algorithm

### DIFF
--- a/docs/sql/oracle/create_schema.sql
+++ b/docs/sql/oracle/create_schema.sql
@@ -612,6 +612,7 @@ CREATE UNIQUE INDEX ns_otp_definition_name ON ns_otp_definition (name);
 CREATE INDEX ns_credential_storage_user_id ON ns_credential_storage (user_id);
 CREATE INDEX ns_credential_storage_status ON ns_credential_storage (status);
 CREATE UNIQUE INDEX ns_credential_storage_query1 ON ns_credential_storage (CASE when user_name IS NOT null THEN credential_definition_id || user_name END);
+CREATE INDEX ns_credential_storage_query1_perf ON ns_credential_storage (credential_definition_id, user_name);
 CREATE UNIQUE INDEX ns_credential_storage_query2 ON ns_credential_storage (user_id, credential_definition_id);
 CREATE INDEX ns_credential_storage_query3 ON ns_credential_storage (credential_definition_id, status);
 CREATE INDEX ns_credential_history_user_id ON ns_credential_history (user_id);

--- a/docs/sql/oracle/create_schema.sql
+++ b/docs/sql/oracle/create_schema.sql
@@ -611,7 +611,7 @@ CREATE UNIQUE INDEX ns_credential_definition_name ON ns_credential_definition (n
 CREATE UNIQUE INDEX ns_otp_definition_name ON ns_otp_definition (name);
 CREATE INDEX ns_credential_storage_user_id ON ns_credential_storage (user_id);
 CREATE INDEX ns_credential_storage_status ON ns_credential_storage (status);
-CREATE UNIQUE INDEX ns_credential_storage_query1 ON ns_credential_storage (credential_definition_id, user_name);
+CREATE UNIQUE INDEX ns_credential_storage_query1 ON ns_credential_storage (CASE when user_name IS NOT null THEN credential_definition_id || user_name END);
 CREATE UNIQUE INDEX ns_credential_storage_query2 ON ns_credential_storage (user_id, credential_definition_id);
 CREATE INDEX ns_credential_storage_query3 ON ns_credential_storage (credential_definition_id, status);
 CREATE INDEX ns_credential_history_user_id ON ns_credential_history (user_id);

--- a/docs/sql/oracle/create_schema.sql
+++ b/docs/sql/oracle/create_schema.sql
@@ -611,7 +611,7 @@ CREATE UNIQUE INDEX ns_credential_definition_name ON ns_credential_definition (n
 CREATE UNIQUE INDEX ns_otp_definition_name ON ns_otp_definition (name);
 CREATE INDEX ns_credential_storage_user_id ON ns_credential_storage (user_id);
 CREATE INDEX ns_credential_storage_status ON ns_credential_storage (status);
-CREATE UNIQUE INDEX ns_credential_storage_query1 ON ns_credential_storage (CASE when user_name IS NOT null THEN credential_definition_id || user_name END);
+CREATE UNIQUE INDEX ns_credential_storage_query1 ON ns_credential_storage (CASE WHEN user_name IS NOT NULL THEN credential_definition_id || '&' || user_name END);
 CREATE INDEX ns_credential_storage_query1_perf ON ns_credential_storage (credential_definition_id, user_name);
 CREATE UNIQUE INDEX ns_credential_storage_query2 ON ns_credential_storage (user_id, credential_definition_id);
 CREATE INDEX ns_credential_storage_query3 ON ns_credential_storage (credential_definition_id, status);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/CredentialGenerationService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/CredentialGenerationService.java
@@ -92,7 +92,7 @@ public class CredentialGenerationService {
                 }
 
             case NO_USERNAME:
-                return "";
+                return null;
 
             default:
                 throw new InvalidConfigurationException("Unsupported username generation algorithm: " + credentialPolicy.getUsernameGenAlgorithm());


### PR DESCRIPTION
The `null` value for username needs to be used for credentials which have no usernames at all due to unique index constraint.

In Oracle multiple `null` values are not allowed in composite unique indexes. Thus, the unique index definition has to handle the `null` username case implicitly. A non-unique index for username was added for Oracle for performance reasons, too. 

In other supported databases multiple `null` values are allowed in composite unique indexes, so no DDL changes are required and the database queries correctly process both use cases (`null` usernames for PINs and `non-null` unique usernames for passwords).