### PR TITLE
Fix #994: Allow setting custom credential expiration for temporary credential migration

### DIFF
--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/request/CreateCredentialRequest.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/request/CreateCredentialRequest.java
@@ -23,6 +23,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -45,6 +46,7 @@ public class CreateCredentialRequest {
     private String username;
     @Size(min = 1, max = 256)
     private String credentialValue;
+    private Date timestampExpires;
     // Null value allowed, defaults to CredentialValidationMode.VALIDATE_USERNAME_AND_CREDENTIAL
     private CredentialValidationMode validationMode;
     @Valid

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/request/CreateUserRequest.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/request/CreateUserRequest.java
@@ -24,10 +24,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Request object used for creating a user identity.
@@ -78,6 +75,7 @@ public class CreateUserRequest {
         private String username;
         @Size(min = 1, max = 256)
         private String credentialValue;
+        private Date timestampExpires;
         // Null value allowed, defaults to CredentialValidationMode.VALIDATE_USERNAME_AND_CREDENTIAL
         private CredentialValidationMode validationMode;
         @Valid

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/request/ResetCredentialRequest.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/request/ResetCredentialRequest.java
@@ -20,6 +20,7 @@ import lombok.Data;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
+import java.util.Date;
 
 /**
  * Request object used for resetting a credential.
@@ -36,5 +37,6 @@ public class ResetCredentialRequest {
     @Size(min = 2, max = 256)
     private String credentialName;
     private CredentialType credentialType;
+    private Date timestampExpires;
 
 }

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/request/UpdateCredentialRequest.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/request/UpdateCredentialRequest.java
@@ -21,6 +21,7 @@ import lombok.Data;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
+import java.util.Date;
 
 /**
  * Request object used for updating a credential.
@@ -41,6 +42,7 @@ public class UpdateCredentialRequest {
     private String username;
     @Size(min = 1, max = 256)
     private String credentialValue;
+    private Date timestampExpires;
     private CredentialStatus credentialStatus;
 
 }

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/request/UpdateUserRequest.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/request/UpdateUserRequest.java
@@ -24,6 +24,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -78,6 +79,7 @@ public class UpdateUserRequest {
         private String username;
         @Size(min = 1, max = 256)
         private String credentialValue;
+        private Date timestampExpires;
 
     }
 

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/UserIdentityService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/UserIdentityService.java
@@ -156,7 +156,8 @@ public class UserIdentityService {
                     validationMode = CredentialValidationMode.VALIDATE_USERNAME_AND_CREDENTIAL;
                 }
                 final CredentialSecretDetail credentialDetail = credentialService.createCredential(user, credentialDefinition,
-                        credential.getCredentialType(), credential.getUsername(), credentialValueRequest, validationMode);
+                        credential.getCredentialType(), credential.getUsername(), credentialValueRequest,
+                        credential.getTimestampExpires(), validationMode);
                 if (credentialHistory != null && !credentialHistory.isEmpty()) {
                     final int dateCount = credentialHistory.size();
                     // Use unique timestamps in seconds to keep order of credential history
@@ -268,7 +269,8 @@ public class UserIdentityService {
                         credentialValueRequest = endToEndEncryptionService.decryptCredential(credentialValueRequest, credentialDefinition);
                     }
                     final CredentialSecretDetail credentialDetail = credentialService.createCredential(user, credentialDefinition,
-                            credential.getCredentialType(), credential.getUsername(), credentialValueRequest, CredentialValidationMode.VALIDATE_USERNAME_AND_CREDENTIAL);
+                            credential.getCredentialType(), credential.getUsername(), credentialValueRequest,
+                            credential.getTimestampExpires(), CredentialValidationMode.VALIDATE_USERNAME_AND_CREDENTIAL);
                     // Return generated credential value, with possible end2end encryption
                     if (credentialValueRequest == null && credentialDefinition.isE2eEncryptionEnabled()) {
                         final String credentialValueResponse = credentialDetail.getCredentialValue();


### PR DESCRIPTION
I added the possibility to override credential expiration timestamp into all cases where credential expiration is handled.