### PR TITLE
Fix #997: Add option to disallow login with temporary credentials in Web Flow

### DIFF
--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/configuration/WebFlowServicesConfiguration.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/configuration/WebFlowServicesConfiguration.java
@@ -95,6 +95,12 @@ public class WebFlowServicesConfiguration {
     private String passwordEncryptionKey;
 
     /**
+     * Whether authentication with temporary credentials is allowed in Web Flow.
+     */
+    @Value("${powerauth.webflow.authentication.allowTemporaryCredentials:false}")
+    private boolean authenticationWithTemporaryCredentialsAllowed;
+
+    /**
      * Delay for resending SMS in milliseconds.
      */
     @Value("${powerauth.webflow.sms.resend.delayMs:60000}")
@@ -234,6 +240,14 @@ public class WebFlowServicesConfiguration {
      */
     public String getPasswordEncryptionKey() {
         return passwordEncryptionKey;
+    }
+
+    /**
+     * Get whether authentication with temporary credentials is allowed.
+     * @return Whether authentication with temporary credentials is allowed.
+     */
+    public boolean isAuthenticationWithTemporaryCredentialsAllowed() {
+        return authenticationWithTemporaryCredentialsAllowed;
     }
 
     /**

--- a/powerauth-webflow/src/main/resources/application.properties
+++ b/powerauth-webflow/src/main/resources/application.properties
@@ -70,6 +70,9 @@ powerauth.webflow.password.protection.type=NO_PROTECTION
 powerauth.webflow.password.encryption.transformation=
 powerauth.webflow.password.encryption.key=
 
+# Configuration of authentication using temporary credentials
+powerauth.webflow.authentication.allowTemporaryCredentials=false
+
 # Configuration of Delay for Resending SMS in Milliseconds
 powerauth.webflow.sms.resend.delayMs=60000
 


### PR DESCRIPTION
This pull request implements credential type check. By default it is not possible to login using TEMPORARY credentials but it can be changed in configuration.

The implementation differs slightly for 2 cases:
- username and password authentication: authentication fails for TEMPORARY credentials
- SCA use case: fake SMS authentication page is presented to user for TEMPORARY credentials

In case Data Adapter proxy is enabled in Next Step the information about credential type is not available, the behaviour is the same as before, it is expected that system which performs the authentication does not allow it for TEMPORARY credentials if required.