### PR TITLE
Fix #1012: Cors exception in Web Flow

### DIFF
--- a/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/configuration/WebSocketConfiguration.java
+++ b/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/configuration/WebSocketConfiguration.java
@@ -49,7 +49,7 @@ public class WebSocketConfiguration implements WebSocketMessageBrokerConfigurer 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         WebSocketHandshakeInterceptor interceptor = new WebSocketHandshakeInterceptor(configuration.isAfsIpAddressDetectionEnabled(), configuration.isAfsIpv4Forced());
-        registry.addEndpoint("/websocket").addInterceptors(interceptor).setAllowedOrigins("*").withSockJS();
+        registry.addEndpoint("/websocket").addInterceptors(interceptor).setAllowedOriginPatterns("*").withSockJS();
     }
 
     /**


### PR DESCRIPTION
Spring Framework introduced a new method for Cors patterns: `setAllowedOriginPatterns`.