### PR TITLE
Allow targeting to JDK 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,8 +89,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+<!--        <maven.compiler.source>11</maven.compiler.source>-->
+<!--        <maven.compiler.target>8</maven.compiler.target>-->
+        <maven.compiler.release>8</maven.compiler.release>
         <maven-jar-plugin.version>3.2.2</maven-jar-plugin.version>
         <maven-javadoc-plugin.version>3.4.0</maven-javadoc-plugin.version>
         <maven-war-plugin.version>3.3.2</maven-war-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -89,8 +89,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-<!--        <maven.compiler.source>11</maven.compiler.source>-->
-<!--        <maven.compiler.target>8</maven.compiler.target>-->
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
         <maven.compiler.release>8</maven.compiler.release>
         <maven-jar-plugin.version>3.2.2</maven-jar-plugin.version>
         <maven-javadoc-plugin.version>3.4.0</maven-javadoc-plugin.version>

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/AuthenticationService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/AuthenticationService.java
@@ -833,7 +833,7 @@ public class AuthenticationService {
             logger.info("Credential verification failed because temporary credential is expired, user ID: {}, credential definition name: {}", credential.getUser().getUserId(), credential.getCredentialDefinition().getName());
             return AuthenticationResult.FAILED;
         }
-        final CredentialAuthenticationMode authModeResolved = Objects.requireNonNullElse(authenticationMode, CredentialAuthenticationMode.MATCH_EXACT);
+        final CredentialAuthenticationMode authModeResolved = authenticationMode != null ? authenticationMode : CredentialAuthenticationMode.MATCH_EXACT;
         switch (authModeResolved) {
             case MATCH_EXACT:
                 final boolean credentialMatched = credentialProtectionService.verifyCredential(credentialValue, credential);
@@ -949,7 +949,8 @@ public class AuthenticationService {
                 return null;
             }
             try {
-                final List<AuthStep> authSteps = objectMapper.readValue(currentHistory.getResponseSteps(), new TypeReference<>() {});
+
+                final List<AuthStep> authSteps = objectMapper.readValue(currentHistory.getResponseSteps(), new TypeReference<List<AuthStep>>() {});
                 if (authSteps.size() != 1) {
                     throw new InvalidRequestException("Authentication method could not be determined " +
                             "during credential authentication, operation ID: " + operation.getOperationId());

--- a/powerauth-tpp-engine-model/pom.xml
+++ b/powerauth-tpp-engine-model/pom.xml
@@ -61,13 +61,7 @@
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <source>11</source>
-                    <target>11</target>
-                    <compilerArgs>
-                        <arg>--add-exports</arg>
-                        <arg>java.base/sun.security.util=ALL-UNNAMED</arg>
-                        <arg>--add-exports</arg>
-                        <arg>java.base/sun.security.x509=ALL-UNNAMED</arg>
-                    </compilerArgs>
+                    <target>8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/powerauth-webflow-authentication-sms/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/sms/controller/SmsAuthorizationController.java
+++ b/powerauth-webflow-authentication-sms/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/sms/controller/SmsAuthorizationController.java
@@ -65,6 +65,7 @@ import org.springframework.web.bind.annotation.RestController;
 import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -785,7 +786,7 @@ public class SmsAuthorizationController extends AuthMethodController<SmsAuthoriz
      * @throws AuthStepException In case step authentication fails.
      */
     private AuthResultDetail verifySignatureUsingQualifiedCertificateAndOtp(String operationId, String userId, String organizationId, String signedMessage, String authCode, AuthMethod authMethod, AccountStatus accountStatus, OperationContext operationContext) throws DataAdapterClientErrorException, NextStepClientException, AuthStepException {
-        final List<AuthInstrument> authInstruments = List.of(AuthInstrument.OTP_KEY, AuthInstrument.QUALIFIED_CERTIFICATE);
+        final List<AuthInstrument> authInstruments = Arrays.asList(AuthInstrument.OTP_KEY, AuthInstrument.QUALIFIED_CERTIFICATE);
         // Certificate parameter is null, qualified certificate is included in signedMessage, verification is done using Data Adapter
         final ObjectResponse<VerifyCertificateResponse> objectResponseCert = dataAdapterClient.verifyCertificate(userId, organizationId, null, signedMessage,
                 AuthInstrument.QUALIFIED_CERTIFICATE, getAuthMethodName(), accountStatus, operationContext);
@@ -810,7 +811,7 @@ public class SmsAuthorizationController extends AuthMethodController<SmsAuthoriz
             throw new MaxAttemptsExceededException("Maximum number of authentication attempts exceeded");
         }
 
-        final AuthOperationResponse response = failAuthorization(operationId, userId, List.of(AuthInstrument.OTP_KEY, AuthInstrument.QUALIFIED_CERTIFICATE), null, null);
+        final AuthOperationResponse response = failAuthorization(operationId, userId, Arrays.asList(AuthInstrument.OTP_KEY, AuthInstrument.QUALIFIED_CERTIFICATE), null, null);
         if (response.getAuthResult() == AuthResult.FAILED) {
             logger.info("Step authentication maximum attempts reached for certificate verification (2FA) due to failed operation, operation ID: {}, authentication method: {}", operationId, authMethod);
             // FAILED result instead of CONTINUE means the authentication method is failed


### PR DESCRIPTION
Support for JDK 8, thanks to @saalistaja.

I suggest we merge it to `1123-payment-signing` branch, unfortunately there are still clients who insist on JDK 8.