### PR TITLE
Fix #1034: Error while generating Javadoc

### DIFF
--- a/docs/Web-Flow-1.1.0.md
+++ b/docs/Web-Flow-1.1.0.md
@@ -1,5 +1,9 @@
 # Migration from 1.0.0 to 1.1.0
 
+## Updated Minimum Java Runtime Version
+
+The minimum required Java runtime version has been updated to Java 11. This version is suggested for deployment because version 11 is a long term support (LTS) version of Java. The software should work`` on Java versions 11, 12, 13, 14, and 15.
+
 ## Embedded Bouncy Castle Library (Version 1.68)
 
 Bouncy Castle library has been updated to version `1.68` and it is now **included directly in the application bundle (\*.war)** for both Web Flow and Next Step.

--- a/pom.xml
+++ b/pom.xml
@@ -89,8 +89,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
         <maven-javadoc-plugin.version>3.3.0</maven-javadoc-plugin.version>
         <maven-war-plugin.version>3.3.1</maven-war-plugin.version>


### PR DESCRIPTION
I suggest we switch the source and target to Java 11. This will not only fix the Javadoc errors, but it will cause a migration to a new and better supported LTS version of Java.

Java 8 has gone through the End of Public Updates process for legacy releases, although commerical support is still available.