### PR TITLE
Migrate to X500Name, code cleanup for Java 8

### DIFF
--- a/powerauth-tpp-engine-model/pom.xml
+++ b/powerauth-tpp-engine-model/pom.xml
@@ -60,7 +60,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <source>11</source>
+                    <source>8</source>
                     <target>8</target>
                 </configuration>
             </plugin>
@@ -71,10 +71,6 @@
                 <configuration>
                     <failOnError>false</failOnError>
                     <detectOfflineLinks>false</detectOfflineLinks>
-                    <additionalOptions>
-                        <option>--add-exports</option>
-                        <option>java.base/sun.security.x509=ALL-UNNAMED</option>
-                    </additionalOptions>
                 </configuration>
                 <executions>
                     <execution>

--- a/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/certificate/ICACertificateParser.java
+++ b/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/certificate/ICACertificateParser.java
@@ -22,7 +22,9 @@ import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.DLSequence;
-import org.bouncycastle.asn1.x509.X509Name;
+import org.bouncycastle.asn1.x500.AttributeTypeAndValue;
+import org.bouncycastle.asn1.x500.RDN;
+import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
@@ -38,7 +40,6 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.Vector;
 
 /**
  * Class to parse PSD2 certificates issued by I.CA certificate authority (Czech Republic).
@@ -134,10 +135,7 @@ public class ICACertificateParser implements ICertificateParser {
                     }
                 }
             }
-
-            final X509Name x509Name = (X509Name) cert.getSubjectDN();
-            final Vector<ASN1ObjectIdentifier> oids = x509Name.getOIDs();
-
+            final X500Name x500Name = new X500Name(cert.getSubjectDN().toString());
             String country = null;
             String serialNumber = null;
             String commonName = null;
@@ -148,9 +146,10 @@ public class ICACertificateParser implements ICertificateParser {
             String zipCode = null;
             String region = null;
             String website = null;
-            for (ASN1ObjectIdentifier asn1oid: oids) {
-                final String oid = asn1oid.toString();
-                final String val = x509Name.getValues(asn1oid).get(0).toString();
+            for (RDN rdn: x500Name.getRDNs()) {
+                final AttributeTypeAndValue attr = rdn.getFirst();
+                final String oid = attr.getType().getId();
+                final String val = attr.getValue().toString();
 
                 switch (oid) {
                     case "2.5.4.6": {   //    C=CZ => 2.5.4.6

--- a/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/certificate/ICACertificateParser.java
+++ b/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/certificate/ICACertificateParser.java
@@ -61,7 +61,6 @@ public class ICACertificateParser implements ICertificateParser {
      * @return Structured certificate information.
      * @throws CertificateException In case certificate cannot be parsed (or in rare case X.509 is not supported).
      */
-    @SuppressWarnings("unchecked")
     public CertInfo parse(String certificatePem) throws CertificateException {
 
         // Check for null certificate value

--- a/powerauth-webflow/pom.xml
+++ b/powerauth-webflow/pom.xml
@@ -36,7 +36,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>11</java.version>
+        <java.version>8</java.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Fixed deprecation and suppression warning, Java 8 is now used as default everywhere.