### PR TITLE
Fix #1284: Review Java warnings

### DIFF
--- a/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/converter/AttributeConverter.java
+++ b/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/converter/AttributeConverter.java
@@ -27,10 +27,10 @@ import io.getlime.security.powerauth.lib.nextstep.model.entity.attribute.*;
  */
 public class AttributeConverter {
 
-    private ValueFormatTypeConverter valueFormatTypeConverter = new ValueFormatTypeConverter();
-    private BannerTypeConverter bannerTypeConverter = new BannerTypeConverter();
-    private BankAccountListConverter bankAccountListConverter = new BankAccountListConverter();
-    private PartyInfoConverter partyInfoConverter = new PartyInfoConverter();
+    private final ValueFormatTypeConverter valueFormatTypeConverter = new ValueFormatTypeConverter();
+    private final BannerTypeConverter bannerTypeConverter = new BannerTypeConverter();
+    private final BankAccountListConverter bankAccountListConverter = new BankAccountListConverter();
+    private final PartyInfoConverter partyInfoConverter = new PartyInfoConverter();
 
     /**
      * Converter from OperationFormFieldAttribute.
@@ -42,37 +42,36 @@ public class AttributeConverter {
             return null;
         }
         switch (input.getType()) {
-            case AMOUNT: {
+            case AMOUNT -> {
                 OperationAmountFieldAttribute attr = (OperationAmountFieldAttribute) input;
                 return new AmountAttribute(attr.getId(), attr.getLabel(), attr.getAmount(), attr.getCurrency(), attr.getCurrencyId(), attr.getFormattedValues());
             }
-            case KEY_VALUE: {
+            case KEY_VALUE -> {
                 OperationKeyValueFieldAttribute attr = (OperationKeyValueFieldAttribute) input;
                 return new KeyValueAttribute(attr.getId(), attr.getLabel(), attr.getValue(), valueFormatTypeConverter.fromOperationValueFormatType(attr.getValueFormatType()), attr.getFormattedValues());
             }
-            case NOTE: {
+            case NOTE -> {
                 OperationNoteFieldAttribute attr = (OperationNoteFieldAttribute) input;
                 return new NoteAttribute(attr.getId(), attr.getLabel(), attr.getNote(), valueFormatTypeConverter.fromOperationValueFormatType(attr.getValueFormatType()), attr.getFormattedValues());
             }
-            case BANK_ACCOUNT_CHOICE: {
+            case BANK_ACCOUNT_CHOICE -> {
                 OperationBankAccountChoiceFieldAttribute attr = (OperationBankAccountChoiceFieldAttribute) input;
                 return new BankAccountChoiceAttribute(attr.getId(), attr.getLabel(), bankAccountListConverter.fromBankAccountDetailList(attr.getBankAccounts()), attr.isEnabled(), attr.getDefaultValue());
             }
-            case BANNER: {
+            case BANNER -> {
                 OperationBannerFieldAttribute attr = (OperationBannerFieldAttribute) input;
                 return new BannerAttribute(attr.getId(), attr.getLabel(), bannerTypeConverter.fromOperationBannerType(attr.getBannerType()), attr.getMessage());
             }
-            case HEADING: {
+            case HEADING -> {
                 OperationHeadingFieldAttribute attr = (OperationHeadingFieldAttribute) input;
                 return new HeadingAttribute(attr.getId(), attr.getLabel(), attr.getValue(), valueFormatTypeConverter.fromOperationValueFormatType(attr.getValueFormatType()), attr.getFormattedValues());
             }
-            case PARTY_INFO: {
+            case PARTY_INFO -> {
                 OperationPartyInfoFieldAttribute attr = (OperationPartyInfoFieldAttribute) input;
                 return new PartyInfoAttribute(attr.getId(), partyInfoConverter.fromOperationPartyInfo(attr.getPartyInfo()));
             }
-            default: {
-                throw new IllegalStateException("Unsupported attribute type: "+input.getType());
-            }
+            default ->
+                throw new IllegalStateException("Unsupported attribute type: " + input.getType());
         }
     }
 
@@ -86,37 +85,36 @@ public class AttributeConverter {
             return null;
         }
         switch (input.getType()) {
-            case AMOUNT: {
+            case AMOUNT -> {
                 AmountAttribute attr = (AmountAttribute) input;
                 return new OperationAmountFieldAttribute(attr.getId(), attr.getLabel(), attr.getAmount(), attr.getCurrency(), attr.getCurrencyId(), attr.getFormattedValues());
             }
-            case KEY_VALUE: {
+            case KEY_VALUE -> {
                 KeyValueAttribute attr = (KeyValueAttribute) input;
                 return new OperationKeyValueFieldAttribute(attr.getId(), attr.getLabel(), attr.getValue(), valueFormatTypeConverter.fromValueFormatType(attr.getValueFormatType()), attr.getFormattedValues());
             }
-            case NOTE: {
+            case NOTE -> {
                 NoteAttribute attr = (NoteAttribute) input;
                 return new OperationNoteFieldAttribute(attr.getId(), attr.getLabel(), attr.getNote(), valueFormatTypeConverter.fromValueFormatType(attr.getValueFormatType()), attr.getFormattedValues());
             }
-            case BANK_ACCOUNT_CHOICE: {
+            case BANK_ACCOUNT_CHOICE -> {
                 BankAccountChoiceAttribute attr = (BankAccountChoiceAttribute) input;
                 return new OperationBankAccountChoiceFieldAttribute(attr.getId(), attr.getLabel(), bankAccountListConverter.fromBankAccountList(attr.getBankAccounts()), attr.isEnabled(), attr.getDefaultValue());
             }
-            case BANNER: {
+            case BANNER -> {
                 BannerAttribute attr = (BannerAttribute) input;
                 return new OperationBannerFieldAttribute(attr.getId(), attr.getLabel(), bannerTypeConverter.fromBannerType(attr.getBannerType()), attr.getMessage());
             }
-            case HEADING: {
+            case HEADING -> {
                 HeadingAttribute attr = (HeadingAttribute) input;
                 return new OperationHeadingFieldAttribute(attr.getId(), attr.getLabel(), attr.getValue(), valueFormatTypeConverter.fromValueFormatType(attr.getValueFormatType()), attr.getFormattedValues());
             }
-            case PARTY_INFO: {
+            case PARTY_INFO -> {
                 PartyInfoAttribute attr = (PartyInfoAttribute) input;
                 return new OperationPartyInfoFieldAttribute(attr.getId(), partyInfoConverter.fromPartyInfo(attr.getPartyInfo()));
             }
-            default: {
-                throw new IllegalStateException("Unsupported attribute type: "+input.getType());
-            }
+            default ->
+                throw new IllegalStateException("Unsupported attribute type: " + input.getType());
         }
     }
 

--- a/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/converter/BannerTypeConverter.java
+++ b/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/converter/BannerTypeConverter.java
@@ -32,16 +32,11 @@ public class BannerTypeConverter {
      * @return Data adapter BannerType.
      */
     public io.getlime.security.powerauth.lib.dataadapter.model.enumeration.BannerType fromOperationBannerType(BannerType input) {
-        switch (input) {
-            case BANNER_INFO:
-                return io.getlime.security.powerauth.lib.dataadapter.model.enumeration.BannerType.BANNER_INFO;
-            case BANNER_WARNING:
-                return io.getlime.security.powerauth.lib.dataadapter.model.enumeration.BannerType.BANNER_WARNING;
-            case BANNER_ERROR:
-                return io.getlime.security.powerauth.lib.dataadapter.model.enumeration.BannerType.BANNER_ERROR;
-            default:
-                throw new IllegalStateException("Unsupported banner type: "+input);
-        }
+        return switch (input) {
+            case BANNER_INFO -> io.getlime.security.powerauth.lib.dataadapter.model.enumeration.BannerType.BANNER_INFO;
+            case BANNER_WARNING -> io.getlime.security.powerauth.lib.dataadapter.model.enumeration.BannerType.BANNER_WARNING;
+            case BANNER_ERROR -> io.getlime.security.powerauth.lib.dataadapter.model.enumeration.BannerType.BANNER_ERROR;
+        };
     }
 
     /**
@@ -50,15 +45,10 @@ public class BannerTypeConverter {
      * @return Next step BannerType.
      */
     public BannerType fromBannerType(io.getlime.security.powerauth.lib.dataadapter.model.enumeration.BannerType input) {
-        switch (input) {
-            case BANNER_INFO:
-                return BannerType.BANNER_INFO;
-            case BANNER_WARNING:
-                return BannerType.BANNER_WARNING;
-            case BANNER_ERROR:
-                return BannerType.BANNER_ERROR;
-            default:
-                throw new IllegalStateException("Unsupported banner type: "+input);
-        }
+        return switch (input) {
+            case BANNER_INFO -> BannerType.BANNER_INFO;
+            case BANNER_WARNING -> BannerType.BANNER_WARNING;
+            case BANNER_ERROR -> BannerType.BANNER_ERROR;
+        };
     }
 }

--- a/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/converter/FormDataConverter.java
+++ b/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/converter/FormDataConverter.java
@@ -33,7 +33,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.entity.attribute.Operati
  */
 public class FormDataConverter {
 
-    private AttributeConverter attributeConverter = new AttributeConverter();
+    private final AttributeConverter attributeConverter = new AttributeConverter();
 
     /**
      * Converter from OperationFormData.

--- a/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/converter/UserAccountStatusConverter.java
+++ b/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/converter/UserAccountStatusConverter.java
@@ -38,17 +38,10 @@ public class UserAccountStatusConverter {
             return null;
         }
 
-        switch (userIdentityStatus) {
-            case ACTIVE:
-                return AccountStatus.ACTIVE;
-
-            case BLOCKED:
-            case REMOVED:
-                return AccountStatus.NOT_ACTIVE;
-
-            default:
-                return null;
-        }
+        return switch (userIdentityStatus) {
+            case ACTIVE -> AccountStatus.ACTIVE;
+            case BLOCKED, REMOVED -> AccountStatus.NOT_ACTIVE;
+        };
     }
 
     /**
@@ -61,17 +54,10 @@ public class UserAccountStatusConverter {
             return null;
         }
 
-        switch (userIdentityStatus) {
-            case ACTIVE:
-                return UserAccountStatus.ACTIVE;
-
-            case BLOCKED:
-            case REMOVED:
-                return UserAccountStatus.NOT_ACTIVE;
-
-            default:
-                return null;
-        }
+        return switch (userIdentityStatus) {
+            case ACTIVE -> UserAccountStatus.ACTIVE;
+            case BLOCKED, REMOVED -> UserAccountStatus.NOT_ACTIVE;
+        };
     }
 
     /**
@@ -84,16 +70,10 @@ public class UserAccountStatusConverter {
             return null;
         }
 
-        switch (accountStatus) {
-            case ACTIVE:
-                return AccountStatus.ACTIVE;
-
-            case NOT_ACTIVE:
-                return AccountStatus.NOT_ACTIVE;
-
-            default:
-                return null;
-        }
+        return switch (accountStatus) {
+            case ACTIVE -> AccountStatus.ACTIVE;
+            case NOT_ACTIVE -> AccountStatus.NOT_ACTIVE;
+        };
     }
 
     /**
@@ -106,16 +86,10 @@ public class UserAccountStatusConverter {
             return null;
         }
 
-        switch (userAccountStatus) {
-            case ACTIVE:
-                return UserAccountStatus.ACTIVE;
-
-            case NOT_ACTIVE:
-                return UserAccountStatus.NOT_ACTIVE;
-
-            default:
-                return null;
-        }
+        return switch (userAccountStatus) {
+            case ACTIVE -> UserAccountStatus.ACTIVE;
+            case NOT_ACTIVE -> UserAccountStatus.NOT_ACTIVE;
+        };
     }
 
 }

--- a/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/converter/ValueFormatTypeConverter.java
+++ b/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/converter/ValueFormatTypeConverter.java
@@ -32,22 +32,14 @@ public class ValueFormatTypeConverter {
      * @return Data adapter value format type.
      */
     public io.getlime.security.powerauth.lib.dataadapter.model.enumeration.ValueFormatType fromOperationValueFormatType(ValueFormatType input) {
-        switch (input) {
-            case AMOUNT:
-                return io.getlime.security.powerauth.lib.dataadapter.model.enumeration.ValueFormatType.AMOUNT;
-            case TEXT:
-                return io.getlime.security.powerauth.lib.dataadapter.model.enumeration.ValueFormatType.TEXT;
-            case LOCALIZED_TEXT:
-                return io.getlime.security.powerauth.lib.dataadapter.model.enumeration.ValueFormatType.LOCALIZED_TEXT;
-            case DATE:
-                return io.getlime.security.powerauth.lib.dataadapter.model.enumeration.ValueFormatType.DATE;
-            case NUMBER:
-                return io.getlime.security.powerauth.lib.dataadapter.model.enumeration.ValueFormatType.NUMBER;
-            case ACCOUNT:
-                return io.getlime.security.powerauth.lib.dataadapter.model.enumeration.ValueFormatType.ACCOUNT;
-            default:
-                throw new IllegalStateException("Unsupported value format type: "+input);
-        }
+        return switch (input) {
+            case AMOUNT -> io.getlime.security.powerauth.lib.dataadapter.model.enumeration.ValueFormatType.AMOUNT;
+            case TEXT -> io.getlime.security.powerauth.lib.dataadapter.model.enumeration.ValueFormatType.TEXT;
+            case LOCALIZED_TEXT -> io.getlime.security.powerauth.lib.dataadapter.model.enumeration.ValueFormatType.LOCALIZED_TEXT;
+            case DATE -> io.getlime.security.powerauth.lib.dataadapter.model.enumeration.ValueFormatType.DATE;
+            case NUMBER -> io.getlime.security.powerauth.lib.dataadapter.model.enumeration.ValueFormatType.NUMBER;
+            case ACCOUNT -> io.getlime.security.powerauth.lib.dataadapter.model.enumeration.ValueFormatType.ACCOUNT;
+        };
     }
 
     /**
@@ -56,22 +48,14 @@ public class ValueFormatTypeConverter {
      * @return Next step value format type.
      */
     public ValueFormatType fromValueFormatType(io.getlime.security.powerauth.lib.dataadapter.model.enumeration.ValueFormatType input) {
-        switch (input) {
-            case AMOUNT:
-                return ValueFormatType.AMOUNT;
-            case TEXT:
-                return ValueFormatType.TEXT;
-            case LOCALIZED_TEXT:
-                return ValueFormatType.LOCALIZED_TEXT;
-            case DATE:
-                return ValueFormatType.DATE;
-            case NUMBER:
-                return ValueFormatType.NUMBER;
-            case ACCOUNT:
-                return ValueFormatType.ACCOUNT;
-            default:
-                throw new IllegalStateException("Unsupported value format type: "+input);
-        }
+        return switch (input) {
+            case AMOUNT -> ValueFormatType.AMOUNT;
+            case TEXT -> ValueFormatType.TEXT;
+            case LOCALIZED_TEXT -> ValueFormatType.LOCALIZED_TEXT;
+            case DATE -> ValueFormatType.DATE;
+            case NUMBER -> ValueFormatType.NUMBER;
+            case ACCOUNT -> ValueFormatType.ACCOUNT;
+        };
     }
 
 }

--- a/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/entity/AuthenticationContext.java
+++ b/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/entity/AuthenticationContext.java
@@ -35,8 +35,8 @@ public class AuthenticationContext {
 
     /**
      * Encryption cipher transformation in case password is encrypted.
-     *
-     * See: https://docs.oracle.com/javase/8/docs/api/javax/crypto/Cipher.html
+     * <p>
+     * @see javax.crypto.Cipher
      */
     private String cipherTransformation;
 

--- a/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/entity/AuthorizationCode.java
+++ b/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/entity/AuthorizationCode.java
@@ -20,36 +20,9 @@ package io.getlime.security.powerauth.lib.dataadapter.model.entity;
 /**
  * Authorization code including salt used when generating the code.
  *
+ * @param code Authorization code.
+ * @param salt Salt used for creating the authorization code or null for unknown salt.
  * @author Roman Strobl, roman.strobl@wultra.com
  */
-public class AuthorizationCode {
-
-    private final String code;
-    private final byte[] salt;
-
-    /**
-     * Authorization code constructor.
-     * @param code Authorization code.
-     * @param salt Salt used for creating the authorization code or null for unknown salt.
-     */
-    public AuthorizationCode(String code, byte[] salt) {
-        this.code = code;
-        this.salt = salt;
-    }
-
-    /**
-     * Get authorization code.
-     * @return Authorization code.
-     */
-    public String getCode() {
-        return code;
-    }
-
-    /**
-     * Get salt.
-     * @return Salt.
-     */
-    public byte[] getSalt() {
-        return salt;
-    }
+public record AuthorizationCode(String code, byte[] salt) {
 }

--- a/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/entity/DataAdapterError.java
+++ b/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/entity/DataAdapterError.java
@@ -34,7 +34,7 @@ public class DataAdapterError extends Error {
     /**
      * Response codes for different authentication failures.
      */
-    public class Code extends Error.Code {
+    public static class Code extends Error.Code {
 
         /**
          * User authentication failed.

--- a/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/entity/FormData.java
+++ b/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/entity/FormData.java
@@ -37,20 +37,10 @@ public class FormData {
     private MessageAttribute title;
     private MessageAttribute greeting;
     private MessageAttribute summary;
-    private List<FormFieldConfig> config;
-    private List<FormBanner> banners;
-    private List<Attribute> parameters;
-    private Map<String, String> userInput;
-
-    /**
-     * Default constructor.
-     */
-    public FormData() {
-        this.config = new ArrayList<>();
-        this.parameters = new ArrayList<>();
-        this.banners = new ArrayList<>();
-        this.userInput = new LinkedHashMap<>();
-    }
+    private final List<FormFieldConfig> config = new ArrayList<>();
+    private final List<FormBanner> banners = new ArrayList<>();
+    private final List<Attribute> parameters = new ArrayList<>();
+    private Map<String, String> userInput = new LinkedHashMap<>();
 
     /**
      * Get form configuration.

--- a/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/entity/attribute/Attribute.java
+++ b/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/entity/attribute/Attribute.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 
 /**
  * Abstract class that represents a form field attribute.
- *
+ * <p>
  * This class requires JSON annotation since it is a base class that is extended with specific types.
  *
  * @author Petr Dvorak, petr@wultra.com

--- a/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/entity/attribute/AttributeFormatted.java
+++ b/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/entity/attribute/AttributeFormatted.java
@@ -38,7 +38,7 @@ public class AttributeFormatted extends Attribute {
     /**
      * Formatted values.
      */
-    protected Map<String, String> formattedValues = new HashMap<>();
+    private final Map<String, String> formattedValues = new HashMap<>();
 
     /**
      * Get value format type of this attribute.

--- a/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/request/SaveConsentFormRequest.java
+++ b/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/request/SaveConsentFormRequest.java
@@ -48,7 +48,7 @@ public class SaveConsentFormRequest {
     /**
      * Consent options with values set by the user.
      */
-    private List<ConsentOption> options;
+    private final List<ConsentOption> options;
 
     /**
      * Default constructor.

--- a/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/request/ValidateConsentFormRequest.java
+++ b/powerauth-data-adapter-model/src/main/java/io/getlime/security/powerauth/lib/dataadapter/model/request/ValidateConsentFormRequest.java
@@ -53,7 +53,7 @@ public class ValidateConsentFormRequest {
     /**
      * Consent options with values set by the user.
      */
-    private List<ConsentOption> options;
+    private final List<ConsentOption> options;
 
     /**
      * Default constructor.

--- a/powerauth-mtoken-model/src/main/java/io/getlime/security/powerauth/lib/mtoken/model/enumeration/ErrorCode.java
+++ b/powerauth-mtoken-model/src/main/java/io/getlime/security/powerauth/lib/mtoken/model/enumeration/ErrorCode.java
@@ -22,7 +22,6 @@ package io.getlime.security.powerauth.lib.mtoken.model.enumeration;
  * Return some of these messages as error codes in the context of our standard
  * {@link io.getlime.core.rest.model.base.response.ErrorResponse} responses.
  *
- *
  * @author Petr Dvorak, petr@wultra.com
  */
 public class ErrorCode {

--- a/powerauth-nextstep-client/src/main/java/io/getlime/security/powerauth/lib/nextstep/client/NextStepClient.java
+++ b/powerauth-nextstep-client/src/main/java/io/getlime/security/powerauth/lib/nextstep/client/NextStepClient.java
@@ -598,7 +598,7 @@ public class NextStepClient {
         final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.put("userId", Collections.singletonList(userId));
         params.put("mobileTokenOnly", Collections.singletonList(String.valueOf(mobileTokenOnly)));
-        return getImpl("/user/operation", params, new ParameterizedTypeReference<ObjectResponse<List<GetOperationDetailResponse>>>() {});
+        return getImpl("/user/operation", params, new ParameterizedTypeReference<>() {});
     }
 
     /**
@@ -613,7 +613,7 @@ public class NextStepClient {
         final GetPendingOperationsRequest request = new GetPendingOperationsRequest();
         request.setUserId(userId);
         request.setMobileTokenOnly(mobileTokenOnly);
-        return postImpl("/user/operation/list", new ObjectRequest<>(request), new ParameterizedTypeReference<ObjectResponse<List<GetOperationDetailResponse>>>() {});
+        return postImpl("/user/operation/list", new ObjectRequest<>(request), new ParameterizedTypeReference<>() {});
     }
 
     // Organization related methods

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/entity/OperationData.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/entity/OperationData.java
@@ -29,7 +29,7 @@ import java.util.Map;
 
 /**
  * Operation data contains structured data used for signatures.
- *
+ * <p>
  * See <a href="https://developers.wultra.com/docs/develop/powerauth-webflow/Operation-Data">operation data documentation</a>.
  *
  * @author Roman Strobl, roman.strobl@wultra.com

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/entity/attribute/OperationFormFieldAttribute.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/entity/attribute/OperationFormFieldAttribute.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 
 /**
  * Abstract class that represents a form field attribute.
- *
+ * <p>
  * This class requires JSON annotation since it is a base class that is extended with specific types.
  *
  * @author Petr Dvorak, petr@wultra.com

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/entity/attribute/OperationFormFieldAttributeFormatted.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/entity/attribute/OperationFormFieldAttributeFormatted.java
@@ -37,7 +37,7 @@ public class OperationFormFieldAttributeFormatted extends OperationFormFieldAttr
     /**
      * Formatted values.
      */
-    protected Map<String, String> formattedValues = new HashMap<>();
+    protected final Map<String, String> formattedValues = new HashMap<>();
 
     /**
      * Get value format type of this attribute.

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/entity/data/OperationDataBuilder.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/entity/data/OperationDataBuilder.java
@@ -28,8 +28,8 @@ import static io.getlime.security.powerauth.lib.nextstep.model.entity.OperationD
 
 /**
  * Builder for operation data.
- *
- * See <a href='https://github.com/wultra/powerauth-webflow/wiki/Off-line-Signatures-QR-Code#operation-data'>operation data documentation</a>.
+ * <p>
+ * See <a href="https://github.com/wultra/powerauth-webflow/wiki/Off-line-Signatures-QR-Code#operation-data">operation data documentation</a>.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */
@@ -124,7 +124,7 @@ public class OperationDataBuilder {
      */
     public class OperationAttributeBuilder {
 
-        private int attributeId;
+        private final int attributeId;
 
         /**
          * Constructor for operation attributes.

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/entity/error/CredentialValidationError.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/entity/error/CredentialValidationError.java
@@ -20,6 +20,7 @@ package io.getlime.security.powerauth.lib.nextstep.model.entity.error;
 import io.getlime.core.rest.model.base.entity.Error;
 import io.getlime.security.powerauth.lib.nextstep.model.entity.enumeration.CredentialValidationFailure;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -31,6 +32,7 @@ import java.util.List;
  */
 public class CredentialValidationError extends Error implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = -4674388987180219329L;
 
     /**

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/entity/error/NextStepError.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/entity/error/NextStepError.java
@@ -19,6 +19,7 @@ package io.getlime.security.powerauth.lib.nextstep.model.entity.error;
 
 import io.getlime.core.rest.model.base.entity.Error;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -28,12 +29,13 @@ import java.io.Serializable;
  */
 public class NextStepError extends Error implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = -4275815737896000891L;
 
     /**
      * Response codes for different failures.
      */
-    public class Code extends Error.Code {
+    public static class Code extends Error.Code {
 
         /**
          * Error caused by the client.

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/entity/error/Violation.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/entity/error/Violation.java
@@ -17,18 +17,11 @@
 
 package io.getlime.security.powerauth.lib.nextstep.model.entity.error;
 
-import lombok.Data;
-
 /**
  * Entity class representing a violation of constraints.
  *
  * @author Petr Dvorak, petr@wultra.com
  */
-@Data
-public class Violation {
-
-    private final String fieldName;
-    private final Object invalidValue;
-    private final String hint;
+public record Violation(String fieldName, Object invalidValue, String hint) {
 
 }

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/request/UpdateCounterRequest.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/request/UpdateCounterRequest.java
@@ -25,7 +25,7 @@ import lombok.Data;
 
 /**
  * Request object used for updating a credential counter.
- *
+ * <p>
  * The counter is either reset or increased based on provided authentication result.
  *
  * @author Roman Strobl, roman.strobl@wultra.com

--- a/powerauth-nextstep-model/src/test/java/io/getlime/security/powerauth/lib/nextstep/model/entity/data/OperationDataBuilderTest.java
+++ b/powerauth-nextstep-model/src/test/java/io/getlime/security/powerauth/lib/nextstep/model/entity/data/OperationDataBuilderTest.java
@@ -135,58 +135,52 @@ class OperationDataBuilderTest {
 
     @Test
     void testDataInvalid1() {
-        Assertions.assertThrows(InvalidOperationDataException.class, () -> {
-            builder.build();
-        });
+        Assertions.assertThrows(InvalidOperationDataException.class, () ->
+                builder.build());
     }
 
     @Test
     void testDataInvalid2() {
-        Assertions.assertThrows(InvalidOperationDataException.class, () -> {
-            builder.templateId(1).build();
-        });
+        Assertions.assertThrows(InvalidOperationDataException.class, () ->
+                builder.templateId(1).build());
     }
 
     @Test
     void testDataInvalid3() {
-        Assertions.assertThrows(InvalidOperationDataException.class, () -> {
-            builder.templateVersion("A").build();
-        });
+        Assertions.assertThrows(InvalidOperationDataException.class, () ->
+                builder.templateVersion("A").build());
     }
 
     @Test
     void testInvalidAmount() {
-        Assertions.assertThrows(InvalidOperationDataException.class, () -> {
-            builder
+        Assertions.assertThrows(InvalidOperationDataException.class, () ->
+                builder
                     .templateId(1)
                     .templateVersion("A")
                     .attr1().accountGeneric("12345678/0100")
                     .attr2().amount(new BigDecimal("0.0099"), "EUR")
-                    .build();
-        });
+                    .build());
     }
 
     @Test
     void testZeroAmount() {
-        Assertions.assertThrows(InvalidOperationDataException.class, () -> {
-            builder
+        Assertions.assertThrows(InvalidOperationDataException.class, () ->
+                builder
                     .templateId(1)
                     .templateVersion("A")
                     .attr1().accountGeneric("12345678/0100")
                     .attr2().amount(BigDecimal.ZERO, "EUR")
-                    .build();
-        });
+                    .build());
     }
 
     @Test
     void testNegativeAmount() {
-        Assertions.assertThrows(InvalidOperationDataException.class, () -> {
-            builder
+        Assertions.assertThrows(InvalidOperationDataException.class, () ->
+                builder
                     .templateId(1)
                     .templateVersion("A")
                     .attr1().accountGeneric("12345678/0100")
                     .attr2().amount(new BigDecimal("-100"), "EUR")
-                    .build();
-        });
+                    .build());
     }
 }

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OrganizationController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OrganizationController.java
@@ -21,7 +21,6 @@ package io.getlime.security.powerauth.app.nextstep.controller;
 import io.getlime.core.rest.model.base.request.ObjectRequest;
 import io.getlime.core.rest.model.base.response.ObjectResponse;
 import io.getlime.security.powerauth.app.nextstep.service.OrganizationService;
-import io.getlime.security.powerauth.lib.nextstep.model.exception.DeleteNotAllowedException;
 import io.getlime.security.powerauth.lib.nextstep.model.exception.OrganizationAlreadyExistsException;
 import io.getlime.security.powerauth.lib.nextstep.model.exception.OrganizationNotFoundException;
 import io.getlime.security.powerauth.lib.nextstep.model.request.CreateOrganizationRequest;
@@ -175,7 +174,6 @@ public class OrganizationController {
      * @param request Delete organization request.
      * @return Delete organization response.
      * @throws OrganizationNotFoundException Thrown when organization is not found.
-     * @throws DeleteNotAllowedException Thrown when delete action is not allowed.
      */
     @Operation(summary = "Delete an organization")
     @ApiResponses(value = {
@@ -184,7 +182,7 @@ public class OrganizationController {
             @ApiResponse(responseCode = "500", description = "Unexpected error")
     })
     @RequestMapping(value = "delete", method = RequestMethod.POST)
-    public ObjectResponse<DeleteOrganizationResponse> deleteOrganization(@Valid @RequestBody ObjectRequest<DeleteOrganizationRequest> request) throws OrganizationNotFoundException, DeleteNotAllowedException {
+    public ObjectResponse<DeleteOrganizationResponse> deleteOrganization(@Valid @RequestBody ObjectRequest<DeleteOrganizationRequest> request) throws OrganizationNotFoundException {
         logger.info("Received deleteOrganization request, organization ID: {}", request.getRequestObject().getOrganizationId());
         final DeleteOrganizationResponse response = organizationService.deleteOrganization(request.getRequestObject());
         logger.info("The deleteOrganization request succeeded, organization ID: {}", request.getRequestObject().getOrganizationId());

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OtpController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/OtpController.java
@@ -129,7 +129,6 @@ public class OtpController {
      * @param includeRemoved Whether removed OTPs should be included.
      * @return Get OTP list response.
      * @throws OperationNotFoundException Thrown when operation is not found.
-     * @throws EncryptionException Thrown when decryption fails.
      */
     @Operation(summary = "Get an OTP list")
     @ApiResponses(value = {
@@ -138,7 +137,7 @@ public class OtpController {
             @ApiResponse(responseCode = "500", description = "Unexpected error")
     })
     @RequestMapping(method = RequestMethod.GET)
-    public ObjectResponse<GetOtpListResponse> getOptList(@RequestParam @NotBlank @Size(min = 1, max = 256) String operationId, @RequestParam boolean includeRemoved) throws OperationNotFoundException, EncryptionException {
+    public ObjectResponse<GetOtpListResponse> getOptList(@RequestParam @NotBlank @Size(min = 1, max = 256) String operationId, @RequestParam boolean includeRemoved) throws OperationNotFoundException {
         logger.info("Received getOptList request, operation ID: {}", operationId);
         GetOtpListRequest request = new GetOtpListRequest();
         request.setOperationId(operationId);
@@ -153,7 +152,6 @@ public class OtpController {
      * @param request Get OTP list request.
      * @return Get OTP list response.
      * @throws OperationNotFoundException Thrown when operation is not found.
-     * @throws EncryptionException Thrown when decryption fails.
      */
     @Operation(summary = "Get an OTP list")
     @ApiResponses(value = {
@@ -162,7 +160,7 @@ public class OtpController {
             @ApiResponse(responseCode = "500", description = "Unexpected error")
     })
     @RequestMapping(value = "list", method = RequestMethod.POST)
-    public ObjectResponse<GetOtpListResponse> getOptListPost(@Valid @RequestBody ObjectRequest<GetOtpListRequest> request) throws OperationNotFoundException, EncryptionException {
+    public ObjectResponse<GetOtpListResponse> getOptListPost(@Valid @RequestBody ObjectRequest<GetOtpListRequest> request) throws OperationNotFoundException {
         logger.info("Received getOptListPost request, operation ID: {}", request.getRequestObject().getOperationId());
         final GetOtpListResponse response = otpService.getOtpList(request.getRequestObject());
         logger.info("The getOptListPost request succeeded, operation ID: {}", request.getRequestObject().getOperationId());

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/converter/CredentialValueConverter.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/converter/CredentialValueConverter.java
@@ -81,11 +81,10 @@ public class CredentialValueConverter {
         }
 
         switch (credentialValue.getEncryptionAlgorithm()) {
-
-            case NO_ENCRYPTION:
+            case NO_ENCRYPTION -> {
                 return credentialValue.getValue();
-
-            case AES_HMAC:
+            }
+            case AES_HMAC -> {
                 final String masterDbEncryptionKeyBase64 = configuration.getMasterDbEncryptionKey();
 
                 // In case master DB encryption key does not exist, do not encrypt the server private key
@@ -115,9 +114,8 @@ public class CredentialValueConverter {
                 } catch (Exception ex) {
                     throw new EncryptionException(ex);
                 }
-
-            default:
-                throw new InvalidConfigurationException("Unsupported encryption algorithm: " + credentialValue.getEncryptionAlgorithm());
+            }
+            default -> throw new InvalidConfigurationException("Unsupported encryption algorithm: " + credentialValue.getEncryptionAlgorithm());
         }
 
     }
@@ -138,11 +136,10 @@ public class CredentialValueConverter {
         }
 
         switch (credentialDefinition.getEncryptionAlgorithm()) {
-
-            case NO_ENCRYPTION:
+            case NO_ENCRYPTION -> {
                 return new CredentialValue(EncryptionAlgorithm.NO_ENCRYPTION, credentialValue);
-
-            case AES_HMAC:
+            }
+            case AES_HMAC -> {
                 final String masterDbEncryptionKeyBase64 = configuration.getMasterDbEncryptionKey();
 
                 // In case master DB encryption key does not exist, do not encrypt the server private key
@@ -155,7 +152,6 @@ public class CredentialValueConverter {
 
                 // Derive secret key from master DB encryption key, userId and activationId
                 final SecretKey secretKey = deriveSecretKey(masterDbEncryptionKey, userId, credentialDefinition.getName());
-
                 try {
                     // Generate random IV
                     final byte[] iv = keyGenerator.generateRandomBytes(16);
@@ -177,9 +173,9 @@ public class CredentialValueConverter {
                 } catch (Exception ex) {
                     throw new EncryptionException(ex);
                 }
-
-            default:
-                throw new InvalidConfigurationException("Unsupported encryption algorithm: " + credentialDefinition.getEncryptionAlgorithm());
+            }
+            default ->
+                    throw new InvalidConfigurationException("Unsupported encryption algorithm: " + credentialDefinition.getEncryptionAlgorithm());
         }
 
     }

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/converter/ExtrasConverter.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/converter/ExtrasConverter.java
@@ -38,7 +38,7 @@ public class ExtrasConverter {
      * @return Map with deserialized extras.
      */
     public Map<String, Object> fromString(String extras) throws JsonProcessingException {
-        return objectMapper.readValue(extras, new TypeReference<Map<String, Object>>() {});
+        return objectMapper.readValue(extras, new TypeReference<>() {});
     }
 
     /**

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/converter/OperationConverter.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/converter/OperationConverter.java
@@ -231,8 +231,7 @@ public class OperationConverter {
      */
     private Map<String, Object> convertExtrasToMap(String extras) {
         try {
-            final TypeReference<Map<String, Object>> typeRef
-                    = new TypeReference<Map<String, Object>>() {};
+            final TypeReference<Map<String, Object>> typeRef = new TypeReference<>() {};
             return objectMapper.readValue(extras, typeRef);
         } catch (IOException e) {
             logger.error("Error occurred while deserializing data", e);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/converter/OtpValueConverter.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/converter/OtpValueConverter.java
@@ -77,11 +77,10 @@ public class OtpValueConverter {
      */
     public String fromDBValue(OtpValue otpValue, String otpId, OtpDefinitionEntity otpDefinition) throws InvalidConfigurationException, EncryptionException {
         switch (otpValue.getEncryptionAlgorithm()) {
-
-            case NO_ENCRYPTION:
+            case NO_ENCRYPTION -> {
                 return otpValue.getValue();
-
-            case AES_HMAC:
+            }
+            case AES_HMAC -> {
                 final String masterDbEncryptionKeyBase64 = configuration.getMasterDbEncryptionKey();
 
                 // In case master DB encryption key does not exist, do not encrypt the server private key
@@ -111,9 +110,8 @@ public class OtpValueConverter {
                 } catch (Exception ex) {
                     throw new EncryptionException(ex);
                 }
-
-            default:
-                throw new InvalidConfigurationException("Unsupported encryption algorithm: " + otpValue.getEncryptionAlgorithm());
+            }
+            default -> throw new InvalidConfigurationException("Unsupported encryption algorithm: " + otpValue.getEncryptionAlgorithm());
         }
 
     }
@@ -134,11 +132,10 @@ public class OtpValueConverter {
         }
 
         switch (otpDefinition.getEncryptionAlgorithm()) {
-
-            case NO_ENCRYPTION:
+            case NO_ENCRYPTION -> {
                 return new OtpValue(EncryptionAlgorithm.NO_ENCRYPTION, otpValue);
-
-            case AES_HMAC:
+            }
+            case AES_HMAC -> {
                 final String masterDbEncryptionKeyBase64 = configuration.getMasterDbEncryptionKey();
 
                 // In case master DB encryption key does not exist, do not encrypt the server private key
@@ -151,7 +148,6 @@ public class OtpValueConverter {
 
                 // Derive secret key from master DB encryption key, userId and activationId
                 final SecretKey secretKey = deriveSecretKey(masterDbEncryptionKey, otpId, otpDefinition.getName());
-
                 try {
                     // Generate random IV
                     final byte[] iv = keyGenerator.generateRandomBytes(16);
@@ -173,9 +169,8 @@ public class OtpValueConverter {
                 } catch (Exception ex) {
                     throw new EncryptionException(ex);
                 }
-
-            default:
-                throw new InvalidConfigurationException("Unsupported encryption algorithm: " + otpDefinition.getEncryptionAlgorithm());
+            }
+            default -> throw new InvalidConfigurationException("Unsupported encryption algorithm: " + otpDefinition.getEncryptionAlgorithm());
         }
 
     }

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/converter/ParameterConverter.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/converter/ParameterConverter.java
@@ -38,7 +38,7 @@ public class ParameterConverter {
      * @return Map with deserialized parameters.
      */
     public Map<String, String> fromString(String param) throws JsonProcessingException {
-        return objectMapper.readValue(param, new TypeReference<Map<String, String>>() {});
+        return objectMapper.readValue(param, new TypeReference<>() {});
     }
 
     /**

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/converter/UserAccountStatusConverter.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/converter/UserAccountStatusConverter.java
@@ -38,17 +38,10 @@ public class UserAccountStatusConverter {
             return null;
         }
 
-        switch (userIdentityStatus) {
-            case ACTIVE:
-                return AccountStatus.ACTIVE;
-
-            case BLOCKED:
-            case REMOVED:
-                return AccountStatus.NOT_ACTIVE;
-
-            default:
-                return null;
-        }
+        return switch (userIdentityStatus) {
+            case ACTIVE -> AccountStatus.ACTIVE;
+            case BLOCKED, REMOVED -> AccountStatus.NOT_ACTIVE;
+        };
     }
 
     /**
@@ -61,17 +54,10 @@ public class UserAccountStatusConverter {
             return null;
         }
 
-        switch (userIdentityStatus) {
-            case ACTIVE:
-                return UserAccountStatus.ACTIVE;
-
-            case BLOCKED:
-            case REMOVED:
-                return UserAccountStatus.NOT_ACTIVE;
-
-            default:
-                return null;
-        }
+        return switch (userIdentityStatus) {
+            case ACTIVE -> UserAccountStatus.ACTIVE;
+            case BLOCKED, REMOVED -> UserAccountStatus.NOT_ACTIVE;
+        };
     }
 
     /**
@@ -84,16 +70,10 @@ public class UserAccountStatusConverter {
             return null;
         }
 
-        switch (accountStatus) {
-            case ACTIVE:
-                return AccountStatus.ACTIVE;
-
-            case NOT_ACTIVE:
-                return AccountStatus.NOT_ACTIVE;
-
-            default:
-                return null;
-        }
+        return switch (accountStatus) {
+            case ACTIVE -> AccountStatus.ACTIVE;
+            case NOT_ACTIVE -> AccountStatus.NOT_ACTIVE;
+        };
     }
 
     /**
@@ -106,16 +86,10 @@ public class UserAccountStatusConverter {
             return null;
         }
 
-        switch (userAccountStatus) {
-            case ACTIVE:
-                return UserAccountStatus.ACTIVE;
-
-            case NOT_ACTIVE:
-                return UserAccountStatus.NOT_ACTIVE;
-
-            default:
-                return null;
-        }
+        return switch (userAccountStatus) {
+            case ACTIVE -> UserAccountStatus.ACTIVE;
+            case NOT_ACTIVE -> UserAccountStatus.NOT_ACTIVE;
+        };
     }
 
 }

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/converter/ValueListConverter.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/converter/ValueListConverter.java
@@ -38,7 +38,7 @@ public class ValueListConverter {
      * @return List with deserialized values.
      */
     public List<String> fromString(String values) throws JsonProcessingException {
-        return objectMapper.readValue(values, new TypeReference<List<String>>() {});
+        return objectMapper.readValue(values, new TypeReference<>() {});
     }
 
     /**

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/UserRoleRepository.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/UserRoleRepository.java
@@ -33,7 +33,7 @@ public interface UserRoleRepository extends CrudRepository<UserRoleEntity, Long>
     /**
      * Count number of role records with a specified role.
      * @param role Role
-     * @return List of user roles.
+     * @return number of user roles.
      */
     long countByRole(RoleEntity role);
 

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/ApplicationEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/ApplicationEntity.java
@@ -22,6 +22,7 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -36,6 +37,7 @@ import java.util.Date;
 @EqualsAndHashCode(of = "name")
 public class ApplicationEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 583672417376181537L;
 
     @Id

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/AuthMethodEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/AuthMethodEntity.java
@@ -22,6 +22,7 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -35,6 +36,7 @@ import java.io.Serializable;
 @EqualsAndHashCode(of = "authMethod")
 public class AuthMethodEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = -2015768978885351433L;
 
     @Id

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/AuthenticationEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/AuthenticationEntity.java
@@ -23,6 +23,7 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -37,6 +38,7 @@ import java.util.Date;
 @EqualsAndHashCode(of = {"userId", "authenticationType", "credential", "otp", "operation", "timestampCreated"})
 public class AuthenticationEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1598100682966462736L;
 
     @Id

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/CredentialDefinitionEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/CredentialDefinitionEntity.java
@@ -25,6 +25,7 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -39,6 +40,7 @@ import java.util.Date;
 @EqualsAndHashCode(of = {"name"})
 public class CredentialDefinitionEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1113222092995641439L;
 
     @Id

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/CredentialEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/CredentialEntity.java
@@ -24,6 +24,7 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -38,6 +39,7 @@ import java.util.Date;
 @EqualsAndHashCode(of = {"credentialDefinition", "user", "type", "username"})
 public class CredentialEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = -1331139715085676624L;
 
     @Id

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/CredentialHistoryEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/CredentialHistoryEntity.java
@@ -22,6 +22,7 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -36,6 +37,7 @@ import java.util.Date;
 @EqualsAndHashCode(of = {"credentialDefinition", "user", "username", "timestampCreated"})
 public class CredentialHistoryEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = -3222892995455956072L;
 
     @Id

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/CredentialPolicyEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/CredentialPolicyEntity.java
@@ -24,6 +24,7 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -38,6 +39,7 @@ import java.util.Date;
 @EqualsAndHashCode(of = "name")
 public class CredentialPolicyEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = -4580881377865304625L;
 
     @Id

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/HashConfigEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/HashConfigEntity.java
@@ -23,6 +23,7 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -37,6 +38,7 @@ import java.util.Date;
 @EqualsAndHashCode(of = "name")
 public class HashConfigEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 5186710016544178844L;
 
     @Id

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OperationAfsActionEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OperationAfsActionEntity.java
@@ -23,6 +23,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -37,6 +38,7 @@ import java.util.Date;
 @EqualsAndHashCode(of = {"afsAction", "stepIndex", "timestampCreated", "operation"})
 public class OperationAfsActionEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 744614077188309148L;
 
     @Id

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OperationConfigEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OperationConfigEntity.java
@@ -24,6 +24,7 @@ import jakarta.persistence.Table;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -37,6 +38,7 @@ import java.io.Serializable;
 @EqualsAndHashCode(of = "operationName")
 public class OperationConfigEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 4855111531493246740L;
 
     @Id

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OperationEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OperationEntity.java
@@ -25,6 +25,7 @@ import lombok.EqualsAndHashCode;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
@@ -40,6 +41,7 @@ import java.util.List;
 @EqualsAndHashCode(of = "operationId")
 public class OperationEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = -8991119412441607003L;
 
     @Id

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OperationHistoryEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OperationHistoryEntity.java
@@ -24,6 +24,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthStepResu
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -38,6 +39,7 @@ import java.util.Date;
 @EqualsAndHashCode(of = "primaryKey")
 public class OperationHistoryEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 4536813173706547247L;
 
     @EmbeddedId
@@ -118,6 +120,7 @@ public class OperationHistoryEntity implements Serializable {
     @AllArgsConstructor
     public static class OperationHistoryKey implements Serializable {
 
+        @Serial
         private static final long serialVersionUID = 7125401949386229372L;
 
         @Column(name = "operation_id")

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OperationMethodConfigEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OperationMethodConfigEntity.java
@@ -24,6 +24,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -37,6 +38,7 @@ import java.io.Serializable;
 @EqualsAndHashCode(of = "primaryKey")
 public class OperationMethodConfigEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 6602831455566058868L;
 
     @EmbeddedId
@@ -51,6 +53,7 @@ public class OperationMethodConfigEntity implements Serializable {
     @AllArgsConstructor
     public static class OperationAuthMethodKey implements Serializable {
 
+        @Serial
         private static final long serialVersionUID = -7631641120957350161L;
 
         @Column(name = "operation_name", nullable = false)

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OrganizationEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OrganizationEntity.java
@@ -24,6 +24,7 @@ import jakarta.persistence.Table;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -37,6 +38,7 @@ import java.io.Serializable;
 @EqualsAndHashCode(of = "organizationId")
 public class OrganizationEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = -3682348562614758414L;
 
     @Id

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OtpDefinitionEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OtpDefinitionEntity.java
@@ -23,6 +23,7 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -37,6 +38,7 @@ import java.util.Date;
 @EqualsAndHashCode(of = "name")
 public class OtpDefinitionEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 5337106400618975622L;
 
     @Id

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OtpEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OtpEntity.java
@@ -23,6 +23,7 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -37,6 +38,7 @@ import java.util.Date;
 @EqualsAndHashCode(of = {"otpDefinition", "userId", "credentialDefinition", "timestampCreated"})
 public class OtpEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 8483820995210446509L;
 
     @Id

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OtpPolicyEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/OtpPolicyEntity.java
@@ -23,6 +23,7 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -37,6 +38,7 @@ import java.util.Date;
 @EqualsAndHashCode(of = "name")
 public class OtpPolicyEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = -1157742528088577985L;
 
     @Id

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/RoleEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/RoleEntity.java
@@ -21,6 +21,7 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -35,6 +36,7 @@ import java.util.Date;
 @EqualsAndHashCode(of = "name")
 public class RoleEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1997494646745106999L;
 
     @Id

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/StepDefinitionEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/StepDefinitionEntity.java
@@ -25,6 +25,7 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -38,6 +39,7 @@ import java.io.Serializable;
 @EqualsAndHashCode(of = {"operationName", "stepDefinitionId"})
 public class StepDefinitionEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1125553531017608411L;
 
     @Id

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/UserAliasEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/UserAliasEntity.java
@@ -22,6 +22,7 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -36,6 +37,7 @@ import java.util.Date;
 @EqualsAndHashCode(of = {"name", "user"})
 public class UserAliasEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = -6855066974507308862L;
 
     @Id

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/UserContactEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/UserContactEntity.java
@@ -22,6 +22,7 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -36,6 +37,7 @@ import java.util.Date;
 @EqualsAndHashCode(of = {"name", "user", "type"})
 public class UserContactEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 7530081244465987786L;
 
     @Id

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/UserIdentityEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/UserIdentityEntity.java
@@ -23,6 +23,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.LinkedHashSet;
@@ -39,6 +40,7 @@ import java.util.Set;
 @EqualsAndHashCode(of = "userId")
 public class UserIdentityEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = -372574158382801384L;
 
     @Id

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/UserIdentityHistoryEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/UserIdentityHistoryEntity.java
@@ -22,6 +22,7 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -36,6 +37,7 @@ import java.util.Date;
 @EqualsAndHashCode(of = {"user", "timestampCreated"})
 public class UserIdentityHistoryEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 2982236221553997424L;
 
     @Id

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/UserPrefsEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/UserPrefsEntity.java
@@ -25,6 +25,7 @@ import jakarta.persistence.Table;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -38,6 +39,7 @@ import java.io.Serializable;
 @EqualsAndHashCode(of = "userId")
 public class UserPrefsEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = -7165002311514127800L;
 
     @Id
@@ -82,20 +84,14 @@ public class UserPrefsEntity implements Serializable {
      * @throws InvalidConfigurationException Thrown when Next Step configuration is invalid.
      */
     public Boolean getAuthMethodEnabled(int columnNumber) throws InvalidConfigurationException {
-        switch (columnNumber) {
-            case 1:
-                return getAuthMethod1Enabled();
-            case 2:
-                return getAuthMethod2Enabled();
-            case 3:
-                return getAuthMethod3Enabled();
-            case 4:
-                return getAuthMethod4Enabled();
-            case 5:
-                return getAuthMethod5Enabled();
-            default:
-                throw new InvalidConfigurationException("Unexpected column number for authentication method: " + columnNumber);
-        }
+        return switch (columnNumber) {
+            case 1 -> getAuthMethod1Enabled();
+            case 2 -> getAuthMethod2Enabled();
+            case 3 -> getAuthMethod3Enabled();
+            case 4 -> getAuthMethod4Enabled();
+            case 5 -> getAuthMethod5Enabled();
+            default -> throw new InvalidConfigurationException("Unexpected column number for authentication method: " + columnNumber);
+        };
     }
 
     /**
@@ -107,23 +103,12 @@ public class UserPrefsEntity implements Serializable {
      */
     public void setAuthMethodEnabled(int columnNumber, Boolean enabled) throws InvalidConfigurationException {
         switch (columnNumber) {
-            case 1:
-                setAuthMethod1Enabled(enabled);
-                break;
-            case 2:
-                setAuthMethod2Enabled(enabled);
-                break;
-            case 3:
-                setAuthMethod3Enabled(enabled);
-                break;
-            case 4:
-                setAuthMethod4Enabled(enabled);
-                break;
-            case 5:
-                setAuthMethod5Enabled(enabled);
-                break;
-            default:
-                throw new InvalidConfigurationException("Unexpected column number for authentication method: " + columnNumber);
+            case 1 -> setAuthMethod1Enabled(enabled);
+            case 2 -> setAuthMethod2Enabled(enabled);
+            case 3 -> setAuthMethod3Enabled(enabled);
+            case 4 -> setAuthMethod4Enabled(enabled);
+            case 5 -> setAuthMethod5Enabled(enabled);
+            default -> throw new InvalidConfigurationException("Unexpected column number for authentication method: " + columnNumber);
         }
     }
 
@@ -134,20 +119,14 @@ public class UserPrefsEntity implements Serializable {
      * @throws InvalidConfigurationException Thrown when Next Step configuration is invalid.
      */
     public String getAuthMethodConfig(int columnNumber) throws InvalidConfigurationException {
-        switch (columnNumber) {
-            case 1:
-                return getAuthMethod1Config();
-            case 2:
-                return getAuthMethod2Config();
-            case 3:
-                return getAuthMethod3Config();
-            case 4:
-                return getAuthMethod4Config();
-            case 5:
-                return getAuthMethod5Config();
-            default:
-                throw new InvalidConfigurationException("Unexpected column number for authentication method: " + columnNumber);
-        }
+        return switch (columnNumber) {
+            case 1 -> getAuthMethod1Config();
+            case 2 -> getAuthMethod2Config();
+            case 3 -> getAuthMethod3Config();
+            case 4 -> getAuthMethod4Config();
+            case 5 -> getAuthMethod5Config();
+            default -> throw new InvalidConfigurationException("Unexpected column number for authentication method: " + columnNumber);
+        };
     }
 
     /**
@@ -158,23 +137,12 @@ public class UserPrefsEntity implements Serializable {
      */
     public void setAuthMethodConfig(int columnNumber, String config) throws InvalidConfigurationException {
         switch (columnNumber) {
-            case 1:
-                setAuthMethod1Config(config);
-                break;
-            case 2:
-                setAuthMethod2Config(config);
-                break;
-            case 3:
-                setAuthMethod3Config(config);
-                break;
-            case 4:
-                setAuthMethod4Config(config);
-                break;
-            case 5:
-                setAuthMethod5Config(config);
-                break;
-            default:
-                throw new InvalidConfigurationException("Unexpected column number for authentication method: " + columnNumber);
+            case 1 -> setAuthMethod1Config(config);
+            case 2 -> setAuthMethod2Config(config);
+            case 3 -> setAuthMethod3Config(config);
+            case 4 -> setAuthMethod4Config(config);
+            case 5 -> setAuthMethod5Config(config);
+            default -> throw new InvalidConfigurationException("Unexpected column number for authentication method: " + columnNumber);
         }
 
     }

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/UserRoleEntity.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/repository/model/entity/UserRoleEntity.java
@@ -22,6 +22,7 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -36,6 +37,7 @@ import java.util.Date;
 @EqualsAndHashCode(of = {"user", "role"})
 public class UserRoleEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = -248437038124901685L;
 
     @Id

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/ApplicationService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/ApplicationService.java
@@ -109,11 +109,8 @@ public class ApplicationService {
      */
     @Transactional
     public UpdateApplicationResponse updateApplication(UpdateApplicationRequest request) throws ApplicationNotFoundException {
-        final Optional<ApplicationEntity> applicationOptional = applicationRepository.findByName(request.getApplicationName());
-        if (!applicationOptional.isPresent()) {
-            throw new ApplicationNotFoundException("Application not found: " + request.getApplicationName());
-        }
-        ApplicationEntity application = applicationOptional.get();
+        ApplicationEntity application = applicationRepository.findByName(request.getApplicationName()).orElseThrow(() ->
+                new ApplicationNotFoundException("Application not found: " + request.getApplicationName()));
         if (application.getStatus() != ApplicationStatus.ACTIVE && request.getApplicationStatus() != ApplicationStatus.ACTIVE) {
             throw new ApplicationNotFoundException("Application is not ACTIVE: " + request.getApplicationName());
         }
@@ -164,11 +161,8 @@ public class ApplicationService {
      */
     @Transactional
     public DeleteApplicationResponse deleteApplication(DeleteApplicationRequest request) throws ApplicationNotFoundException {
-        final Optional<ApplicationEntity> applicationOptional = applicationRepository.findByName(request.getApplicationName());
-        if (!applicationOptional.isPresent()) {
-            throw new ApplicationNotFoundException("Application not found: " + request.getApplicationName());
-        }
-        ApplicationEntity application = applicationOptional.get();
+        ApplicationEntity application = applicationRepository.findByName(request.getApplicationName()).orElseThrow(() ->
+                new ApplicationNotFoundException("Application not found: " + request.getApplicationName()));
         application.setStatus(ApplicationStatus.REMOVED);
         application.setTimestampLastUpdated(new Date());
         application = applicationRepository.save(application);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/AuthMethodChangeService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/AuthMethodChangeService.java
@@ -38,7 +38,6 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
 
 /**
  * This service handles authentication method changes within an operation with specific logic
@@ -125,11 +124,8 @@ public class AuthMethodChangeService {
             logger.info("Set chosen authentication method failed for operation ID: {}, authentication method: {}", request.getOperationId(), request.getTargetAuthMethod());
             return response;
         }
-        final Optional<OperationEntity> operationOptional = operationRepository.findById(operationId);
-        if (!operationOptional.isPresent()) {
-            throw new OperationNotFoundException("Operation not found, operation ID: " + operationId);
-        }
-        final OperationEntity operation = operationOptional.get();
+        final OperationEntity operation = operationRepository.findById(operationId).orElseThrow(() ->
+                new OperationNotFoundException("Operation not found, operation ID: " + operationId));
         if (operation.getResult() != AuthResult.CONTINUE) {
             // Invalid request - authentication method choice expects a CONTINUE operation result
             response.setResult(AuthResult.FAILED);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/AuthenticationService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/AuthenticationService.java
@@ -835,7 +835,7 @@ public class AuthenticationService {
         }
         final CredentialAuthenticationMode authModeResolved = authenticationMode != null ? authenticationMode : CredentialAuthenticationMode.MATCH_EXACT;
         switch (authModeResolved) {
-            case MATCH_EXACT:
+            case MATCH_EXACT -> {
                 final boolean credentialMatched = credentialProtectionService.verifyCredential(credentialValue, credential);
                 if (credentialMatched) {
                     logger.info("Credential verification succeeded, user ID: {}, credential definition name: {}", credential.getUser().getUserId(), credential.getCredentialDefinition().getName());
@@ -844,15 +844,14 @@ public class AuthenticationService {
                     logger.info("Credential verification failed, user ID: {}, credential definition name: {}, attempt counter: {}, soft counter: {}, hard counter: {}", credential.getUser().getUserId(), credential.getCredentialDefinition().getName(), credential.getAttemptCounter(), credential.getFailedAttemptCounterSoft(), credential.getFailedAttemptCounterHard());
                     return AuthenticationResult.FAILED;
                 }
-
-            case MATCH_ONLY_SPECIFIED_POSITIONS:
+            }
+            case MATCH_ONLY_SPECIFIED_POSITIONS -> {
                 if (credentialPositionsToVerify.isEmpty()) {
                     throw new InvalidRequestException("No positions specified for authentication mode MATCH_ONLY_SPECIFIED_POSITIONS");
                 }
                 if (credential.getHashingConfig() != null) {
                     throw new InvalidConfigurationException("Credential verification is not possible in MATCH_ONLY_SPECIFIED_POSITIONS mode when credential hashing is enabled");
                 }
-
                 final String expectedCredentialValue = credentialProtectionService.extractCredentialValue(credential);
                 int counter = 0;
                 for (Integer position : credentialPositionsToVerify) {
@@ -872,9 +871,8 @@ public class AuthenticationService {
                 }
                 logger.info("Credential verification succeeded for position match, user ID: {}, credential definition name: {}", credential.getUser().getUserId(), credential.getCredentialDefinition().getName());
                 return AuthenticationResult.SUCCEEDED;
-
-            default:
-                throw new InvalidRequestException("Invalid authentication mode: " + authenticationMode);
+            }
+            default -> throw new InvalidRequestException("Invalid authentication mode: " + authenticationMode);
         }
     }
 
@@ -950,7 +948,7 @@ public class AuthenticationService {
             }
             try {
 
-                final List<AuthStep> authSteps = objectMapper.readValue(currentHistory.getResponseSteps(), new TypeReference<List<AuthStep>>() {});
+                final List<AuthStep> authSteps = objectMapper.readValue(currentHistory.getResponseSteps(), new TypeReference<>() {});
                 if (authSteps.size() != 1) {
                     throw new InvalidRequestException("Authentication method could not be determined " +
                             "during credential authentication, operation ID: " + operation.getOperationId());

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/CredentialCounterService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/CredentialCounterService.java
@@ -101,12 +101,11 @@ public class CredentialCounterService {
         final Integer softLimit = credentialDefinition.getCredentialPolicy().getLimitSoft();
         final Integer hardLimit = credentialDefinition.getCredentialPolicy().getLimitHard();
         switch (authenticationResult) {
-            case SUCCEEDED:
+            case SUCCEEDED -> {
                 credential.setFailedAttemptCounterSoft(0);
                 credential.setFailedAttemptCounterHard(0);
-                break;
-
-            case FAILED:
+            }
+            case FAILED -> {
                 credential.setFailedAttemptCounterSoft(credential.getFailedAttemptCounterSoft() + 1);
                 credential.setFailedAttemptCounterHard(credential.getFailedAttemptCounterHard() + 1);
                 if (hardLimit != null && credential.getFailedAttemptCounterHard() >= hardLimit
@@ -118,11 +117,8 @@ public class CredentialCounterService {
                     credential.setStatus(CredentialStatus.BLOCKED_TEMPORARY);
                     credential.setTimestampBlocked(new Date());
                 }
-                break;
-
-            default:
-                throw new InvalidRequestException("Invalid authentication result: " + authenticationResult);
-
+            }
+            default -> throw new InvalidRequestException("Invalid authentication result: " + authenticationResult);
         }
         credential = credentialRepository.save(credential);
         logger.info("Credential counter updated, user ID: {}, credential definition name: {}, attempt counter: {}, soft counter: {}, hard counter: {}, status: {}",
@@ -133,7 +129,7 @@ public class CredentialCounterService {
 
     /**
      * Reset all soft failed attempt counters.
-     *
+     * <p>
      * Method behavior depends on the counter reset mode:
      * <ul>
      *     <li>RESET_BLOCKED_TEMPORARY - reset soft failed attempt counters for credentials with BLOCKED_TEMPORARY status, change status to ACTIVE</li>
@@ -147,20 +143,16 @@ public class CredentialCounterService {
     public ResetCountersResponse resetCounters(ResetCountersRequest request) throws InvalidRequestException {
         int resetCounter = 0;
         switch (request.getResetMode()) {
-            case RESET_BLOCKED_TEMPORARY:
+            case RESET_BLOCKED_TEMPORARY -> {
                 resetCounter += credentialRepository.resetSoftFailedCountersForBlockedTemporaryStatus();
                 logger.info("Soft failed attempt credential counters were reset for status BLOCKED_TEMPORARY and status was changed to ACTIVE, updated record count: {}", resetCounter);
-                break;
-
-            case RESET_ACTIVE_AND_BLOCKED_TEMPORARY:
+            }
+            case RESET_ACTIVE_AND_BLOCKED_TEMPORARY -> {
                 resetCounter += credentialRepository.resetSoftFailedCountersForBlockedTemporaryStatus();
                 resetCounter += credentialRepository.resetSoftFailedCountersForActiveStatus();
                 logger.info("Soft failed attempt credential counters were reset for statuses ACTIVE and BLOCKED_TEMPORARY, status was changed to ACTIVE, updated record count: {}", resetCounter);
-                break;
-
-            default:
-                throw new InvalidRequestException("Invalid counter reset mode: " + request.getResetMode());
-
+            }
+            default -> throw new InvalidRequestException("Invalid counter reset mode: " + request.getResetMode());
         }
         final ResetCountersResponse response = new ResetCountersResponse();
         response.setResetCounterCount(resetCounter);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/CredentialDefinitionService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/CredentialDefinitionService.java
@@ -97,26 +97,20 @@ public class CredentialDefinitionService {
         if (credentialDefinitionOptional.isPresent()) {
             throw new CredentialDefinitionAlreadyExistsException("Credential definition already exists: " + request.getCredentialDefinitionName());
         }
-        final Optional<ApplicationEntity> applicationOptional = applicationRepository.findByName(request.getApplicationName());
-        if (!applicationOptional.isPresent()) {
-            throw new ApplicationNotFoundException("Application does not exist: " + request.getApplicationName());
-        }
-        final ApplicationEntity application = applicationOptional.get();
+        final ApplicationEntity application = applicationRepository.findByName(request.getApplicationName()).orElseThrow(() ->
+                new ApplicationNotFoundException("Application does not exist: " + request.getApplicationName()));
         if (application.getStatus() != ApplicationStatus.ACTIVE) {
             throw new ApplicationNotFoundException("Application is not ACTIVE: " + request.getApplicationName());
         }
-        final Optional<CredentialPolicyEntity> credentialPolicyOptional = credentialPolicyRepository.findByName(request.getCredentialPolicyName());
-        if (!credentialPolicyOptional.isPresent()) {
-            throw new CredentialPolicyNotFoundException("Credential policy does not exist: " + request.getCredentialPolicyName());
-        }
-        final CredentialPolicyEntity credentialPolicy = credentialPolicyOptional.get();
+        final CredentialPolicyEntity credentialPolicy = credentialPolicyRepository.findByName(request.getCredentialPolicyName()).orElseThrow(() ->
+                new CredentialPolicyNotFoundException("Credential policy does not exist: " + request.getCredentialPolicyName()));
         if (credentialPolicy.getStatus() != CredentialPolicyStatus.ACTIVE) {
             throw new CredentialPolicyNotFoundException("Credential policy is not ACTIVE: " + request.getCredentialPolicyName());
         }
         HashConfigEntity hashConfigEntity = null;
         if (request.isHashingEnabled() && request.getHashConfigName() != null) {
             final Optional<HashConfigEntity> hashConfigOptional = hashConfigRepository.findByName(request.getHashConfigName());
-            if (!hashConfigOptional.isPresent()) {
+            if (hashConfigOptional.isEmpty()) {
                 throw new HashConfigNotFoundException("Hashing configuration does not exist: " + request.getHashConfigName());
             }
             hashConfigEntity = hashConfigOptional.get();
@@ -129,11 +123,9 @@ public class CredentialDefinitionService {
         credentialDefinition.setDescription(request.getDescription());
         credentialDefinition.setApplication(application);
         if (request.getOrganizationId() != null) {
-            final Optional<OrganizationEntity> organizationOptional = organizationRepository.findById(request.getOrganizationId());
-            if (!organizationOptional.isPresent()) {
-                throw new OrganizationNotFoundException("Organization not found: " + request.getOrganizationId());
-            }
-            credentialDefinition.setOrganization(organizationOptional.get());
+            final OrganizationEntity organization = organizationRepository.findById(request.getOrganizationId()).orElseThrow(() ->
+                    new OrganizationNotFoundException("Organization not found: " + request.getOrganizationId()));
+            credentialDefinition.setOrganization(organization);
         }
         credentialDefinition.setCredentialPolicy(credentialPolicy);
         credentialDefinition.setCategory(request.getCategory());
@@ -188,37 +180,25 @@ public class CredentialDefinitionService {
      */
     @Transactional
     public UpdateCredentialDefinitionResponse updateCredentialDefinition(UpdateCredentialDefinitionRequest request) throws CredentialDefinitionNotFoundException, ApplicationNotFoundException, CredentialPolicyNotFoundException, HashConfigNotFoundException, OrganizationNotFoundException {
-        final Optional<CredentialDefinitionEntity> credentialDefinitionOptional = credentialDefinitionRepository.findByName(request.getCredentialDefinitionName());
-        if (!credentialDefinitionOptional.isPresent()) {
-            throw new CredentialDefinitionNotFoundException("Credential definition not found: " + request.getCredentialDefinitionName());
-        }
-        CredentialDefinitionEntity credentialDefinition = credentialDefinitionOptional.get();
+        CredentialDefinitionEntity credentialDefinition = credentialDefinitionRepository.findByName(request.getCredentialDefinitionName()).orElseThrow(() ->
+            new CredentialDefinitionNotFoundException("Credential definition not found: " + request.getCredentialDefinitionName()));
         if (credentialDefinition.getStatus() != CredentialDefinitionStatus.ACTIVE && request.getCredentialDefinitionStatus() != CredentialDefinitionStatus.ACTIVE) {
             throw new CredentialDefinitionNotFoundException("Credential definition is not ACTIVE: " + request.getCredentialDefinitionName());
         }
-        final Optional<ApplicationEntity> applicationOptional = applicationRepository.findByName(request.getApplicationName());
-        if (!applicationOptional.isPresent()) {
-            throw new ApplicationNotFoundException("Application does not exist: " + request.getApplicationName());
-        }
-        final ApplicationEntity application = applicationOptional.get();
+        final ApplicationEntity application = applicationRepository.findByName(request.getApplicationName()).orElseThrow(() ->
+               new ApplicationNotFoundException("Application does not exist: " + request.getApplicationName()));
         if (application.getStatus() != ApplicationStatus.ACTIVE) {
             throw new ApplicationNotFoundException("Application is not ACTIVE: " + request.getApplicationName());
         }
-        final Optional<CredentialPolicyEntity> credentialPolicyOptional = credentialPolicyRepository.findByName(request.getCredentialPolicyName());
-        if (!credentialPolicyOptional.isPresent()) {
-            throw new CredentialPolicyNotFoundException("Credential policy does not exist: " + request.getCredentialPolicyName());
-        }
-        final CredentialPolicyEntity credentialPolicy = credentialPolicyOptional.get();
+        final CredentialPolicyEntity credentialPolicy = credentialPolicyRepository.findByName(request.getCredentialPolicyName()).orElseThrow(() ->
+                new CredentialPolicyNotFoundException("Credential policy does not exist: " + request.getCredentialPolicyName()));
         if (credentialPolicy.getStatus() != CredentialPolicyStatus.ACTIVE) {
             throw new CredentialPolicyNotFoundException("Credential policy is not ACTIVE: " + request.getCredentialPolicyName());
         }
         HashConfigEntity hashConfigEntity = null;
         if (request.isHashingEnabled() && request.getHashConfigName() != null) {
-            final Optional<HashConfigEntity> hashConfigOptional = hashConfigRepository.findByName(request.getHashConfigName());
-            if (!hashConfigOptional.isPresent()) {
-                throw new HashConfigNotFoundException("Hashing configuration does not exist: " + request.getHashConfigName());
-            }
-            hashConfigEntity = hashConfigOptional.get();
+            hashConfigEntity = hashConfigRepository.findByName(request.getHashConfigName()).orElseThrow(() ->
+                    new HashConfigNotFoundException("Hashing configuration does not exist: " + request.getHashConfigName()));
             if (hashConfigEntity.getStatus() != HashConfigStatus.ACTIVE) {
                 throw new HashConfigNotFoundException("Hashing configuration is not ACTIVE: " + request.getHashConfigName());
             }
@@ -231,11 +211,8 @@ public class CredentialDefinitionService {
         credentialDefinition.setApplication(application);
         OrganizationEntity organization = null;
         if (request.getOrganizationId() != null) {
-            Optional<OrganizationEntity> organizationOptional = organizationRepository.findById(request.getOrganizationId());
-            if (!organizationOptional.isPresent()) {
-                throw new OrganizationNotFoundException("Organization not found: " + request.getOrganizationId());
-            }
-            organization = organizationOptional.get();
+            organization = organizationRepository.findById(request.getOrganizationId()).orElseThrow(() ->
+                    new OrganizationNotFoundException("Organization not found: " + request.getOrganizationId()));
             credentialDefinition.setOrganization(organization);
         }
         credentialDefinition.setCredentialPolicy(credentialPolicy);
@@ -308,11 +285,8 @@ public class CredentialDefinitionService {
      */
     @Transactional
     public DeleteCredentialDefinitionResponse deleteCredentialDefinition(DeleteCredentialDefinitionRequest request) throws CredentialDefinitionNotFoundException {
-        final Optional<CredentialDefinitionEntity> credentialDefinitionOptional = credentialDefinitionRepository.findByName(request.getCredentialDefinitionName());
-        if (!credentialDefinitionOptional.isPresent()) {
-            throw new CredentialDefinitionNotFoundException("Credential definition not found: " + request.getCredentialDefinitionName());
-        }
-        CredentialDefinitionEntity credentialDefinition = credentialDefinitionOptional.get();
+        CredentialDefinitionEntity credentialDefinition = credentialDefinitionRepository.findByName(request.getCredentialDefinitionName()).orElseThrow(() ->
+                new CredentialDefinitionNotFoundException("Credential definition not found: " + request.getCredentialDefinitionName()));
         if (credentialDefinition.getStatus() == CredentialDefinitionStatus.REMOVED) {
             throw new CredentialDefinitionNotFoundException("Credential definition is already REMOVED: " + request.getCredentialDefinitionName());
         }
@@ -337,11 +311,8 @@ public class CredentialDefinitionService {
      * @throws CredentialDefinitionNotFoundException Thrown when credential definition is not found.
      */
     public CredentialDefinitionEntity findActiveCredentialDefinition(String credentialDefinitionName) throws CredentialDefinitionNotFoundException {
-        final Optional<CredentialDefinitionEntity> credentialDefinitionOptional = credentialDefinitionRepository.findByName(credentialDefinitionName);
-        if (!credentialDefinitionOptional.isPresent()) {
-            throw new CredentialDefinitionNotFoundException("Credential definition not found: " + credentialDefinitionName);
-        }
-        final CredentialDefinitionEntity credentialDefinition = credentialDefinitionOptional.get();
+        final CredentialDefinitionEntity credentialDefinition = credentialDefinitionRepository.findByName(credentialDefinitionName).orElseThrow(() ->
+                new CredentialDefinitionNotFoundException("Credential definition not found: " + credentialDefinitionName));
         if (credentialDefinition.getStatus() != CredentialDefinitionStatus.ACTIVE) {
             throw new CredentialDefinitionNotFoundException("Credential definition is not ACTIVE: " + credentialDefinitionName);
         }

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/CredentialGenerationService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/CredentialGenerationService.java
@@ -76,7 +76,7 @@ public class CredentialGenerationService {
     public String generateUsername(CredentialDefinitionEntity credentialDefinition) throws InvalidConfigurationException {
         final CredentialPolicyEntity credentialPolicy = credentialDefinition.getCredentialPolicy();
         switch (credentialPolicy.getUsernameGenAlgorithm()) {
-            case RANDOM_DIGITS:
+            case RANDOM_DIGITS -> {
                 try {
                     return generateRandomUsernameWithDigits(credentialDefinition);
                 } catch (InvalidConfigurationException ex) {
@@ -84,8 +84,8 @@ public class CredentialGenerationService {
                 } catch (Exception ex) {
                     throw new InvalidConfigurationException(ex);
                 }
-
-            case RANDOM_LETTERS:
+            }
+            case RANDOM_LETTERS -> {
                 try {
                     return generateRandomUsernameWithLetters(credentialDefinition);
                 } catch (InvalidConfigurationException ex) {
@@ -93,12 +93,12 @@ public class CredentialGenerationService {
                 } catch (Exception ex) {
                     throw new InvalidConfigurationException(ex);
                 }
-
-            case NO_USERNAME:
+            }
+            case NO_USERNAME -> {
                 return null;
-
-            default:
-                throw new InvalidConfigurationException("Unsupported username generation algorithm: " + credentialPolicy.getUsernameGenAlgorithm());
+            }
+            default ->
+                    throw new InvalidConfigurationException("Unsupported username generation algorithm: " + credentialPolicy.getUsernameGenAlgorithm());
         }
     }
 
@@ -111,7 +111,7 @@ public class CredentialGenerationService {
     public String generateCredentialValue(CredentialDefinitionEntity credentialDefinition) throws InvalidConfigurationException {
         final CredentialPolicyEntity credentialPolicy = credentialDefinition.getCredentialPolicy();
         switch (credentialPolicy.getCredentialGenAlgorithm()) {
-            case RANDOM_PASSWORD:
+            case RANDOM_PASSWORD -> {
                 try {
                     return generateRandomPassword(credentialPolicy);
                 } catch (InvalidConfigurationException ex) {
@@ -119,8 +119,8 @@ public class CredentialGenerationService {
                 } catch (Exception ex) {
                     throw new InvalidConfigurationException(ex);
                 }
-
-            case RANDOM_PIN:
+            }
+            case RANDOM_PIN -> {
                 try {
                     return generateRandomPin(credentialPolicy);
                 } catch (InvalidConfigurationException ex) {
@@ -128,9 +128,9 @@ public class CredentialGenerationService {
                 } catch (Exception ex) {
                     throw new InvalidConfigurationException(ex);
                 }
-
-            default:
-                throw new InvalidConfigurationException("Unsupported credential value generation algorithm: " + credentialPolicy.getCredentialGenAlgorithm());
+            }
+            default ->
+                    throw new InvalidConfigurationException("Unsupported credential value generation algorithm: " + credentialPolicy.getCredentialGenAlgorithm());
         }
     }
 

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/CredentialPolicyService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/CredentialPolicyService.java
@@ -160,11 +160,8 @@ public class CredentialPolicyService {
      */
     @Transactional
     public UpdateCredentialPolicyResponse updateCredentialPolicy(UpdateCredentialPolicyRequest request) throws CredentialPolicyNotFoundException, InvalidRequestException {
-        final Optional<CredentialPolicyEntity> credentialPolicyOptional = credentialPolicyRepository.findByName(request.getCredentialPolicyName());
-        if (!credentialPolicyOptional.isPresent()) {
-            throw new CredentialPolicyNotFoundException("Credential policy not found: " + request.getCredentialPolicyName());
-        }
-        CredentialPolicyEntity credentialPolicy = credentialPolicyOptional.get();
+        CredentialPolicyEntity credentialPolicy = credentialPolicyRepository.findByName(request.getCredentialPolicyName()).orElseThrow(() ->
+                new CredentialPolicyNotFoundException("Credential policy not found: " + request.getCredentialPolicyName()));
         if (credentialPolicy.getStatus() != CredentialPolicyStatus.ACTIVE && request.getCredentialPolicyStatus() != CredentialPolicyStatus.ACTIVE) {
             throw new CredentialPolicyNotFoundException("Credential policy is not ACTIVE: " + request.getCredentialPolicyName());
         }
@@ -271,11 +268,8 @@ public class CredentialPolicyService {
      */
     @Transactional
     public DeleteCredentialPolicyResponse deleteCredentialPolicy(DeleteCredentialPolicyRequest request) throws CredentialPolicyNotFoundException {
-        final Optional<CredentialPolicyEntity> credentialPolicyOptional = credentialPolicyRepository.findByName(request.getCredentialPolicyName());
-        if (!credentialPolicyOptional.isPresent()) {
-            throw new CredentialPolicyNotFoundException("Credential policy not found: " + request.getCredentialPolicyName());
-        }
-        CredentialPolicyEntity credentialPolicy = credentialPolicyOptional.get();
+        CredentialPolicyEntity credentialPolicy = credentialPolicyRepository.findByName(request.getCredentialPolicyName()).orElseThrow(() ->
+            new CredentialPolicyNotFoundException("Credential policy not found: " + request.getCredentialPolicyName()));
         if (credentialPolicy.getStatus() == CredentialPolicyStatus.REMOVED) {
             throw new CredentialPolicyNotFoundException("Credential policy is already REMOVED: " + request.getCredentialPolicyName());
         }

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/CredentialProtectionService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/CredentialProtectionService.java
@@ -95,15 +95,12 @@ public class CredentialProtectionService {
             throw new InvalidConfigurationException(ex);
         }
         switch (algorithm) {
-            case ARGON_2D:
-            case ARGON_2I:
-            case ARGON_2ID:
+            case ARGON_2D, ARGON_2I, ARGON_2ID -> {
                 final Argon2Hash argon2Hash = hashCredentialUsingArgon2(credentialValue, algorithm, param);
                 final String hashedValue = argon2Hash.toString();
                 return credentialValueConverter.toDBValue(hashedValue, userId, credentialDefinition);
-
-            default:
-                throw new InvalidConfigurationException("Unsupported hashing algorithm: " + algorithm);
+            }
+            default -> throw new InvalidConfigurationException("Unsupported hashing algorithm: " + algorithm);
         }
     }
 
@@ -128,17 +125,14 @@ public class CredentialProtectionService {
         }
         final HashAlgorithm algorithm = hashingConfig.getAlgorithm();
         switch (algorithm) {
-            case ARGON_2I:
-            case ARGON_2D:
-            case ARGON_2ID:
+            case ARGON_2I, ARGON_2D, ARGON_2ID -> {
                 final boolean succeeded = verifyCredentialUsingArgon2(credentialValue, algorithm, decryptedCredentialValue);
                 if (succeeded) {
                     updateStoredCredentialValueIfRequired(credentialValue, credential);
                 }
                 return succeeded;
-
-            default:
-                throw new InvalidConfigurationException("Unsupported hashing algorithm: " + algorithm);
+            }
+            default -> throw new InvalidConfigurationException("Unsupported hashing algorithm: " + algorithm);
         }
     }
 
@@ -158,15 +152,9 @@ public class CredentialProtectionService {
             return credentialValue.equals(decryptedCredentialValue);
         }
         final HashAlgorithm algorithm = hashingConfig.getAlgorithm();
-        switch (algorithm) {
-            case ARGON_2I:
-            case ARGON_2D:
-            case ARGON_2ID:
-                return verifyCredentialUsingArgon2(credentialValue, algorithm, decryptedCredentialValue);
-
-            default:
-                throw new InvalidConfigurationException("Unsupported hashing algorithm: " + algorithm);
-        }
+        return switch (algorithm) {
+            case ARGON_2I, ARGON_2D, ARGON_2ID -> verifyCredentialUsingArgon2(credentialValue, algorithm, decryptedCredentialValue);
+        };
     }
 
     /**

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/CredentialService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/CredentialService.java
@@ -177,7 +177,7 @@ public class CredentialService {
         UserIdentityEntity user = userIdentityLookupService.findUser(request.getUserId());
         final CredentialDefinitionEntity credentialDefinition = credentialDefinitionService.findActiveCredentialDefinition(request.getCredentialName());
         final Optional<CredentialEntity> credentialOptional = user.getCredentials().stream().filter(c -> c.getCredentialDefinition().equals(credentialDefinition)).findFirst();
-        if (!credentialOptional.isPresent()) {
+        if (credentialOptional.isEmpty()) {
             throw new CredentialNotFoundException("Credential not found: " + request.getCredentialName() + ", user ID: " + user.getUserId());
         }
         boolean updateCredentialExpiration = false;
@@ -413,7 +413,7 @@ public class CredentialService {
         UserIdentityEntity user = userIdentityLookupService.findUser(request.getUserId());
         final CredentialDefinitionEntity credentialDefinition = credentialDefinitionService.findActiveCredentialDefinition(request.getCredentialName());
         final Optional<CredentialEntity> credentialOptional = user.getCredentials().stream().filter(c -> c.getCredentialDefinition().equals(credentialDefinition)).findFirst();
-        if (!credentialOptional.isPresent()) {
+        if (credentialOptional.isEmpty()) {
             throw new CredentialNotFoundException("Credential not found: " + request.getCredentialName() + ", user ID: " + user.getUserId());
         }
         final CredentialEntity credential = credentialOptional.get();
@@ -484,7 +484,7 @@ public class CredentialService {
         UserIdentityEntity user = userIdentityLookupService.findUser(request.getUserId());
         final CredentialDefinitionEntity credentialDefinition = credentialDefinitionService.findActiveCredentialDefinition(request.getCredentialName());
         final Optional<CredentialEntity> credentialOptional = user.getCredentials().stream().filter(c -> c.getCredentialDefinition().equals(credentialDefinition)).findFirst();
-        if (!credentialOptional.isPresent()) {
+        if (credentialOptional.isEmpty()) {
             throw new CredentialNotFoundException("Credential not found: " + request.getCredentialName() + ", user ID: " + user.getUserId());
         }
         final CredentialEntity credential = credentialOptional.get();
@@ -524,7 +524,7 @@ public class CredentialService {
         UserIdentityEntity user = userIdentityLookupService.findUser(request.getUserId());
         final CredentialDefinitionEntity credentialDefinition = credentialDefinitionService.findActiveCredentialDefinition(request.getCredentialName());
         final Optional<CredentialEntity> credentialOptional = user.getCredentials().stream().filter(c -> c.getCredentialDefinition().equals(credentialDefinition)).findFirst();
-        if (!credentialOptional.isPresent()) {
+        if (credentialOptional.isEmpty()) {
             throw new CredentialNotFoundException("Credential not found: " + request.getCredentialName() + ", user ID: " + user.getUserId());
         }
         final CredentialEntity credential = credentialOptional.get();
@@ -565,7 +565,7 @@ public class CredentialService {
         UserIdentityEntity user = userIdentityLookupService.findUser(request.getUserId());
         final CredentialDefinitionEntity credentialDefinition = credentialDefinitionService.findActiveCredentialDefinition(request.getCredentialName());
         final Optional<CredentialEntity> credentialOptional = user.getCredentials().stream().filter(c -> c.getCredentialDefinition().equals(credentialDefinition)).findFirst();
-        if (!credentialOptional.isPresent()) {
+        if (credentialOptional.isEmpty()) {
             throw new CredentialNotFoundException("Credential not found: " + request.getCredentialName() + ", user ID: " + user.getUserId());
         }
         final CredentialEntity credential = credentialOptional.get();
@@ -620,11 +620,10 @@ public class CredentialService {
      * @throws CredentialNotFoundException Thrown when credential is not found.
      */
     public CredentialEntity findCredential(CredentialDefinitionEntity credentialDefinition, UserIdentityEntity user) throws CredentialNotFoundException {
-        final Optional<CredentialEntity> credentialOptional = user.getCredentials().stream().filter(c -> c.getCredentialDefinition().equals(credentialDefinition)).findFirst();
-        if (!credentialOptional.isPresent()) {
-            throw new CredentialNotFoundException("Credential not found: " + credentialDefinition.getName());
-        }
-        return credentialOptional.get();
+        return user.getCredentials().stream()
+                .filter(c -> c.getCredentialDefinition().equals(credentialDefinition))
+                .findFirst().orElseThrow(() ->
+                        new CredentialNotFoundException("Credential not found: " + credentialDefinition.getName()));
     }
 
     /**

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/CredentialValidationService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/CredentialValidationService.java
@@ -319,31 +319,42 @@ public class CredentialValidationService {
      */
     private CredentialValidationFailure convertToValidationFailure(String errorCode) throws InvalidConfigurationException {
         switch (errorCode) {
-            case "ILLEGAL_WHITESPACE":
+            case "ILLEGAL_WHITESPACE" -> {
                 return CredentialValidationFailure.CREDENTIAL_ILLEGAL_WHITESPACE;
-            case "ILLEGAL_USERNAME":
+            }
+            case "ILLEGAL_USERNAME" -> {
                 return CredentialValidationFailure.CREDENTIAL_ILLEGAL_USERNAME;
-            case "ILLEGAL_USERNAME_REVERSED":
+            }
+            case "ILLEGAL_USERNAME_REVERSED" -> {
                 return CredentialValidationFailure.CREDENTIAL_ILLEGAL_USERNAME_REVERSED;
-            case "ALLOWED_CHAR":
+            }
+            case "ALLOWED_CHAR" -> {
                 return CredentialValidationFailure.CREDENTIAL_ALLOWED_CHAR_FAILED;
-            case "ALLOWED_MATCH":
+            }
+            case "ALLOWED_MATCH" -> {
                 return CredentialValidationFailure.CREDENTIAL_ALLOWED_MATCH_FAILED;
-            case "ILLEGAL_CHAR":
+            }
+            case "ILLEGAL_CHAR" -> {
                 return CredentialValidationFailure.CREDENTIAL_ILLEGAL_CHAR;
-            case "ILLEGAL_MATCH":
+            }
+            case "ILLEGAL_MATCH" -> {
                 return CredentialValidationFailure.CREDENTIAL_ILLEGAL_MATCH;
-            case "INSUFFICIENT_UPPERCASE":
+            }
+            case "INSUFFICIENT_UPPERCASE" -> {
                 return CredentialValidationFailure.CREDENTIAL_INSUFFICIENT_UPPERCASE;
-            case "INSUFFICIENT_LOWERCASE":
+            }
+            case "INSUFFICIENT_LOWERCASE" -> {
                 return CredentialValidationFailure.CREDENTIAL_INSUFFICIENT_LOWERCASE;
-            case "INSUFFICIENT_ALPHABETICAL":
+            }
+            case "INSUFFICIENT_ALPHABETICAL" -> {
                 return CredentialValidationFailure.CREDENTIAL_INSUFFICIENT_ALPHABETICAL;
-            case "INSUFFICIENT_DIGIT":
+            }
+            case "INSUFFICIENT_DIGIT" -> {
                 return CredentialValidationFailure.CREDENTIAL_INSUFFICIENT_DIGIT;
-            case "INSUFFICIENT_SPECIAL":
+            }
+            case "INSUFFICIENT_SPECIAL" -> {
                 return CredentialValidationFailure.CREDENTIAL_INSUFFICIENT_SPECIAL;
-
+            }
         }
         throw new InvalidConfigurationException("Unknown error code: " + errorCode);
     }

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/HashConfigService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/HashConfigService.java
@@ -125,11 +125,8 @@ public class HashConfigService {
      */
     @Transactional
     public UpdateHashConfigResponse updateHashConfig(UpdateHashConfigRequest request) throws HashConfigNotFoundException, InvalidRequestException {
-        final Optional<HashConfigEntity> hashConfigOptional = hashConfigRepository.findByName(request.getHashConfigName());
-        if (!hashConfigOptional.isPresent()) {
-            throw new HashConfigNotFoundException("Hashing configuration not found: " + request.getHashConfigName());
-        }
-        HashConfigEntity hashConfig = hashConfigOptional.get();
+        HashConfigEntity hashConfig = hashConfigRepository.findByName(request.getHashConfigName()).orElseThrow(() ->
+                new HashConfigNotFoundException("Hashing configuration not found: " + request.getHashConfigName()));
         if (hashConfig.getStatus() != HashConfigStatus.ACTIVE && request.getHashConfigStatus() != HashConfigStatus.ACTIVE) {
             throw new HashConfigNotFoundException("Hashing configuration is not ACTIVE: " + request.getHashConfigName());
         }
@@ -188,11 +185,8 @@ public class HashConfigService {
      */
     @Transactional
     public DeleteHashConfigResponse deleteHashConfig(DeleteHashConfigRequest request) throws HashConfigNotFoundException {
-        final Optional<HashConfigEntity> hashConfigOptional = hashConfigRepository.findByName(request.getHashConfigName());
-        if (!hashConfigOptional.isPresent()) {
-            throw new HashConfigNotFoundException("Hashing configuration not found: " + request.getHashConfigName());
-        }
-        HashConfigEntity hashConfig = hashConfigOptional.get();
+        HashConfigEntity hashConfig = hashConfigRepository.findByName(request.getHashConfigName()).orElseThrow(() ->
+            new HashConfigNotFoundException("Hashing configuration not found: " + request.getHashConfigName()));
         if (hashConfig.getStatus() == HashConfigStatus.REMOVED) {
             throw new HashConfigNotFoundException("Hashing configuration is already REMOVED: " + request.getHashConfigName());
         }

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/OperationConfigurationService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/OperationConfigurationService.java
@@ -119,11 +119,8 @@ public class OperationConfigurationService {
      */
     @Transactional
     public GetOperationConfigDetailResponse getOperationConfig(String operationName) throws OperationConfigNotFoundException {
-        final Optional<OperationConfigEntity> operationConfigOptional = operationConfigRepository.findById(operationName);
-        if (!operationConfigOptional.isPresent()) {
-            throw new OperationConfigNotFoundException("Operation not configured, operation name: " + operationName);
-        }
-        final OperationConfigEntity operationConfig = operationConfigOptional.get();
+        final OperationConfigEntity operationConfig = operationConfigRepository.findById(operationName).orElseThrow(() ->
+                new OperationConfigNotFoundException("Operation not configured, operation name: " + operationName));
         return configConverter.fromOperationConfigEntity(operationConfig);
     }
 
@@ -151,15 +148,12 @@ public class OperationConfigurationService {
      */
     @Transactional
     public DeleteOperationConfigResponse deleteOperationConfig(DeleteOperationConfigRequest request) throws OperationConfigNotFoundException, DeleteNotAllowedException {
-        final Optional<OperationConfigEntity> operationConfigOptional = operationConfigRepository.findById(request.getOperationName());
-        if (!operationConfigOptional.isPresent()) {
-            throw new OperationConfigNotFoundException("Operation configuration not found, operation name: " + request.getOperationName());
-        }
+        final OperationConfigEntity operationConfig = operationConfigRepository.findById(request.getOperationName()).orElseThrow(() ->
+            new OperationConfigNotFoundException("Operation configuration not found, operation name: " + request.getOperationName()));
         final long existingOperationCount = operationRepository.countByOperationName(request.getOperationName());
         if (existingOperationCount > 0) {
             throw new DeleteNotAllowedException("Operation configuration cannot be deleted because it is used: " + request.getOperationName());
         }
-        final OperationConfigEntity operationConfig = operationConfigOptional.get();
         operationConfigRepository.delete(operationConfig);
         logger.debug("Operation configuration was deleted, operation name: {}", operationConfig.getOperationName());
         audit.info("Operation configuration was deleted", AuditDetail.builder()
@@ -182,11 +176,11 @@ public class OperationConfigurationService {
     @Transactional
     public CreateOperationMethodConfigResponse createOperationMethodConfig(CreateOperationMethodConfigRequest request) throws OperationMethodConfigAlreadyExists, OperationConfigNotFoundException, AuthMethodNotFoundException {
         final Optional<OperationConfigEntity> operationConfigOptional = operationConfigRepository.findById(request.getOperationName());
-        if (!operationConfigOptional.isPresent()) {
+        if (operationConfigOptional.isEmpty()) {
             throw new OperationConfigNotFoundException("Operation configuration not found, operation: " + request.getOperationName());
         }
         final Optional<AuthMethodEntity> authMethodOptional = authMethodRepository.findById(request.getAuthMethod());
-        if (!authMethodOptional.isPresent()) {
+        if (authMethodOptional.isEmpty()) {
             throw new AuthMethodNotFoundException("Authentication method not found: " + request.getAuthMethod());
         }
         final OperationMethodConfigEntity.OperationAuthMethodKey primaryKey = new OperationMethodConfigEntity.OperationAuthMethodKey(request.getOperationName(), request.getAuthMethod());
@@ -213,11 +207,8 @@ public class OperationConfigurationService {
     @Transactional
     public GetOperationMethodConfigDetailResponse getOperationMethodConfigDetail(GetOperationMethodConfigDetailRequest request) throws OperationMethodConfigNotFoundException {
         final OperationMethodConfigEntity.OperationAuthMethodKey primaryKey = new OperationMethodConfigEntity.OperationAuthMethodKey(request.getOperationName(), request.getAuthMethod());
-        final Optional<OperationMethodConfigEntity> operationMethodConfigOptional = operationMethodConfigRepository.findById(primaryKey);
-        if (!operationMethodConfigOptional.isPresent()) {
-            throw new OperationMethodConfigNotFoundException("Configuration not found, operation name: " + request.getOperationName() + ", authentication method: " + request.getAuthMethod());
-        }
-        final OperationMethodConfigEntity operationMethodConfig = operationMethodConfigOptional.get();
+        final OperationMethodConfigEntity operationMethodConfig = operationMethodConfigRepository.findById(primaryKey).orElseThrow(() ->
+                new OperationMethodConfigNotFoundException("Configuration not found, operation name: " + request.getOperationName() + ", authentication method: " + request.getAuthMethod()));
         final GetOperationMethodConfigDetailResponse response = new GetOperationMethodConfigDetailResponse();
         response.setOperationName(operationMethodConfig.getPrimaryKey().getOperationName());
         response.setAuthMethod(operationMethodConfig.getPrimaryKey().getAuthMethod());
@@ -234,11 +225,8 @@ public class OperationConfigurationService {
     @Transactional
     public DeleteOperationMethodConfigResponse deleteOperationMethodConfig(DeleteOperationMethodConfigRequest request) throws OperationMethodConfigNotFoundException {
         final OperationMethodConfigEntity.OperationAuthMethodKey primaryKey = new OperationMethodConfigEntity.OperationAuthMethodKey(request.getOperationName(), request.getAuthMethod());
-        final Optional<OperationMethodConfigEntity> operationMethodConfigOptional = operationMethodConfigRepository.findById(primaryKey);
-        if (!operationMethodConfigOptional.isPresent()) {
-            throw new OperationMethodConfigNotFoundException("Configuration not found, operation name: " + request.getOperationName() + ", authentication method: " + request.getAuthMethod());
-        }
-        final OperationMethodConfigEntity operationMethodConfig = operationMethodConfigOptional.get();
+        final OperationMethodConfigEntity operationMethodConfig = operationMethodConfigRepository.findById(primaryKey).orElseThrow(() ->
+                new OperationMethodConfigNotFoundException("Configuration not found, operation name: " + request.getOperationName() + ", authentication method: " + request.getAuthMethod()));
         operationMethodConfigRepository.delete(operationMethodConfig);
         logger.debug("Operation and authentication method configuration was deleted, operation name: {}, authentication method: {}", operationMethodConfig.getPrimaryKey().getOperationName(), operationMethodConfig.getPrimaryKey().getAuthMethod());
         audit.info("Operation and authentication method configuration was deleted", AuditDetail.builder()

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/OperationPersistenceService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/OperationPersistenceService.java
@@ -117,11 +117,9 @@ public class OperationPersistenceService {
         operation.setOperationId(response.getOperationId());
         operation.setUserId(request.getUserId());
         if (request.getOrganizationId() != null) {
-            final Optional<OrganizationEntity> organizationOptional = organizationRepository.findById(request.getOrganizationId());
-            if (!organizationOptional.isPresent()) {
-                throw new OrganizationNotFoundException("Organization not found: " + request.getOrganizationId());
-            }
-            operation.setOrganization(organizationOptional.get());
+            final OrganizationEntity organization = organizationRepository.findById(request.getOrganizationId()).orElseThrow(() ->
+                    new OrganizationNotFoundException("Organization not found: " + request.getOrganizationId()));
+            operation.setOrganization(organization);
         }
         operation.setExternalOperationName(request.getOperationNameExternal());
         operation.setExternalTransactionId(request.getExternalTransactionId());
@@ -222,21 +220,16 @@ public class OperationPersistenceService {
         final IdGeneratorService idGeneratorService = serviceCatalogue.getIdGeneratorService();
         final OperationCustomizationService operationCustomizationService = serviceCatalogue.getOperationCustomizationService();
 
-        final Optional<OperationEntity> operationOptional = operationRepository.findById(response.getOperationId());
-        if (!operationOptional.isPresent()) {
-            throw new OperationNotFoundException("Operation not found, operation ID: " + response.getOperationId());
-        }
-        OperationEntity operation = operationOptional.get();
+        OperationEntity operation = operationRepository.findById(response.getOperationId()).orElseThrow(() ->
+                new OperationNotFoundException("Operation not found, operation ID: " + response.getOperationId()));
         final AuthResult originalResult = operation.getResult();
         if (request.getUserId() != null) {
             operation.setUserId(request.getUserId());
         }
         if (request.getOrganizationId() != null) {
-            final Optional<OrganizationEntity> organizationOptional = organizationRepository.findById(request.getOrganizationId());
-            if (!organizationOptional.isPresent()) {
-                throw new OrganizationNotFoundException("Organization not found: " + request.getOrganizationId());
-            }
-            operation.setOrganization(organizationOptional.get());
+            final OrganizationEntity organization = organizationRepository.findById(request.getOrganizationId()).orElseThrow(() ->
+                    new OrganizationNotFoundException("Organization not found: " + request.getOrganizationId()));
+            operation.setOrganization(organization);
         }
         operation.setResult(response.getResult());
         if (request.getApplicationContext() != null) {
@@ -314,11 +307,9 @@ public class OperationPersistenceService {
         final OperationEntity operation = getOperation(operationId);
         operation.setUserId(userId);
         if (organizationId != null) {
-            final Optional<OrganizationEntity> organizationOptional = organizationRepository.findById(organizationId);
-            if (!organizationOptional.isPresent()) {
-                throw new OrganizationNotFoundException("Organization not found: " + organizationId);
-            }
-            operation.setOrganization(organizationOptional.get());
+            final OrganizationEntity organization = organizationRepository.findById(organizationId).orElseThrow(() ->
+                    new OrganizationNotFoundException("Organization not found: " + organizationId));
+            operation.setOrganization(organization);
         }
         if (accountStatus != null) {
             operation.setUserAccountStatus(accountStatus);
@@ -340,11 +331,8 @@ public class OperationPersistenceService {
      * @throws OperationNotFoundException Thrown when operation does not exist.
      */
     public void updateFormData(UpdateFormDataRequest request) throws OperationNotFoundException {
-        final Optional<OperationEntity> operationOptional = operationRepository.findById(request.getOperationId());
-        if (!operationOptional.isPresent()) {
-            throw new OperationNotFoundException("Operation not found, operation ID: " + request.getOperationId());
-        }
-        final OperationEntity operation = operationOptional.get();
+        final OperationEntity operation = operationRepository.findById(request.getOperationId()).orElseThrow(() ->
+                new OperationNotFoundException("Operation not found, operation ID: " + request.getOperationId()));
         try {
             final OperationFormData formData = objectMapper.readValue(operation.getOperationFormData(), OperationFormData.class);
             // update only formData.userInput which should contain all input from the user
@@ -376,11 +364,8 @@ public class OperationPersistenceService {
      * @throws OperationNotValidException Thrown when operation is invalid.
      */
     public void updateChosenAuthMethod(UpdateChosenAuthMethodRequest request) throws OperationNotFoundException, InvalidRequestException, OperationNotValidException {
-        final Optional<OperationEntity> operationOptional = operationRepository.findById(request.getOperationId());
-        if (!operationOptional.isPresent()) {
-            throw new OperationNotFoundException("Operation not found, operation ID: " + request.getOperationId());
-        }
-        final OperationEntity operation = operationOptional.get();
+        final OperationEntity operation = operationRepository.findById(request.getOperationId()).orElseThrow(() ->
+                new OperationNotFoundException("Operation not found, operation ID: " + request.getOperationId()));
         updateChosenAuthMethod(operation, request.getChosenAuthMethod());
     }
 
@@ -427,11 +412,8 @@ public class OperationPersistenceService {
      */
     public void updateMobileToken(UpdateMobileTokenRequest request) throws OperationNotFoundException, OperationNotValidException, InvalidConfigurationException {
         final MobileTokenConfigurationService mobileTokenConfigurationService = serviceCatalogue.getMobileTokenConfigurationService();
-        final Optional<OperationEntity> operationOptional = operationRepository.findById(request.getOperationId());
-        if (!operationOptional.isPresent()) {
-            throw new OperationNotFoundException("Operation not found, operation ID: " + request.getOperationId());
-        }
-        final OperationEntity operation = operationOptional.get();
+        final OperationEntity operation = operationRepository.findById(request.getOperationId()).orElseThrow(() ->
+                new OperationNotFoundException("Operation not found, operation ID: " + request.getOperationId()));
         final OperationHistoryEntity currentHistory = operation.getCurrentOperationHistoryEntity();
         if (currentHistory == null) {
             throw new OperationNotValidException("Operation is missing history");
@@ -461,11 +443,8 @@ public class OperationPersistenceService {
      * @throws OperationNotFoundException Thrown when operation does not exist.
      */
     public void updateApplicationContext(UpdateApplicationContextRequest request) throws OperationNotFoundException {
-        final Optional<OperationEntity> operationOptional = operationRepository.findById(request.getOperationId());
-        if (!operationOptional.isPresent()) {
-            throw new OperationNotFoundException("Operation not found, operation ID: " + request.getOperationId());
-        }
-        final OperationEntity operation = operationOptional.get();
+        final OperationEntity operation = operationRepository.findById(request.getOperationId()).orElseThrow(() ->
+                new OperationNotFoundException("Operation not found, operation ID: " + request.getOperationId()));
         final ApplicationContext applicationContext = request.getApplicationContext();
         try {
             if (applicationContext == null) {
@@ -520,11 +499,8 @@ public class OperationPersistenceService {
      * @throws OperationNotValidException Thrown when operation is invalid.
      */
     public OperationEntity getOperation(String operationId, boolean validateOperation) throws OperationNotFoundException, OperationNotValidException {
-        final Optional<OperationEntity> operationOptional = operationRepository.findById(operationId);
-        if (!operationOptional.isPresent()) {
-            throw new OperationNotFoundException("Operation not found, operation ID: " + operationId);
-        }
-        final OperationEntity operation = operationOptional.get();
+        final OperationEntity operation = operationRepository.findById(operationId).orElseThrow(() ->
+                new OperationNotFoundException("Operation not found, operation ID: " + operationId));
         if (validateOperation) {
             validateMobileTokenOperation(operation);
         }

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/OrganizationService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/OrganizationService.java
@@ -24,7 +24,6 @@ import io.getlime.security.powerauth.app.nextstep.converter.OrganizationConverte
 import io.getlime.security.powerauth.app.nextstep.repository.OrganizationRepository;
 import io.getlime.security.powerauth.app.nextstep.repository.catalogue.RepositoryCatalogue;
 import io.getlime.security.powerauth.app.nextstep.repository.model.entity.OrganizationEntity;
-import io.getlime.security.powerauth.lib.nextstep.model.exception.DeleteNotAllowedException;
 import io.getlime.security.powerauth.lib.nextstep.model.exception.OrganizationAlreadyExistsException;
 import io.getlime.security.powerauth.lib.nextstep.model.exception.OrganizationNotFoundException;
 import io.getlime.security.powerauth.lib.nextstep.model.request.CreateOrganizationRequest;
@@ -113,11 +112,8 @@ public class OrganizationService {
      */
     @Transactional
     public GetOrganizationDetailResponse getOrganizationDetail(GetOrganizationDetailRequest request) throws OrganizationNotFoundException {
-        final Optional<OrganizationEntity> organizationOptional = organizationRepository.findById(request.getOrganizationId());
-        if (!organizationOptional.isPresent()) {
-            throw new OrganizationNotFoundException("Organization not found: " + request.getOrganizationId());
-        }
-        final OrganizationEntity organization = organizationOptional.get();
+        final OrganizationEntity organization = organizationRepository.findById(request.getOrganizationId()).orElseThrow(() ->
+                new OrganizationNotFoundException("Organization not found: " + request.getOrganizationId()));
         return organizationConverter.fromOrganizationEntity(organization);
     }
 
@@ -141,15 +137,11 @@ public class OrganizationService {
      * @param request Delete organization request.
      * @return Delete organization response.
      * @throws OrganizationNotFoundException Thrown when organization is not found.
-     * @throws DeleteNotAllowedException Thrown when record cannot be deleted.
      */
     @Transactional
-    public DeleteOrganizationResponse deleteOrganization(DeleteOrganizationRequest request) throws OrganizationNotFoundException, DeleteNotAllowedException {
-        final Optional<OrganizationEntity> organizationOptional = organizationRepository.findById(request.getOrganizationId());
-        if (!organizationOptional.isPresent()) {
-            throw new OrganizationNotFoundException("Organization not found: " + request.getOrganizationId());
-        }
-        final OrganizationEntity organization = organizationOptional.get();
+    public DeleteOrganizationResponse deleteOrganization(DeleteOrganizationRequest request) throws OrganizationNotFoundException {
+        final OrganizationEntity organization = organizationRepository.findById(request.getOrganizationId()).orElseThrow(() ->
+                new OrganizationNotFoundException("Organization not found: " + request.getOrganizationId()));
         organizationRepository.delete(organization);
         logger.debug("Organization was deleted: {}", organization.getOrganizationId());
         audit.info("Organization was deleted", AuditDetail.builder()

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/OtpDefinitionService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/OtpDefinitionService.java
@@ -97,19 +97,13 @@ public class OtpDefinitionService {
         if (otpDefinitionOptional.isPresent()) {
             throw new OtpDefinitionAlreadyExistsException("One time password already exists: " + request.getOtpDefinitionName());
         }
-        final Optional<ApplicationEntity> applicationOptional = applicationRepository.findByName(request.getApplicationName());
-        if (!applicationOptional.isPresent()) {
-            throw new ApplicationNotFoundException("Application does not exist: " + request.getApplicationName());
-        }
-        final ApplicationEntity application = applicationOptional.get();
+        final ApplicationEntity application = applicationRepository.findByName(request.getApplicationName()).orElseThrow(() ->
+                new ApplicationNotFoundException("Application does not exist: " + request.getApplicationName()));
         if (application.getStatus() != ApplicationStatus.ACTIVE) {
             throw new ApplicationNotFoundException("Application is not ACTIVE: " + request.getApplicationName());
         }
-        final Optional<OtpPolicyEntity> otpPolicyOptional = otpPolicyRepository.findByName(request.getOtpPolicyName());
-        if (!otpPolicyOptional.isPresent()) {
-            throw new OtpPolicyNotFoundException("Otp policy does not exist: " + request.getOtpPolicyName());
-        }
-        final OtpPolicyEntity otpPolicy = otpPolicyOptional.get();
+        final OtpPolicyEntity otpPolicy = otpPolicyRepository.findByName(request.getOtpPolicyName()).orElseThrow(() ->
+                new OtpPolicyNotFoundException("Otp policy does not exist: " + request.getOtpPolicyName()));
         if (otpPolicy.getStatus() != OtpPolicyStatus.ACTIVE) {
             throw new OtpPolicyNotFoundException("Otp policy is not ACTIVE: " + request.getOtpPolicyName());
         }
@@ -150,27 +144,18 @@ public class OtpDefinitionService {
      */
     @Transactional
     public UpdateOtpDefinitionResponse updateOtpDefinition(UpdateOtpDefinitionRequest request) throws OtpDefinitionNotFoundException, ApplicationNotFoundException, OtpPolicyNotFoundException {
-        final Optional<OtpDefinitionEntity> otpDefinitionOptional = otpDefinitionRepository.findByName(request.getOtpDefinitionName());
-        if (!otpDefinitionOptional.isPresent()) {
-            throw new OtpDefinitionNotFoundException("One time password definition not found: " + request.getOtpDefinitionName());
-        }
-        OtpDefinitionEntity otpDefinition = otpDefinitionOptional.get();
+        OtpDefinitionEntity otpDefinition = otpDefinitionRepository.findByName(request.getOtpDefinitionName()).orElseThrow(() ->
+                new OtpDefinitionNotFoundException("One time password definition not found: " + request.getOtpDefinitionName()));
         if (otpDefinition.getStatus() != OtpDefinitionStatus.ACTIVE && request.getOtpDefinitionStatus() != OtpDefinitionStatus.ACTIVE) {
             throw new OtpDefinitionNotFoundException("One time password definition is not ACTIVE: " + request.getOtpDefinitionName());
         }
-        final Optional<ApplicationEntity> applicationOptional = applicationRepository.findByName(request.getApplicationName());
-        if (!applicationOptional.isPresent()) {
-            throw new ApplicationNotFoundException("Application does not exist: " + request.getApplicationName());
-        }
-        final ApplicationEntity application = applicationOptional.get();
+        final ApplicationEntity application = applicationRepository.findByName(request.getApplicationName()).orElseThrow(() ->
+                new ApplicationNotFoundException("Application does not exist: " + request.getApplicationName()));
         if (application.getStatus() != ApplicationStatus.ACTIVE) {
             throw new ApplicationNotFoundException("Application is not ACTIVE: " + request.getApplicationName());
         }
-        final Optional<OtpPolicyEntity> otpPolicyOptional = otpPolicyRepository.findByName(request.getOtpPolicyName());
-        if (!otpPolicyOptional.isPresent()) {
-            throw new OtpPolicyNotFoundException("Otp policy does not exist: " + request.getOtpPolicyName());
-        }
-        final OtpPolicyEntity otpPolicy = otpPolicyOptional.get();
+        final OtpPolicyEntity otpPolicy = otpPolicyRepository.findByName(request.getOtpPolicyName()).orElseThrow(() ->
+                new OtpPolicyNotFoundException("Otp policy does not exist: " + request.getOtpPolicyName()));
         if (otpPolicy.getStatus() != OtpPolicyStatus.ACTIVE) {
             throw new OtpPolicyNotFoundException("Otp policy is not ACTIVE: " + request.getOtpPolicyName());
         }
@@ -232,11 +217,8 @@ public class OtpDefinitionService {
      */
     @Transactional
     public DeleteOtpDefinitionResponse deleteOtpDefinition(DeleteOtpDefinitionRequest request) throws OtpDefinitionNotFoundException {
-        final Optional<OtpDefinitionEntity> otpDefinitionOptional = otpDefinitionRepository.findByName(request.getOtpDefinitionName());
-        if (!otpDefinitionOptional.isPresent()) {
-            throw new OtpDefinitionNotFoundException("One time password definition not found: " + request.getOtpDefinitionName());
-        }
-        OtpDefinitionEntity otpDefinition = otpDefinitionOptional.get();
+        OtpDefinitionEntity otpDefinition = otpDefinitionRepository.findByName(request.getOtpDefinitionName()).orElseThrow(() ->
+                new OtpDefinitionNotFoundException("One time password definition not found: " + request.getOtpDefinitionName()));
         if (otpDefinition.getStatus() == OtpDefinitionStatus.REMOVED) {
             throw new OtpDefinitionNotFoundException("One time password definition is already REMOVED: " + request.getOtpDefinitionName());
         }
@@ -261,11 +243,8 @@ public class OtpDefinitionService {
      * @throws OtpDefinitionNotFoundException Thrown when OTP definition is not found.
      */
     public OtpDefinitionEntity findActiveOtpDefinition(String otpDefinitionName) throws OtpDefinitionNotFoundException {
-        final Optional<OtpDefinitionEntity> otpDefinitionOptional = otpDefinitionRepository.findByName(otpDefinitionName);
-        if (!otpDefinitionOptional.isPresent()) {
-            throw new OtpDefinitionNotFoundException("OTP definition not found: " + otpDefinitionName);
-        }
-        final OtpDefinitionEntity otpDefinition = otpDefinitionOptional.get();
+        final OtpDefinitionEntity otpDefinition = otpDefinitionRepository.findByName(otpDefinitionName).orElseThrow(() ->
+                new OtpDefinitionNotFoundException("OTP definition not found: " + otpDefinitionName));
         if (otpDefinition.getStatus() != OtpDefinitionStatus.ACTIVE) {
             throw new OtpDefinitionNotFoundException("OTP definition is not ACTIVE: " + otpDefinitionName);
         }

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/OtpGenerationService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/OtpGenerationService.java
@@ -59,7 +59,7 @@ public class OtpGenerationService {
         final Integer length = otpPolicy.getLength();
         final OtpGenerationAlgorithm otpGenAlgorithm = otpPolicy.getGenAlgorithm();
         switch (otpGenAlgorithm) {
-            case OTP_DATA_DIGEST:
+            case OTP_DATA_DIGEST -> {
                 try {
                     final DataDigest dataDigest = new DataDigest(length);
                     final DataDigest.Result result = dataDigest.generateDigest(Collections.singletonList(otpData));
@@ -73,8 +73,8 @@ public class OtpGenerationService {
                     throw new InvalidConfigurationException("OTP generation failed, error: " + ex.getMessage());
                 }
                 return otpValueDetail;
-
-            case OTP_RANDOM_DIGIT_GROUPS:
+            }
+            case OTP_RANDOM_DIGIT_GROUPS -> {
                 final OtpGenerationParam otpGenerationParam;
                 try {
                     otpGenerationParam = parameterConverter.fromString(otpPolicy.getGenParam(), OtpGenerationParam.class);
@@ -112,9 +112,8 @@ public class OtpGenerationService {
                 }
                 otpValueDetail.setOtpValue(otpBuilder.toString());
                 return otpValueDetail;
-
-            default:
-                throw new OtpGenAlgorithmNotSupportedException("OTP generation algorithm is not supported: " + otpGenAlgorithm);
+            }
+            default -> throw new OtpGenAlgorithmNotSupportedException("OTP generation algorithm is not supported: " + otpGenAlgorithm);
         }
     }
 }

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/OtpPolicyService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/OtpPolicyService.java
@@ -130,11 +130,8 @@ public class OtpPolicyService {
      */
     @Transactional
     public UpdateOtpPolicyResponse updateOtpPolicy(UpdateOtpPolicyRequest request) throws OtpPolicyNotFoundException, InvalidRequestException {
-        final Optional<OtpPolicyEntity> otpPolicyOptional = otpPolicyRepository.findByName(request.getOtpPolicyName());
-        if (!otpPolicyOptional.isPresent()) {
-            throw new OtpPolicyNotFoundException("One time password policy not found: " + request.getOtpPolicyName());
-        }
-        OtpPolicyEntity otpPolicy = otpPolicyOptional.get();
+        OtpPolicyEntity otpPolicy = otpPolicyRepository.findByName(request.getOtpPolicyName()).orElseThrow(() ->
+                new OtpPolicyNotFoundException("One time password policy not found: " + request.getOtpPolicyName()));
         if (otpPolicy.getStatus() != OtpPolicyStatus.ACTIVE && request.getOtpPolicyStatus() != OtpPolicyStatus.ACTIVE) {
             throw new OtpPolicyNotFoundException("One time password policy is not ACTIVE: " + request.getOtpPolicyName());
         }
@@ -205,11 +202,8 @@ public class OtpPolicyService {
      */
     @Transactional
     public DeleteOtpPolicyResponse deleteOtpPolicy(DeleteOtpPolicyRequest request) throws OtpPolicyNotFoundException {
-        final Optional<OtpPolicyEntity> otpPolicyOptional = otpPolicyRepository.findByName(request.getOtpPolicyName());
-        if (!otpPolicyOptional.isPresent()) {
-            throw new OtpPolicyNotFoundException("One time password policy not found: " + request.getOtpPolicyName());
-        }
-        OtpPolicyEntity otpPolicy = otpPolicyOptional.get();
+        OtpPolicyEntity otpPolicy = otpPolicyRepository.findByName(request.getOtpPolicyName()).orElseThrow(() ->
+                new OtpPolicyNotFoundException("One time password policy not found: " + request.getOtpPolicyName()));
         if (otpPolicy.getStatus() == OtpPolicyStatus.REMOVED) {
             throw new OtpPolicyNotFoundException("One time password policy is already REMOVED: " + request.getOtpPolicyName());
         }

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/OtpService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/OtpService.java
@@ -312,10 +312,9 @@ public class OtpService {
      * @param request Get OTP list request.
      * @return Get OTP list response.
      * @throws OperationNotFoundException Thrown when operation is not found.
-     * @throws EncryptionException Thrown when decryption fails.
      */
     @Transactional
-    public GetOtpListResponse getOtpList(GetOtpListRequest request) throws OperationNotFoundException, EncryptionException {
+    public GetOtpListResponse getOtpList(GetOtpListRequest request) throws OperationNotFoundException {
         final OperationPersistenceService operationPersistenceService = serviceCatalogue.getOperationPersistenceService();
         final OperationEntity operation = operationPersistenceService.getOperation(request.getOperationId());
         final GetOtpListResponse response = new GetOtpListResponse();
@@ -400,11 +399,8 @@ public class OtpService {
         final OperationPersistenceService operationPersistenceService = serviceCatalogue.getOperationPersistenceService();
         final OtpEntity otp;
         if (otpId != null) {
-            final Optional<OtpEntity> otpOptional = otpRepository.findById(otpId);
-            if (!otpOptional.isPresent()) {
-                throw new OtpNotFoundException("OTP not found: " + otpId);
-            }
-            otp = otpOptional.get();
+            otp = otpRepository.findById(otpId).orElseThrow(() ->
+                    new OtpNotFoundException("OTP not found: " + otpId));
             if (operationId != null) {
                 if (otp.getOperation() == null) {
                     throw new InvalidRequestException("OTP was not created within an operation: " + otpId);
@@ -415,11 +411,8 @@ public class OtpService {
             }
         } else if (operationId != null) {
             final OperationEntity operation = operationPersistenceService.getOperation(operationId);
-            final Optional<OtpEntity> otpOptional = otpRepository.findFirstByOperationOrderByTimestampCreatedDesc(operation);
-            if (!otpOptional.isPresent()) {
-                throw new OtpNotFoundException("No OTP found for operation: " + operation.getOperationId());
-            }
-            otp = otpOptional.get();
+            otp = otpRepository.findFirstByOperationOrderByTimestampCreatedDesc(operation).orElseThrow(() ->
+                    new OtpNotFoundException("No OTP found for operation: " + operation.getOperationId()));
         } else {
             throw new InvalidRequestException("Missing otp ID or operation ID");
         }

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/RoleService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/RoleService.java
@@ -122,11 +122,8 @@ public class RoleService {
      */
     @Transactional
     public DeleteRoleResponse deleteRole(DeleteRoleRequest request) throws RoleNotFoundException, DeleteNotAllowedException {
-        final Optional<RoleEntity> roleOptional = roleRepository.findByName(request.getRoleName());
-        if (!roleOptional.isPresent()) {
-            throw new RoleNotFoundException("Role not found: " + request.getRoleName());
-        }
-        final RoleEntity role = roleOptional.get();
+        final RoleEntity role = roleRepository.findByName(request.getRoleName()).orElseThrow(() ->
+                new RoleNotFoundException("Role not found: " + request.getRoleName()));
         final long existingRoleCount = userRoleRepository.countByRole(role);
         if (existingRoleCount > 0) {
             throw new DeleteNotAllowedException("Role cannot be deleted because it is used: " + request.getRoleName());

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/StepDefinitionService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/StepDefinitionService.java
@@ -117,11 +117,8 @@ public class StepDefinitionService {
     @Transactional
     public DeleteStepDefinitionResponse deleteStepDefinition(DeleteStepDefinitionRequest request) throws StepDefinitionNotFoundException {
         final StepResolutionService stepResolutionService = serviceCatalogue.getStepResolutionService();
-        final Optional<StepDefinitionEntity> stepDefinitionOptional = stepDefinitionRepository.findById(request.getStepDefinitionId());
-        if (!stepDefinitionOptional.isPresent()) {
-            throw new StepDefinitionNotFoundException("Step definition not found, ID: " + request.getStepDefinitionId());
-        }
-        final StepDefinitionEntity stepDefinition = stepDefinitionOptional.get();
+        final StepDefinitionEntity stepDefinition = stepDefinitionRepository.findById(request.getStepDefinitionId()).orElseThrow(() ->
+                new StepDefinitionNotFoundException("Step definition not found, ID: " + request.getStepDefinitionId()));
         stepDefinitionRepository.delete(stepDefinition);
         logger.debug("Step definition was deleted, step definition ID: {}", stepDefinition.getStepDefinitionId());
         audit.info("Step definition was deleted", AuditDetail.builder()

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/StepResolutionService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/StepResolutionService.java
@@ -328,7 +328,7 @@ public class StepResolutionService {
      * @param stepDefinitions step definitions
      */
     private void sortSteps(List<StepDefinitionEntity> stepDefinitions) {
-        Collections.sort(stepDefinitions, Comparator.comparing(StepDefinitionEntity::getResponsePriority));
+        stepDefinitions.sort(Comparator.comparing(StepDefinitionEntity::getResponsePriority));
     }
 
     /**
@@ -383,11 +383,8 @@ public class StepResolutionService {
             }
         }
         // check whether authMethod supports check of authorization failure count
-        final Optional<AuthMethodEntity> authMethodEntityOptional = authMethodRepository.findByAuthMethod(authMethod);
-        if (!authMethodEntityOptional.isPresent()) {
-            throw new AuthMethodNotFoundException("Authentication method not found: " + authMethod);
-        }
-        final AuthMethodEntity authMethodEntity = authMethodEntityOptional.get();
+        final AuthMethodEntity authMethodEntity = authMethodRepository.findByAuthMethod(authMethod).orElseThrow(() ->
+                new AuthMethodNotFoundException("Authentication method not found: " + authMethod));
         if (authMethodEntity.getCheckAuthFails()) {
             // count failures
             int failureCount = 0;
@@ -420,7 +417,7 @@ public class StepResolutionService {
         final AuthMethod authMethod = currentOperationHistory.getRequestAuthMethod();
         // check whether authMethod supports check of authorization failure count
         final Optional<AuthMethodEntity> authMethodEntityOptional = authMethodRepository.findByAuthMethod(authMethod);
-        if (!authMethodEntityOptional.isPresent()) {
+        if (authMethodEntityOptional.isEmpty()) {
             return null;
         }
         // in case authentication method previously failed, it is already failed

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/UserAliasService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/UserAliasService.java
@@ -179,15 +179,13 @@ public class UserAliasService {
     public UpdateUserAliasResponse updateUserAlias(UpdateUserAliasRequest request) throws UserNotFoundException, InvalidRequestException, UserAliasNotFoundException {
         final UserIdentityLookupService userIdentityLookupService = serviceCatalogue.getUserIdentityLookupService();
         UserIdentityEntity user = userIdentityLookupService.findUser(request.getUserId());
-        final Optional<UserAliasEntity> aliasOptional = user.getAliases().stream().filter(alias -> alias.getName().equals(request.getAliasName())).findFirst();
-        final UserAliasEntity alias;
-        if (!aliasOptional.isPresent()) {
-            throw new UserAliasNotFoundException("User alias not found: " + request.getAliasName() + ", user ID: " + request.getUserId());
-        } else {
-            alias = aliasOptional.get();
-            if (alias.getStatus() == UserAliasStatus.REMOVED && request.getUserAliasStatus() != UserAliasStatus.ACTIVE) {
-                throw new UserAliasNotFoundException("User alias is REMOVED: " + request.getAliasName() + ", user ID: " + user.getUserId());
-            }
+        final UserAliasEntity alias = user.getAliases().stream()
+                .filter(it -> it.getName().equals(request.getAliasName()))
+                .findFirst()
+                .orElseThrow(() ->
+                        new UserAliasNotFoundException("User alias not found: " + request.getAliasName() + ", user ID: " + request.getUserId()));
+        if (alias.getStatus() == UserAliasStatus.REMOVED && request.getUserAliasStatus() != UserAliasStatus.ACTIVE) {
+            throw new UserAliasNotFoundException("User alias is REMOVED: " + request.getAliasName() + ", user ID: " + user.getUserId());
         }
         alias.setTimestampLastUpdated(new Date());
         alias.setValue(request.getAliasValue());
@@ -231,15 +229,13 @@ public class UserAliasService {
     public DeleteUserAliasResponse deleteUserAlias(DeleteUserAliasRequest request) throws UserNotFoundException, UserAliasNotFoundException {
         final UserIdentityLookupService userIdentityLookupService = serviceCatalogue.getUserIdentityLookupService();
         UserIdentityEntity user = userIdentityLookupService.findUser(request.getUserId());
-        final Optional<UserAliasEntity> aliasOptional = user.getAliases().stream().filter(alias -> alias.getName().equals(request.getAliasName())).findFirst();
-        final UserAliasEntity alias;
-        if (!aliasOptional.isPresent()) {
-            throw new UserAliasNotFoundException("User alias not found: " + request.getAliasName() + ", user ID: " + request.getUserId());
-        } else {
-            alias = aliasOptional.get();
-            if (alias.getStatus() == UserAliasStatus.REMOVED) {
-                throw new UserAliasNotFoundException("User alias is already REMOVED: " + request.getAliasName());
-            }
+        final UserAliasEntity alias = user.getAliases().stream()
+                .filter(it -> it.getName().equals(request.getAliasName()))
+                .findFirst()
+                .orElseThrow(() ->
+                        new UserAliasNotFoundException("User alias not found: " + request.getAliasName() + ", user ID: " + request.getUserId()));
+        if (alias.getStatus() == UserAliasStatus.REMOVED) {
+            throw new UserAliasNotFoundException("User alias is already REMOVED: " + request.getAliasName());
         }
         alias.setStatus(UserAliasStatus.REMOVED);
         alias.setTimestampLastUpdated(new Date());

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/UserContactService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/UserContactService.java
@@ -156,10 +156,10 @@ public class UserContactService {
         UserIdentityEntity user = userIdentityLookupService.findUser(request.getUserId());
         Set<UserContactEntity> contacts = user.getContacts();
         Optional<UserContactEntity> contactOptional = contacts.stream().filter(c -> c.getName().equals(request.getContactName()) && c.getType().equals(request.getContactType())).findFirst();
-        if (!contactOptional.isPresent()) {
+        if (contactOptional.isEmpty()) {
             throw new UserContactNotFoundException("User contact not found: " + request.getContactName() + ", user ID: " + user.getUserId() + ", type: " + request.getContactType());
         }
-        UserContactEntity contact = contactOptional.get();
+        final UserContactEntity contact = contactOptional.get();
         contact.setUser(user);
         contact.setName(request.getContactName());
         contact.setType(request.getContactType());
@@ -197,10 +197,10 @@ public class UserContactService {
         UserIdentityEntity user = userIdentityLookupService.findUser(request.getUserId());
         Set<UserContactEntity> contacts = user.getContacts();
         Optional<UserContactEntity> contactOptional = contacts.stream().filter(c -> c.getName().equals(request.getContactName()) && c.getType().equals(request.getContactType())).findFirst();
-        if (!contactOptional.isPresent()) {
+        if (contactOptional.isEmpty()) {
             throw new UserContactNotFoundException("No user contact found: " + request.getContactName() + ", user ID: " + user.getUserId() + ", type: " + request.getContactType());
         }
-        UserContactEntity contact = contactOptional.get();
+        final UserContactEntity contact = contactOptional.get();
         user.getContacts().remove(contact);
         user = userIdentityRepository.save(user);
         logger.debug("User contact was deleted, user ID: {}, contact name: {}", user.getUserId(), contact.getName());
@@ -228,7 +228,7 @@ public class UserContactService {
             List<UserContactEntity> contactListPrimary = contacts.stream()
                     .filter(c -> c.getType().equals(ct))
                     .filter(UserContactEntity::isPrimary)
-                    .collect(Collectors.toList());
+                    .toList();
             if (contactListPrimary.size() > 1) {
                 // Multiple primary contacts exists, find the newest one by created or last updated date
                 Date maxDate = new Date(0);

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/UserIdentityLookupService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/UserIdentityLookupService.java
@@ -99,21 +99,15 @@ public class UserIdentityLookupService {
         boolean dateFiltered = false;
 
         if (credentialName!= null) {
-            final Optional<CredentialDefinitionEntity> credentialDefinitionOptional = credentialDefinitionRepository.findByName(credentialName);
-            if (!credentialDefinitionOptional.isPresent()) {
-                throw new InvalidRequestException("Credential definition not found: " + credentialName);
-            }
-            credentialDefinition = credentialDefinitionOptional.get();
+            credentialDefinition = credentialDefinitionRepository.findByName(credentialName).orElseThrow(() ->
+                    new InvalidRequestException("Credential definition not found: " + credentialName));
         }
 
         // Choose main query based on most exact parameters, filter lookup results in code by additional parameters
         if (username != null && credentialName != null) {
             // When username and credentialName are present, lookup the user identity, single result or no result is found
-            final Optional<CredentialEntity> credentialOptional = credentialRepository.findByCredentialDefinitionAndUsername(credentialDefinition, username);
-            if (!credentialOptional.isPresent()) {
-                throw new UserNotFoundException("User not found, credential definition name: " + credentialName + ", username: " + username);
-            }
-            final CredentialEntity credential = credentialOptional.get();
+            final CredentialEntity credential = credentialRepository.findByCredentialDefinitionAndUsername(credentialDefinition, username).orElseThrow(() ->
+                    new UserNotFoundException("User not found, credential definition name: " + credentialName + ", username: " + username));
             if (credentialStatus == null || credential.getStatus() == credentialStatus) {
                 // Filter by credentialStatus in case it is also specified
                 UserIdentityEntity user = credential.getUser();
@@ -159,11 +153,11 @@ public class UserIdentityLookupService {
             // Filter by roles
             final List<UserIdentityEntity> filteredList = new ArrayList<>();
             for (UserIdentityEntity user: lookupResult) {
-                final List<UserRoleEntity> userRoles = user.getRoles().stream().filter(r -> r.getStatus() == UserRoleStatus.ACTIVE).collect(Collectors.toList());
+                final List<UserRoleEntity> userRoles = user.getRoles().stream().filter(r -> r.getStatus() == UserRoleStatus.ACTIVE).toList();
                 final List<String> roleNames = userRoles.stream()
                         .map(roleEntity -> roleEntity.getRole().getName())
-                        .collect(Collectors.toList());
-                if (roleNames.containsAll(roles)) {
+                        .toList();
+                if (new HashSet<>(roleNames).containsAll(roles)) {
                     filteredList.add(user);
                 }
             }
@@ -200,11 +194,8 @@ public class UserIdentityLookupService {
         CredentialDefinitionEntity credentialDefinition = null;
 
         if (credentialName!= null) {
-            final Optional<CredentialDefinitionEntity> credentialDefinitionOptional = credentialDefinitionRepository.findByName(credentialName);
-            if (!credentialDefinitionOptional.isPresent()) {
-                throw new InvalidRequestException("Credential definition not found: " + credentialName);
-            }
-            credentialDefinition = credentialDefinitionOptional.get();
+            credentialDefinition = credentialDefinitionRepository.findByName(credentialName).orElseThrow(() ->
+                    new InvalidRequestException("Credential definition not found: " + credentialName));
             if (credentialDefinition.isDataAdapterProxyEnabled()) {
                 // Lookup is performed using Data Adapter
                 if (operationId == null) {
@@ -232,11 +223,8 @@ public class UserIdentityLookupService {
         }
 
         // When username and credentialName are present, lookup the user identity, single result or no result is found
-        final Optional<CredentialEntity> credentialOptional = credentialRepository.findByCredentialDefinitionAndUsername(credentialDefinition, username);
-        if (!credentialOptional.isPresent()) {
-            throw new UserNotFoundException("User not found, credential definition name: " + credentialName + ", username: " + username);
-        }
-        final CredentialEntity credential = credentialOptional.get();
+        final CredentialEntity credential = credentialRepository.findByCredentialDefinitionAndUsername(credentialDefinition, username).orElseThrow(() ->
+                new UserNotFoundException("User not found, credential definition name: " + credentialName + ", username: " + username));
         if (credential.getStatus() == CredentialStatus.REMOVED) {
             throw new UserNotFoundException("User not found, credential definition name: " + credentialName + ", username: " + username);
         }
@@ -254,11 +242,8 @@ public class UserIdentityLookupService {
      * @throws UserNotFoundException Thrown when user identity entity is not found.
      */
     public UserIdentityEntity findUser(String userId) throws UserNotFoundException {
-        final Optional<UserIdentityEntity> userOptional = userIdentityRepository.findById(userId);
-        if (!userOptional.isPresent()) {
-            throw new UserNotFoundException("User identity not found: " + userId);
-        }
-        final UserIdentityEntity user = userOptional.get();
+        final UserIdentityEntity user = userIdentityRepository.findById(userId).orElseThrow(() ->
+                new UserNotFoundException("User identity not found: " + userId));
         if (user.getStatus() == UserIdentityStatus.REMOVED) {
             throw new UserNotFoundException("User identity is REMOVED: " + userId);
         }
@@ -273,11 +258,8 @@ public class UserIdentityLookupService {
      * @throws UserNotFoundException Thrown when user identity entity is not found.
      */
     public UserIdentityEntity findUser(String userId, boolean includeRemoved) throws UserNotFoundException {
-        final Optional<UserIdentityEntity> userOptional = userIdentityRepository.findById(userId);
-        if (!userOptional.isPresent()) {
-            throw new UserNotFoundException("User identity not found: " + userId);
-        }
-        final UserIdentityEntity user = userOptional.get();
+        final UserIdentityEntity user = userIdentityRepository.findById(userId).orElseThrow(() ->
+                new UserNotFoundException("User identity not found: " + userId));
         if (!includeRemoved &&  user.getStatus() == UserIdentityStatus.REMOVED) {
             throw new UserNotFoundException("User identity is REMOVED: " + userId);
         }
@@ -290,15 +272,8 @@ public class UserIdentityLookupService {
      * @return Optional user identity.
      */
     public Optional<UserIdentityEntity> findUserOptional(String userId) {
-        final Optional<UserIdentityEntity> userOptional = userIdentityRepository.findById(userId);
-        if (!userOptional.isPresent()) {
-            return Optional.empty();
-        }
-        final UserIdentityEntity user = userOptional.get();
-        if (user.getStatus() == UserIdentityStatus.REMOVED) {
-            return Optional.empty();
-        }
-        return Optional.of(user);
+        return userIdentityRepository.findById(userId)
+                .filter(user -> user.getStatus() != UserIdentityStatus.REMOVED);
     }
 
     /**
@@ -308,14 +283,7 @@ public class UserIdentityLookupService {
      * @return Optional user identity.
      */
     public Optional<UserIdentityEntity> findUserOptional(String userId, boolean includeRemoved) {
-        final Optional<UserIdentityEntity> userOptional = userIdentityRepository.findById(userId);
-        if (!userOptional.isPresent()) {
-            return Optional.empty();
-        }
-        final UserIdentityEntity user = userOptional.get();
-        if (!includeRemoved && user.getStatus() == UserIdentityStatus.REMOVED) {
-            return Optional.empty();
-        }
-        return Optional.of(user);
+        return userIdentityRepository.findById(userId)
+                .filter(user -> includeRemoved || user.getStatus() != UserIdentityStatus.REMOVED);
     }
 }

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/UserIdentityService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/UserIdentityService.java
@@ -233,12 +233,9 @@ public class UserIdentityService {
         final EndToEndEncryptionService endToEndEncryptionService = serviceCatalogue.getEndToEndEncryptionService();
         final CredentialService credentialService = serviceCatalogue.getCredentialService();
 
-        final Optional<UserIdentityEntity> userOptional = userIdentityRepository.findById(request.getUserId());
-        if (!userOptional.isPresent()) {
-            throw new UserNotFoundException("User identity not found: " + request.getUserId());
-        }
+        UserIdentityEntity user = userIdentityRepository.findById(request.getUserId()).orElseThrow(() ->
+                new UserNotFoundException("User identity not found: " + request.getUserId()));
         // The findUser() method is not used to allow update REMOVED -> ACTIVE
-        UserIdentityEntity user = userOptional.get();
         Map<String, RoleEntity> roleEntities = new HashMap<>();
         if (request.getRoles() != null) {
             roleEntities = collectRoleEntities(request.getRoles());
@@ -373,7 +370,7 @@ public class UserIdentityService {
                 throw new InvalidRequestException(ex);
             }
         }
-        final List<UserRoleEntity> userRoles = user.getRoles().stream().filter(r -> r.getStatus() == UserRoleStatus.ACTIVE).collect(Collectors.toList());
+        final List<UserRoleEntity> userRoles = user.getRoles().stream().filter(r -> r.getStatus() == UserRoleStatus.ACTIVE).toList();
         userRoles.forEach(userRole -> response.getRoles().add(userRole.getRole().getName()));
         final Set<UserContactEntity> userContacts = user.getContacts();
         for (UserContactEntity userContact: userContacts) {
@@ -559,11 +556,9 @@ public class UserIdentityService {
     private Map<String, RoleEntity> collectRoleEntities(List<String> roles) throws InvalidRequestException {
         final Map<String, RoleEntity> roleEntities = new HashMap<>();
         for (String roleName : roles) {
-            final Optional<RoleEntity> roleOptional = roleRepository.findByName(roleName);
-            if (!roleOptional.isPresent()) {
-                throw new InvalidRequestException("User role not found: " + roleName);
-            }
-            roleEntities.put(roleName, roleOptional.get());
+            final RoleEntity role = roleRepository.findByName(roleName).orElseThrow(() ->
+                    new InvalidRequestException("User role not found: " + roleName));
+            roleEntities.put(roleName, role);
         }
         return roleEntities;
     }
@@ -664,7 +659,7 @@ public class UserIdentityService {
         final List<String> credentialsToKeep = activeCredentials
                 .stream()
                 .map(CredentialSecretDetail::getCredentialName)
-                .collect(Collectors.toList());
+                .toList();
         existingCredentials.forEach(credential -> {
             if (!credentialsToKeep.contains(credential.getCredentialDefinition().getName())
                     && credential.getStatus() != CredentialStatus.REMOVED) {

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/UserRoleService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/UserRoleService.java
@@ -89,11 +89,8 @@ public class UserRoleService {
         final UserIdentityService userIdentityService = serviceCatalogue.getUserIdentityService();
 
         UserIdentityEntity user = userIdentityLookupService.findUser(request.getUserId());
-        final Optional<RoleEntity> roleOptional = roleRepository.findByName(request.getRoleName());
-        if (!roleOptional.isPresent()) {
-            throw new InvalidRequestException("Role not found: " + request.getRoleName());
-        }
-        final RoleEntity role = roleOptional.get();
+        final RoleEntity role = roleRepository.findByName(request.getRoleName()).orElseThrow(() ->
+                new InvalidRequestException("Role not found: " + request.getRoleName()));
         final Optional<UserRoleEntity> userRoleOptional = user.getRoles().stream().filter(r -> r.getRole().equals(role)).findFirst();
         final UserRoleEntity userRole;
         if (userRoleOptional.isPresent()) {
@@ -140,11 +137,8 @@ public class UserRoleService {
         final UserIdentityService userIdentityService = serviceCatalogue.getUserIdentityService();
 
         UserIdentityEntity user = userIdentityLookupService.findUser(request.getUserId());
-        final Optional<RoleEntity> roleOptional = roleRepository.findByName(request.getRoleName());
-        if (!roleOptional.isPresent()) {
-            throw new InvalidRequestException("Role not found: " + request.getRoleName());
-        }
-        final RoleEntity role = roleOptional.get();
+        final RoleEntity role = roleRepository.findByName(request.getRoleName()).orElseThrow(() ->
+                new InvalidRequestException("Role not found: " + request.getRoleName()));
         final Optional<UserRoleEntity> userRoleOptional = user.getRoles().stream().filter(r -> r.getRole().equals(role)).findFirst();
         final UserRoleEntity userRole;
         if (userRoleOptional.isPresent()) {

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/adapter/OperationCustomizationService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/adapter/OperationCustomizationService.java
@@ -77,19 +77,18 @@ public class OperationCustomizationService {
         final OperationContext operationContext = operationConverter.toOperationContext(operation);
         final OperationChange operationChange;
         switch (operationDetail.getResult()) {
-            case DONE:
-                operationChange = OperationChange.DONE;
-                break;
-            case FAILED:
+            case DONE -> operationChange = OperationChange.DONE;
+            case FAILED -> {
                 if (operation.getCurrentOperationHistoryEntity() != null && operation.getCurrentOperationHistoryEntity().getRequestAuthStepResult() == AuthStepResult.CANCELED) {
                     operationChange = OperationChange.CANCELED;
                     break;
                 }
                 operationChange = OperationChange.FAILED;
-                break;
-            default:
+            }
+            default -> {
                 // Notification is not sent when authResult is CONTINUE
                 return;
+            }
         }
         List<OperationHistoryEntity> operationHistory = new ArrayList<>(operation.getOperationHistory());
         Collections.reverse(operationHistory);

--- a/powerauth-tpp-engine-client/src/main/java/io/getlime/security/powerauth/lib/tpp/engine/client/TppEngineClient.java
+++ b/powerauth-tpp-engine-client/src/main/java/io/getlime/security/powerauth/lib/tpp/engine/client/TppEngineClient.java
@@ -190,7 +190,7 @@ public class TppEngineClient {
     public ObjectResponse<List<TppAppDetailResponse>> fetchApplicationList(String tppLicense) throws TppEngineClientException {
         final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.put("tppLicense", Collections.singletonList(tppLicense));
-        return getImpl("/tpp/app/list", params, new ParameterizedTypeReference<ObjectResponse<List<TppAppDetailResponse>>>(){});
+        return getImpl("/tpp/app/list", params, new ParameterizedTypeReference<>(){});
     }
 
     /**
@@ -405,7 +405,7 @@ public class TppEngineClient {
         if (e.getErrorResponse() == null || e.getErrorResponse().getResponseObject() == null) {
             logger.trace("Wultra Java Core lib did not parse ErrorResponse for {}", e.getResponse());
             try {
-                final ObjectResponse<TppEngineError> errorResponse = new ObjectMapper().readValue(e.getResponse(), new TypeReference<ObjectResponse<TppEngineError>>(){});
+                final ObjectResponse<TppEngineError> errorResponse = new ObjectMapper().readValue(e.getResponse(), new TypeReference<>(){});
                 if (errorResponse != null && errorResponse.getResponseObject() != null) {
                     return errorResponse.getResponseObject();
                 }

--- a/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/certificate/CertInfo.java
+++ b/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/certificate/CertInfo.java
@@ -19,7 +19,6 @@
 package io.getlime.security.powerauth.app.tppengine.model.certificate;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -28,7 +27,8 @@ import java.util.Set;
  *
  * @author Petr Dvorak, petr@wultra.com
  */
-public class CertInfo {
+public record CertInfo(String serialNumber, String commonName, String psd2License, String organization, String street, String city,
+                       String zipCode, String region, String country, String website, Set<PSD2> psd2Mandates) {
 
     public enum PSD2 {
         /**
@@ -47,7 +47,7 @@ public class CertInfo {
         PSP_IC,
 
         /**
-         *  Payment Initiation Service Provider
+         * Payment Initiation Service Provider
          */
         PSP_PI
     }
@@ -56,76 +56,6 @@ public class CertInfo {
      * Location of the forwarded certificate in HTTP header.
      */
     public static final String HTTP_HEADER = "X-Client-Certificate";
-
-    private String serialNumber;
-    private String commonName;
-    private String psd2License;
-    private String organization;
-    private String street;
-    private String city;
-    private String zipCode;
-    private String region;
-    private String country;
-    private String website;
-    private Set<PSD2> psd2Mandates;
-
-    public CertInfo(String serialNumber, String commonName, String psd2License, String organization, String street, String city, String zipCode, String region, String country, String website, Set<PSD2> psd2Mandates) {
-        this.serialNumber = serialNumber;
-        this.commonName = commonName;
-        this.psd2License = psd2License;
-        this.organization = organization;
-        this.street = street;
-        this.city = city;
-        this.zipCode = zipCode;
-        this.region = region;
-        this.country = country;
-        this.website = website;
-        this.psd2Mandates = new HashSet<>(psd2Mandates);
-    }
-
-    public String getSerialNumber() {
-        return serialNumber;
-    }
-
-    public String getCommonName() {
-        return commonName;
-    }
-
-    public String getPsd2License() {
-        return psd2License;
-    }
-
-    public String getOrganization() {
-        return organization;
-    }
-
-    public String getStreet() {
-        return street;
-    }
-
-    public String getCity() {
-        return city;
-    }
-
-    public String getZipCode() {
-        return zipCode;
-    }
-
-    public String getRegion() {
-        return region;
-    }
-
-    public String getCountry() {
-        return country;
-    }
-
-    public String getWebsite() {
-        return website;
-    }
-
-    public Set<PSD2> getPsd2Mandates() {
-        return psd2Mandates;
-    }
 
     /**
      * Checks if the certificate info contains a correct PSD2 license information.

--- a/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/certificate/ICACertificateParser.java
+++ b/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/certificate/ICACertificateParser.java
@@ -33,7 +33,6 @@ import org.bouncycastle.openssl.PEMParser;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateException;
@@ -70,11 +69,7 @@ public class ICACertificateParser implements ICertificateParser {
 
         // Handle the URL encoded certificates
         if (certificatePem.startsWith("-----BEGIN%20CERTIFICATE-----")) { // certificate is URL encoded by nginx.
-            try {
-                certificatePem = URLDecoder.decode(certificatePem, StandardCharsets.UTF_8.toString());
-            } catch (UnsupportedEncodingException e) {
-                throw new CertificateException("Unable to extract certificate in PEM format (nginx).");
-            }
+            certificatePem = URLDecoder.decode(certificatePem, StandardCharsets.UTF_8);
         }
 
         // Replace spaces in Apache forwarded certificate by newlines correctly
@@ -108,8 +103,7 @@ public class ICACertificateParser implements ICertificateParser {
             Set<CertInfo.PSD2> psd2Mandates = new HashSet<>();
 
             for (ASN1Encodable asn1Primitive : it) {
-                if (asn1Primitive instanceof DLSequence) {
-                    DLSequence sequence = (DLSequence) asn1Primitive;
+                if (asn1Primitive instanceof final DLSequence sequence) {
                     if (sequence.size() == 2) {
                         ASN1ObjectIdentifier id = (ASN1ObjectIdentifier) sequence.getObjectAt(0);
                         DLSequence mandates = (DLSequence) sequence.getObjectAt(1);
@@ -138,7 +132,7 @@ public class ICACertificateParser implements ICertificateParser {
                     }
                 }
             }
-            final X500Name x500Name = new X500Name(cert.getSubjectDN().toString());
+            final X500Name x500Name = new X500Name(cert.getSubjectX500Principal().toString());
             String country = null;
             String serialNumber = null;
             String commonName = null;
@@ -155,42 +149,33 @@ public class ICACertificateParser implements ICertificateParser {
                 final String val = attr.getValue().toString();
 
                 switch (oid) {
-                    case "2.5.4.6": {   //    C=CZ => 2.5.4.6
+                    case "2.5.4.6" -> {   //    C=CZ => 2.5.4.6
                         country = val;
-                        break;
                     }
-                    case "2.5.4.3": {   //    CN=cnb.cz => 2.5.4.3
+                    case "2.5.4.3" -> {   //    CN=cnb.cz => 2.5.4.3
                         commonName = val;
                         website = "https://" + val;
-                        break;
                     }
-                    case "2.5.4.10": {  //    O=ČESKÁ NÁRODNÍ BANKA => 2.5.4.10
+                    case "2.5.4.10" -> {  //    O=ČESKÁ NÁRODNÍ BANKA => 2.5.4.10
                         organization = val;
-                        break;
                     }
-                    case "2.5.4.9": {   //    STREET=Na příkopě 864/28 => 2.5.4.9
+                    case "2.5.4.9" -> {   //    STREET=Na příkopě 864/28 => 2.5.4.9
                         street = val;
-                        break;
                     }
-                    case "2.5.4.7": {   //    L=Praha 1 => 2.5.4.7
+                    case "2.5.4.7" -> {   //    L=Praha 1 => 2.5.4.7
                         city = val;
-                        break;
                     }
-                    case "2.5.4.17": {  //    OID.2.5.4.17=11000 => 2.5.4.17
+                    case "2.5.4.17" -> {  //    OID.2.5.4.17=11000 => 2.5.4.17
                         zipCode = val;
-                        break;
                     }
-                    case "2.5.4.5": {   //    SERIALNUMBER=48136450 => 2.5.4.5
+                    case "2.5.4.5" -> {   //    SERIALNUMBER=48136450 => 2.5.4.5
                         serialNumber = val;
-                        break;
                     }
-                    case "2.5.4.8": {   //    ST=Hlavní město Praha => 2.5.4.8
+                    case "2.5.4.8" -> {   //    ST=Hlavní město Praha => 2.5.4.8
                         region = val;
-                        break;
                     }
-                    case "2.5.4.97": {  //   OID.2.5.4.97=PSDCZ-CNB-48136450 => 2.5.4.97
+                    case "2.5.4.97" -> {  //   OID.2.5.4.97=PSDCZ-CNB-48136450 => 2.5.4.97
                         psd2License = val;
-                        break;
                     }
                 }
             }

--- a/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/entity/TppEngineError.java
+++ b/powerauth-tpp-engine-model/src/main/java/io/getlime/security/powerauth/app/tppengine/model/entity/TppEngineError.java
@@ -33,7 +33,7 @@ public class TppEngineError extends Error {
     /**
      * Response codes for different authentication failures.
      */
-    public class Code extends Error.Code {
+    public static class Code extends Error.Code {
         public static final String REMOTE_ERROR = "REMOTE_ERROR";
         public static final String TPP_ENGINE_CLIENT_ERROR = "TPP_ENGINE_CLIENT_ERROR";
         public static final String COMMUNICATION_ERROR = "COMMUNICATION_ERROR";

--- a/powerauth-tpp-engine-model/src/test/java/io/getlime/security/powerauth/app/tppengine/model/certificate/ICACertificateParserTest.java
+++ b/powerauth-tpp-engine-model/src/test/java/io/getlime/security/powerauth/app/tppengine/model/certificate/ICACertificateParserTest.java
@@ -31,69 +31,70 @@ import java.util.Set;
 class ICACertificateParserTest {
 
     @Test
-    public void testCertificateParser() throws CertificateException {
+    void testCertificateParser() throws CertificateException {
 
-        final String certificate = "-----BEGIN CERTIFICATE-----\n" +
-                "MIIIJjCCBg6gAwIBAgIJA7fTH4NdPar6MA0GCSqGSIb3DQEBCwUAMH8xCzAJBgNV\n" +
-                "BAYTAkNaMSgwJgYDVQQDDB9JLkNBIFRFU1QgU1NMIEVWIENBL1JTQSAxMC8yMDE3\n" +
-                "MS0wKwYDVQQKDCRQcnZuw60gY2VydGlmaWthxI1uw60gYXV0b3JpdGEsIGEucy4x\n" +
-                "FzAVBgNVBGEMDk5UUkNaLTI2NDM5Mzk1MB4XDTE5MTIwMjEwNDgwMVoXDTIwMTIw\n" +
-                "MTEwNDgwMVowggEEMQswCQYDVQQGEwJDWjEPMA0GA1UEAwwGY25iLmN6MSAwHgYD\n" +
-                "VQQKDBfEjEVTS8OBIE7DgVJPRE7DjSBCQU5LQTEdMBsGA1UECQwUTmEgcMWZw61r\n" +
-                "b3DEmyA4NjQvMjgxEDAOBgNVBAcMB1ByYWhhIDExDjAMBgNVBBEMBTExMDAwMREw\n" +
-                "DwYDVQQFEwg0ODEzNjQ1MDEdMBsGA1UEDwwUUHJpdmF0ZSBPcmdhbml6YXRpb24x\n" +
-                "EzARBgsrBgEEAYI3PAIBAxMCQ1oxHTAbBgNVBAgMFEhsYXZuw60gbcSbc3RvIFBy\n" +
-                "YWhhMRswGQYDVQRhDBJQU0RDWi1DTkItNDgxMzY0NTAwggEiMA0GCSqGSIb3DQEB\n" +
-                "AQUAA4IBDwAwggEKAoIBAQC5A6VAB2sORt9dLxc2w86vINN+3N/vq9F9LGHn7xC4\n" +
-                "4apnCRdGqeRFvdDZBZPKfYOpw1cvfk3YTAtEeh2MbGQCgdTqrl0LKBILEPKi60lT\n" +
-                "rcEFtIBFxC34NhuHeUDifU9pul3y1SIGq1kYgU3zeF0IJBOEfJ5Ez9kIQ/pbjx+h\n" +
-                "41VMQh0esqKu9hEMQr5QOJlUP1uILX76pMfyKgyGHlP4Dy587yMI/dSp7E2S97+n\n" +
-                "1/D/zW/3fB3fC2x4NYJx8ufrwhCG/etvWk917iclR39f5GU9mu8a5pBDgGwxuNCW\n" +
-                "QLnB9aDIuqOK7miQtzeXlIKR4VcwWLCrkHyrjy2KtzPhAgMBAAGjggMcMIIDGDAR\n" +
-                "BgNVHREECjAIggZjbmIuY3owCQYDVR0TBAIwADCB5gYDVR0gBIHeMIHbMIHNBg0r\n" +
-                "BgEEAYG4SAoDKAEBMIG7MB0GCCsGAQUFBwIBFhFodHRwOi8vd3d3LmljYS5jejCB\n" +
-                "mQYIKwYBBQUHAgIwgYwagYlUZW50byBURVNUIGNlcnRpZmlrYXQgYnlsIHZ5ZGFu\n" +
-                "IHYgc291bGFkdSBzIG5hcml6ZW5pbSBFVSBjLiBubm4vUlJSVC5UaGlzIGlzIGEg\n" +
-                "VEVTVCBjZXJ0aWZpY2F0ZSBhY2NvcmRpbmcgdG8gUmVndWxhdGlvbiAoRVUpIE5v\n" +
-                "IG5ubi9SUlJSLjAJBgcEAIvsQAEEMDMGA1UdHwQsMCowKKAmoCSGImh0dHA6Ly90\n" +
-                "ZXN0cS5pY2EuY3ovdHFjdzE3X3JzYS5jcmwwagYIKwYBBQUHAQEEXjBcMC4GCCsG\n" +
-                "AQUFBzAChiJodHRwOi8vdGVzdHEuaWNhLmN6L3RxY3cxN19yc2EuY2VyMCoGCCsG\n" +
-                "AQUFBzABhh5odHRwOi8vdG9jc3AuaWNhLmN6L3RxY3cxN19yc2EwDgYDVR0PAQH/\n" +
-                "BAQDAgWgMIH+BggrBgEFBQcBAwSB8TCB7jAIBgYEAI5GAQEwEwYGBACORgEGMAkG\n" +
-                "BwQAjkYBBgMwVgYGBACORgEFMEwwJBYeaHR0cDovL3Rlc3RxLmljYS5jei9wZHNf\n" +
-                "Y3MucGRmEwJjczAkFh5odHRwOi8vdGVzdHEuaWNhLmN6L3Bkc19lbi5wZGYTAmVu\n" +
-                "MHUGBgQAgZgnAjBrMEwwEQYHBACBmCcBAQwGUFNQX0FTMBEGBwQAgZgnAQIMBlBT\n" +
-                "UF9QSTARBgcEAIGYJwEDDAZQU1BfQUkwEQYHBACBmCcBBAwGUFNQX0lDDBNDemVj\n" +
-                "aCBOYXRpb25hbCBCYW5rDAZDWi1DTkIwHwYDVR0jBBgwFoAUOv/ngSfM0sonGeca\n" +
-                "odAaO8awn6owHQYDVR0OBBYEFIe6wOqAu0xteqo19vBNC1OjVvHnMB0GA1UdJQQW\n" +
-                "MBQGCCsGAQUFBwMBBggrBgEFBQcDAjANBgkqhkiG9w0BAQsFAAOCAgEAfA3xRbrm\n" +
-                "61of+TQUMxpkYSLgfTUKzZ6bJqc6ir1r4NPb4WNrAZkJSaJnIFSvej4m6z0Nit0o\n" +
-                "eHeGxJDQEwWCaQFa3E9lJS/33oZQQGn0iMsgN8rj70FXbGGRE1ZcvyhhioKEmA7f\n" +
-                "AbbkRlgxigrRp3cY12M7m3SfuD0Rr9fAJ30vvi1UuUBiJCUIznjbWezF2gNyd1KX\n" +
-                "hroKcoqMxl5260m5DSAWwoUvwc7MxjlHyCEx28RXv2/lWij2P9hnyN8WdjnO1Py9\n" +
-                "1RrJEJg9BJmfEdOfzVvtCjqAME77EqLB8wysktDe0T6BE7Ef96j/QKEFLId2kVtv\n" +
-                "U9iJ6xaZwyo5Jh68cC0/tZGMJ4cTx3OES4VttRNzIcneZ8y+gtoPs4X5Ob/uqc5s\n" +
-                "QrFMf+AclRFimNdAz0DN6Kv3kUS8kZtKn+XN7+Y1gkMHmbT6WSgfWB6BQUbbxG+a\n" +
-                "Wj3TY+MPQ/SuAJ42hv7iiWUwapcXTyI560n5KFKKiyXHtgu+jipCAR74VBIf4or9\n" +
-                "fO3E0tLGMlFvwLe2vfiAnBuiAZ1baM9a2vQWBcB/7SahqrBtKGpwGkJg6TAkYVIN\n" +
-                "EruSUWJnKZlRB/wtGJ6Z/b8DI+18RGmpy4YlF9ujYTiice2GyVXD2HndNBVhqq2o\n" +
-                "QYANhYtS0EAXe5o3NF2ZxkQ2fiABEPO7/RU=\n" +
-                "-----END CERTIFICATE-----";
+        final String certificate = """
+                -----BEGIN CERTIFICATE-----
+                MIIIJjCCBg6gAwIBAgIJA7fTH4NdPar6MA0GCSqGSIb3DQEBCwUAMH8xCzAJBgNV
+                BAYTAkNaMSgwJgYDVQQDDB9JLkNBIFRFU1QgU1NMIEVWIENBL1JTQSAxMC8yMDE3
+                MS0wKwYDVQQKDCRQcnZuw60gY2VydGlmaWthxI1uw60gYXV0b3JpdGEsIGEucy4x
+                FzAVBgNVBGEMDk5UUkNaLTI2NDM5Mzk1MB4XDTE5MTIwMjEwNDgwMVoXDTIwMTIw
+                MTEwNDgwMVowggEEMQswCQYDVQQGEwJDWjEPMA0GA1UEAwwGY25iLmN6MSAwHgYD
+                VQQKDBfEjEVTS8OBIE7DgVJPRE7DjSBCQU5LQTEdMBsGA1UECQwUTmEgcMWZw61r
+                b3DEmyA4NjQvMjgxEDAOBgNVBAcMB1ByYWhhIDExDjAMBgNVBBEMBTExMDAwMREw
+                DwYDVQQFEwg0ODEzNjQ1MDEdMBsGA1UEDwwUUHJpdmF0ZSBPcmdhbml6YXRpb24x
+                EzARBgsrBgEEAYI3PAIBAxMCQ1oxHTAbBgNVBAgMFEhsYXZuw60gbcSbc3RvIFBy
+                YWhhMRswGQYDVQRhDBJQU0RDWi1DTkItNDgxMzY0NTAwggEiMA0GCSqGSIb3DQEB
+                AQUAA4IBDwAwggEKAoIBAQC5A6VAB2sORt9dLxc2w86vINN+3N/vq9F9LGHn7xC4
+                4apnCRdGqeRFvdDZBZPKfYOpw1cvfk3YTAtEeh2MbGQCgdTqrl0LKBILEPKi60lT
+                rcEFtIBFxC34NhuHeUDifU9pul3y1SIGq1kYgU3zeF0IJBOEfJ5Ez9kIQ/pbjx+h
+                41VMQh0esqKu9hEMQr5QOJlUP1uILX76pMfyKgyGHlP4Dy587yMI/dSp7E2S97+n
+                1/D/zW/3fB3fC2x4NYJx8ufrwhCG/etvWk917iclR39f5GU9mu8a5pBDgGwxuNCW
+                QLnB9aDIuqOK7miQtzeXlIKR4VcwWLCrkHyrjy2KtzPhAgMBAAGjggMcMIIDGDAR
+                BgNVHREECjAIggZjbmIuY3owCQYDVR0TBAIwADCB5gYDVR0gBIHeMIHbMIHNBg0r
+                BgEEAYG4SAoDKAEBMIG7MB0GCCsGAQUFBwIBFhFodHRwOi8vd3d3LmljYS5jejCB
+                mQYIKwYBBQUHAgIwgYwagYlUZW50byBURVNUIGNlcnRpZmlrYXQgYnlsIHZ5ZGFu
+                IHYgc291bGFkdSBzIG5hcml6ZW5pbSBFVSBjLiBubm4vUlJSVC5UaGlzIGlzIGEg
+                VEVTVCBjZXJ0aWZpY2F0ZSBhY2NvcmRpbmcgdG8gUmVndWxhdGlvbiAoRVUpIE5v
+                IG5ubi9SUlJSLjAJBgcEAIvsQAEEMDMGA1UdHwQsMCowKKAmoCSGImh0dHA6Ly90
+                ZXN0cS5pY2EuY3ovdHFjdzE3X3JzYS5jcmwwagYIKwYBBQUHAQEEXjBcMC4GCCsG
+                AQUFBzAChiJodHRwOi8vdGVzdHEuaWNhLmN6L3RxY3cxN19yc2EuY2VyMCoGCCsG
+                AQUFBzABhh5odHRwOi8vdG9jc3AuaWNhLmN6L3RxY3cxN19yc2EwDgYDVR0PAQH/
+                BAQDAgWgMIH+BggrBgEFBQcBAwSB8TCB7jAIBgYEAI5GAQEwEwYGBACORgEGMAkG
+                BwQAjkYBBgMwVgYGBACORgEFMEwwJBYeaHR0cDovL3Rlc3RxLmljYS5jei9wZHNf
+                Y3MucGRmEwJjczAkFh5odHRwOi8vdGVzdHEuaWNhLmN6L3Bkc19lbi5wZGYTAmVu
+                MHUGBgQAgZgnAjBrMEwwEQYHBACBmCcBAQwGUFNQX0FTMBEGBwQAgZgnAQIMBlBT
+                UF9QSTARBgcEAIGYJwEDDAZQU1BfQUkwEQYHBACBmCcBBAwGUFNQX0lDDBNDemVj
+                aCBOYXRpb25hbCBCYW5rDAZDWi1DTkIwHwYDVR0jBBgwFoAUOv/ngSfM0sonGeca
+                odAaO8awn6owHQYDVR0OBBYEFIe6wOqAu0xteqo19vBNC1OjVvHnMB0GA1UdJQQW
+                MBQGCCsGAQUFBwMBBggrBgEFBQcDAjANBgkqhkiG9w0BAQsFAAOCAgEAfA3xRbrm
+                61of+TQUMxpkYSLgfTUKzZ6bJqc6ir1r4NPb4WNrAZkJSaJnIFSvej4m6z0Nit0o
+                eHeGxJDQEwWCaQFa3E9lJS/33oZQQGn0iMsgN8rj70FXbGGRE1ZcvyhhioKEmA7f
+                AbbkRlgxigrRp3cY12M7m3SfuD0Rr9fAJ30vvi1UuUBiJCUIznjbWezF2gNyd1KX
+                hroKcoqMxl5260m5DSAWwoUvwc7MxjlHyCEx28RXv2/lWij2P9hnyN8WdjnO1Py9
+                1RrJEJg9BJmfEdOfzVvtCjqAME77EqLB8wysktDe0T6BE7Ef96j/QKEFLId2kVtv
+                U9iJ6xaZwyo5Jh68cC0/tZGMJ4cTx3OES4VttRNzIcneZ8y+gtoPs4X5Ob/uqc5s
+                QrFMf+AclRFimNdAz0DN6Kv3kUS8kZtKn+XN7+Y1gkMHmbT6WSgfWB6BQUbbxG+a
+                Wj3TY+MPQ/SuAJ42hv7iiWUwapcXTyI560n5KFKKiyXHtgu+jipCAR74VBIf4or9
+                fO3E0tLGMlFvwLe2vfiAnBuiAZ1baM9a2vQWBcB/7SahqrBtKGpwGkJg6TAkYVIN
+                EruSUWJnKZlRB/wtGJ6Z/b8DI+18RGmpy4YlF9ujYTiice2GyVXD2HndNBVhqq2o
+                QYANhYtS0EAXe5o3NF2ZxkQ2fiABEPO7/RU=
+                -----END CERTIFICATE-----""";
 
         ICACertificateParser parser = new ICACertificateParser();
         final CertInfo parse = parser.parse(certificate);
 
         // Check basic certificate info
-        Assertions.assertEquals("48136450", parse.getSerialNumber());
-        Assertions.assertEquals("cnb.cz", parse.getCommonName());
-        Assertions.assertEquals("PSDCZ-CNB-48136450", parse.getPsd2License());
-        Assertions.assertEquals("ČESKÁ NÁRODNÍ BANKA", parse.getOrganization());
-        Assertions.assertEquals("Na příkopě 864/28", parse.getStreet());
-        Assertions.assertEquals("Praha 1", parse.getCity());
-        Assertions.assertEquals("Hlavní město Praha", parse.getRegion());
-        Assertions.assertEquals("11000", parse.getZipCode());
-        Assertions.assertEquals("CZ", parse.getCountry());
-        Assertions.assertEquals("https://cnb.cz", parse.getWebsite());
+        Assertions.assertEquals("48136450", parse.serialNumber());
+        Assertions.assertEquals("cnb.cz", parse.commonName());
+        Assertions.assertEquals("PSDCZ-CNB-48136450", parse.psd2License());
+        Assertions.assertEquals("ČESKÁ NÁRODNÍ BANKA", parse.organization());
+        Assertions.assertEquals("Na příkopě 864/28", parse.street());
+        Assertions.assertEquals("Praha 1", parse.city());
+        Assertions.assertEquals("Hlavní město Praha", parse.region());
+        Assertions.assertEquals("11000", parse.zipCode());
+        Assertions.assertEquals("CZ", parse.country());
+        Assertions.assertEquals("https://cnb.cz", parse.website());
         Assertions.assertEquals("Na příkopě 864/28\nPraha 1\n11000\nHlavní město Praha\nCZ", parse.getAddressUnstructured());
 
         Set<CertInfo.PSD2> expected = new HashSet<>();
@@ -101,7 +102,7 @@ class ICACertificateParserTest {
         expected.add(CertInfo.PSD2.PSP_AI);
         expected.add(CertInfo.PSD2.PSP_IC);
         expected.add(CertInfo.PSD2.PSP_PI);
-        Assertions.assertEquals(expected, parse.getPsd2Mandates());
+        Assertions.assertEquals(expected, parse.psd2Mandates());
 
     }
 

--- a/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/errorhandling/exception/UnableToCreateAppException.java
+++ b/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/errorhandling/exception/UnableToCreateAppException.java
@@ -26,7 +26,7 @@ import java.util.List;
  */
 public class UnableToCreateAppException extends Exception {
 
-    private List<String> errors;
+    private final List<String> errors;
 
     public UnableToCreateAppException(List<String> errors) {
         this.errors = new ArrayList<>(errors);

--- a/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/repository/model/entity/ConsentEntity.java
+++ b/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/repository/model/entity/ConsentEntity.java
@@ -23,6 +23,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /**
@@ -34,6 +35,7 @@ import java.io.Serializable;
 @Table(name = "tpp_consent")
 public class ConsentEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = -3031091688188605604L;
 
     @Id

--- a/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/repository/model/entity/TppAppDetailEntity.java
+++ b/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/repository/model/entity/TppAppDetailEntity.java
@@ -20,6 +20,7 @@ package io.getlime.security.powerauth.app.tppengine.repository.model.entity;
 
 import jakarta.persistence.*;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -35,6 +36,7 @@ import java.util.Objects;
 @Table(name = "tpp_app_detail")
 public class TppAppDetailEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 4100688209055833070L;
 
     @EmbeddedId
@@ -103,6 +105,7 @@ public class TppAppDetailEntity implements Serializable {
     @Embeddable
     public static class TppAppDetailKey implements Serializable {
 
+        @Serial
         private static final long serialVersionUID = -527239721500406289L;
 
         @Column(name = "app_client_id", nullable = false)
@@ -138,8 +141,7 @@ public class TppAppDetailEntity implements Serializable {
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (!(o instanceof TppAppDetailKey)) return false;
-            TppAppDetailKey that = (TppAppDetailKey) o;
+            if (!(o instanceof final TppAppDetailKey that)) return false;
             return Objects.equals(appClientId, that.appClientId) && Objects.equals(tppId, that.tppId);
         }
 

--- a/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/repository/model/entity/TppEntity.java
+++ b/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/repository/model/entity/TppEntity.java
@@ -20,6 +20,7 @@ package io.getlime.security.powerauth.app.tppengine.repository.model.entity;
 
 import jakarta.persistence.*;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.List;
 
@@ -32,6 +33,7 @@ import java.util.List;
 @Table(name = "tpp_detail")
 public class TppEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = -7089801604663605351L;
 
     @Id

--- a/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/repository/model/entity/UserConsentEntity.java
+++ b/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/repository/model/entity/UserConsentEntity.java
@@ -20,6 +20,7 @@ package io.getlime.security.powerauth.app.tppengine.repository.model.entity;
 
 import jakarta.persistence.*;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -32,6 +33,7 @@ import java.util.Date;
 @Table(name = "tpp_user_consent")
 public class UserConsentEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 4873304514084189625L;
 
     @Id

--- a/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/repository/model/entity/UserConsentHistoryEntity.java
+++ b/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/repository/model/entity/UserConsentHistoryEntity.java
@@ -21,6 +21,7 @@ package io.getlime.security.powerauth.app.tppengine.repository.model.entity;
 import io.getlime.security.powerauth.app.tppengine.model.enumeration.ConsentChange;
 import jakarta.persistence.*;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -34,6 +35,7 @@ import java.util.Date;
 @Table(name = "tpp_user_consent_history")
 public class UserConsentHistoryEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 6697728608700209704L;
 
     @Id

--- a/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/service/UserConsentService.java
+++ b/powerauth-tpp-engine/src/main/java/io/getlime/security/powerauth/app/tppengine/service/UserConsentService.java
@@ -107,11 +107,8 @@ public class UserConsentService {
     public UserConsentDetailResponse consentStatus(String userId, String consentId, String clientId) throws ConsentNotFoundException {
 
         // Check if a consent with given consent ID exists
-        final Optional<ConsentEntity> consentOptional = consentRepository.findFirstById(consentId);
-        if (!consentOptional.isPresent()) {
-            throw new ConsentNotFoundException(consentId);
-        }
-        final ConsentEntity consent = consentOptional.get();
+        final ConsentEntity consent = consentRepository.findFirstById(consentId).orElseThrow(() ->
+                new ConsentNotFoundException(consentId));
 
         final Optional<UserConsentEntity> consentStatusOptional = userConsentRepository.findConsentStatus(userId, consentId, clientId);
         if (consentStatusOptional.isPresent()) {
@@ -154,11 +151,8 @@ public class UserConsentService {
     public GiveConsentResponse giveConsent(GiveConsentRequest ro) throws ConsentNotFoundException {
 
         // Check if a consent with given consent exists
-        final Optional<ConsentEntity> consentOptional = consentRepository.findFirstById(ro.getConsentId());
-        if (!consentOptional.isPresent()) {
-            throw new ConsentNotFoundException(ro.getConsentId());
-        }
-        final ConsentEntity consent = consentOptional.get();
+        final ConsentEntity consent = consentRepository.findFirstById(ro.getConsentId()).orElseThrow(() ->
+                new ConsentNotFoundException(ro.getConsentId()));
 
         // Find if a user already gave this consent, so that it can be updated on save
         final Optional<UserConsentEntity> consentStatusOptional = userConsentRepository.findConsentStatus(ro.getUserId(), ro.getConsentId(), ro.getClientId());
@@ -219,7 +213,7 @@ public class UserConsentService {
 
         // Check if a consent with given consent exists
         final Optional<ConsentEntity> consentOptional = consentRepository.findFirstById(ro.getConsentId());
-        if (!consentOptional.isPresent()) {
+        if (consentOptional.isEmpty()) {
             throw new ConsentNotFoundException(ro.getConsentId());
         }
 
@@ -260,7 +254,7 @@ public class UserConsentService {
 
             // Check if a consent with given consent exists
             final Optional<ConsentEntity> consentOptional = consentRepository.findFirstById(consentStatus.getConsentId());
-            if (!consentOptional.isPresent()) { // should happen only in case of data inconsistency.
+            if (consentOptional.isEmpty()) { // should happen only in case of data inconsistency.
                 throw new ConsentNotFoundException(consentStatus.getConsentId());
             }
 
@@ -306,11 +300,8 @@ public class UserConsentService {
         for (UserConsentHistoryEntity uche: userConsentHistoryEntities) {
 
             // Find the consent template
-            final Optional<ConsentEntity> consentEntityOptional = consentRepository.findFirstById(uche.getConsentId());
-            if (!consentEntityOptional.isPresent()) {
-                throw new ConsentNotFoundException(uche.getConsentId());
-            }
-            final ConsentEntity consent = consentEntityOptional.get();
+            final ConsentEntity consent = consentRepository.findFirstById(uche.getConsentId()).orElseThrow(() ->
+                    new ConsentNotFoundException(uche.getConsentId()));
 
             //TODO: Replace by converter
             GivenConsentHistory givenConsentHistory = new GivenConsentHistory();
@@ -369,11 +360,8 @@ public class UserConsentService {
         for (UserConsentEntity uce: consentEntities) {
 
             // Find the consent template
-            final Optional<ConsentEntity> consentEntityOptional = consentRepository.findFirstById(uce.getConsentId());
-            if (!consentEntityOptional.isPresent()) {
-                throw new ConsentNotFoundException(uce.getConsentId());
-            }
-            final ConsentEntity consent = consentEntityOptional.get();
+            final ConsentEntity consent = consentRepository.findFirstById(uce.getConsentId()).orElseThrow(() ->
+                    new ConsentNotFoundException(uce.getConsentId()));
 
             // Prepare the consent entity for the response
             //TODO: Replace by converter

--- a/powerauth-tpp-engine/src/test/java/io/getlime/security/powerauth/app/tppengine/service/TppServiceTest.java
+++ b/powerauth-tpp-engine/src/test/java/io/getlime/security/powerauth/app/tppengine/service/TppServiceTest.java
@@ -86,9 +86,8 @@ public class TppServiceTest {
     void testBlockTppWhenNotFound() {
         Mockito.when(tppRepository.findFirstByTppLicense(TPP_LICENSE)).thenReturn(Optional.empty());
 
-        assertThrows(TppNotFoundException.class, () -> {
-            tppService.blockTpp(TPP_LICENSE);
-        });
+        assertThrows(TppNotFoundException.class, () ->
+                tppService.blockTpp(TPP_LICENSE));
     }
 
     @Test
@@ -115,9 +114,8 @@ public class TppServiceTest {
     void testUnblockTppWhenNotFound() {
         Mockito.when(tppRepository.findFirstByTppLicense(TPP_LICENSE)).thenReturn(Optional.empty());
 
-        assertThrows(TppNotFoundException.class, () -> {
-            tppService.unblockTpp(TPP_LICENSE);
-        });
+        assertThrows(TppNotFoundException.class, () ->
+                tppService.unblockTpp(TPP_LICENSE));
     }
 
 }

--- a/powerauth-webflow-authentication-approval-sca/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/approvalsca/controller/ApprovalScaController.java
+++ b/powerauth-webflow-authentication-approval-sca/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/approvalsca/controller/ApprovalScaController.java
@@ -65,7 +65,7 @@ public class ApprovalScaController extends AuthMethodController<ApprovalScaAuthR
 
     private static final Logger logger = LoggerFactory.getLogger(ApprovalScaController.class);
 
-    private final String FIELD_BANK_ACCOUNT_CHOICE_DISABLED = "operation.bankAccountChoice.disabled";
+    private static final String FIELD_BANK_ACCOUNT_CHOICE_DISABLED = "operation.bankAccountChoice.disabled";
 
     private final DataAdapterClient dataAdapterClient;
     private final NextStepClient nextStepClient;

--- a/powerauth-webflow-authentication-consent/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/consent/controller/ConsentController.java
+++ b/powerauth-webflow-authentication-consent/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/consent/controller/ConsentController.java
@@ -311,8 +311,7 @@ public class ConsentController extends AuthMethodController<ConsentAuthRequest, 
             final ConsentAuthResponse response = new ConsentAuthResponse();
             response.setResult(AuthStepResult.AUTH_FAILED);
             logger.info("Step result: AUTH_FAILED, authentication method: {}", getAuthMethodName().toString());
-            if (e instanceof ConsentValidationFailedException) {
-                ConsentValidationFailedException validationEx = (ConsentValidationFailedException) e;
+            if (e instanceof final ConsentValidationFailedException validationEx) {
                 response.setConsentValidationPassed(false);
                 response.setValidationErrorMessage(validationEx.getErrorMessage());
                 response.setOptionValidationResults(validationEx.getOptionValidationResults());

--- a/powerauth-webflow-authentication-consent/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/consent/model/response/ConsentInitResponse.java
+++ b/powerauth-webflow-authentication-consent/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/consent/model/response/ConsentInitResponse.java
@@ -32,7 +32,7 @@ public class ConsentInitResponse extends AuthStepResponse {
 
     private boolean shouldDisplayConsent;
     private String consentHtml;
-    private List<ConsentOption> options;
+    private final List<ConsentOption> options;
 
     /**
      * Default constructor.

--- a/powerauth-webflow-authentication-form/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/form/controller/FormLoginController.java
+++ b/powerauth-webflow-authentication-form/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/form/controller/FormLoginController.java
@@ -166,21 +166,19 @@ public class FormLoginController extends AuthMethodController<UsernamePasswordAu
             String cipherTransformation = configuration.getCipherTransformation();
             PasswordProtection passwordProtection;
             switch (passwordProtectionType) {
-                case NO_PROTECTION:
+                case NO_PROTECTION -> {
                     // Password is sent in plain text
                     passwordProtection = new NoPasswordProtection();
                     logger.info("No protection is used for protecting user password");
-                    break;
-
-                case PASSWORD_ENCRYPTION_AES:
+                }
+                case PASSWORD_ENCRYPTION_AES -> {
                     // Encrypt user password in case password encryption is configured in Web Flow
                     passwordProtection = new AesEncryptionPasswordProtection(cipherTransformation, configuration.getPasswordEncryptionKey());
                     logger.info("User password is protected using transformation: {}", cipherTransformation);
-                    break;
-
-                default:
+                }
+                default ->
                     // Unsupported authentication type
-                    throw new AuthStepException("Invalid authentication type", "error.invalidRequest");
+                        throw new AuthStepException("Invalid authentication type", "error.invalidRequest");
             }
 
             String protectedPassword = passwordProtection.protect(request.getPassword());
@@ -290,8 +288,7 @@ public class FormLoginController extends AuthMethodController<UsernamePasswordAu
             logger.warn("Error occurred while authenticating user: {}", e.getMessage());
             if (afsAction != null) {
                 final List<AfsAuthInstrument> authInstruments = authInstrumentConverter.fromAuthInstruments(request.getAuthInstruments());
-                if (e instanceof AuthenticationFailedException) {
-                    AuthenticationFailedException authEx = (AuthenticationFailedException) e;
+                if (e instanceof final AuthenticationFailedException authEx) {
                     if (authEx.getAccountStatus() != UserAccountStatus.ACTIVE) {
                         // notify AFS about failed authentication method due to the fact that user account is not active
                         afsIntegrationService.executeAuthAction(operation.getOperationId(), afsAction, username, authInstruments, AuthStepResult.AUTH_METHOD_FAILED);

--- a/powerauth-webflow-authentication-login-sca/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/loginsca/controller/LoginScaController.java
+++ b/powerauth-webflow-authentication-login-sca/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/method/loginsca/controller/LoginScaController.java
@@ -242,8 +242,7 @@ public class LoginScaController extends AuthMethodController<LoginScaAuthRequest
             // Send error to client
             LoginScaAuthResponse response = new LoginScaAuthResponse();
             response.setResult(AuthStepResult.AUTH_FAILED);
-            if (ex instanceof DataAdapterClientErrorException) {
-                DataAdapterClientErrorException ex2 = (DataAdapterClientErrorException) ex;
+            if (ex instanceof final DataAdapterClientErrorException ex2) {
                 response.setRemainingAttempts(ex2.getError().getRemainingAttempts());
                 response.setMessage(ex2.getError().getMessage());
             } else {
@@ -275,17 +274,18 @@ public class LoginScaController extends AuthMethodController<LoginScaAuthRequest
             ObjectResponse<InitAuthMethodResponse> objectResponse = dataAdapterClient.initAuthMethod(operation.getUserId(), operation.getOrganizationId(), AuthMethod.LOGIN_SCA, operationContext);
             InitAuthMethodResponse initResponse = objectResponse.getResponseObject();
             switch (initResponse.getCertificateAuthenticationMode()) {
-                case ENABLED:
+                case ENABLED -> {
                     response.setClientCertificateAuthenticationAvailable(true);
                     response.setClientCertificateAuthenticationEnabled(true);
-                    break;
-                case DISABLED:
+                }
+                case DISABLED -> {
                     response.setClientCertificateAuthenticationAvailable(true);
                     response.setClientCertificateAuthenticationEnabled(false);
-                    break;
-                default:
+                }
+                default -> {
                     response.setClientCertificateAuthenticationAvailable(false);
                     response.setClientCertificateAuthenticationEnabled(false);
+                }
             }
             response.setClientCertificateVerificationUrl(initResponse.getCertificateVerificationUrl());
             if (operation.getUserId() != null && operation.getOrganizationId() != null) {

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileAppApiController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileAppApiController.java
@@ -407,14 +407,14 @@ public class MobileAppApiController extends AuthMethodController<MobileTokenAuth
         // Evaluate various signature types
         if (allowedSignatureType != null) {
             switch (allowedSignatureType.getType()) {
-                case MULTIFACTOR_1FA: {
+                case MULTIFACTOR_1FA -> {
                     // Is the signature correct 1FA type - "possession"?
                     // Also, allow any 2FA signature as they are more strict than 1FA signature, as a fallback
                     return PowerAuthSignatureTypes.POSSESSION.equals(signatureTypes)
                             || PowerAuthSignatureTypes.POSSESSION_KNOWLEDGE.equals(signatureTypes)
                             || PowerAuthSignatureTypes.POSSESSION_BIOMETRY.equals(signatureTypes);
                 }
-                case MULTIFACTOR_2FA: {
+                case MULTIFACTOR_2FA -> {
                     // Is the signature correct 2FA type - "possession_knowledge" or "possession_biometry"?
                     // Check for "possession_knowledge" first
                     if (PowerAuthSignatureTypes.POSSESSION_KNOWLEDGE.equals(signatureTypes)) {
@@ -424,9 +424,8 @@ public class MobileAppApiController extends AuthMethodController<MobileTokenAuth
                     if (PowerAuthSignatureTypes.POSSESSION_BIOMETRY.equals(signatureTypes)) {
                         return allowedSignatureType.getVariants() != null && allowedSignatureType.getVariants().contains("possession_biometry");
                     }
-                    break;
                 }
-                case ASYMMETRIC_ECDSA: {
+                case ASYMMETRIC_ECDSA -> {
                     // Not allowed at this moment
                     return false;
                 }

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOfflineController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOfflineController.java
@@ -277,7 +277,7 @@ public class MobileTokenOfflineController extends AuthMethodController<QrCodeAut
         // generating of QR code
         OfflineSignatureQrCode qrCode = generateQrCode(activationEntity);
         initResponse.setQrCode(qrCode.generateImage());
-        initResponse.setNonce(qrCode.getNonce());
+        initResponse.setNonce(qrCode.nonce());
         initResponse.setChosenActivation(activationEntity);
         // currently the choice of activations is limited only to the configured activation, however list is kept in case we decide in future to re-enable the choice
         initResponse.setActivations(activationEntities);

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOnlineController.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/controller/MobileTokenOnlineController.java
@@ -222,19 +222,15 @@ public class MobileTokenOnlineController extends AuthMethodController<MobileToke
 
                 if (h.getAuthStepResultDescription() != null) {
                     switch (h.getAuthStepResultDescription()) {
-                        case "canceled.incorrect_data":
-                        case "canceled.unexpected_operation":
-                        case "canceled.unknown":
+                        case "canceled.incorrect_data", "canceled.unexpected_operation", "canceled.unknown" ->
                             // User rejected the operation
-                            response.setMessage("operation.canceled");
-                            break;
-                        case "canceled.timed_out_operation":
+                                response.setMessage("operation.canceled");
+                        case "canceled.timed_out_operation" ->
                             // The operation timed out
-                            response.setMessage("operation.timeout");
-                            break;
-                        default:
+                                response.setMessage("operation.timeout");
+                        default ->
                             // The operation failed for other reason
-                            response.setMessage("operation.alreadyFailed");
+                                response.setMessage("operation.alreadyFailed");
                     }
                 } else {
                     response.setMessage("error.unknown");

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/model/converter/AttributeConverter.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/model/converter/AttributeConverter.java
@@ -38,28 +38,28 @@ public class AttributeConverter {
             return null;
         }
         switch (input.getType()) {
-            case AMOUNT: {
+            case AMOUNT -> {
                 OperationAmountFieldAttribute attr = (OperationAmountFieldAttribute) input;
                 return new AmountAttribute(attr.getId(), attr.getLabel(), attr.getAmount(), attr.getCurrency(),
                         attr.getFormattedValues().get("amount"), attr.getFormattedValues().get("currency"));
             }
-            case KEY_VALUE: {
+            case KEY_VALUE -> {
                 OperationKeyValueFieldAttribute attr = (OperationKeyValueFieldAttribute) input;
                 return new KeyValueAttribute(attr.getId(), attr.getLabel(), attr.getFormattedValues().get("value"));
             }
-            case NOTE: {
+            case NOTE -> {
                 OperationNoteFieldAttribute attr = (OperationNoteFieldAttribute) input;
                 return new NoteAttribute(attr.getId(), attr.getLabel(), attr.getFormattedValues().get("value"));
             }
-            case HEADING: {
+            case HEADING -> {
                 OperationHeadingFieldAttribute attr = (OperationHeadingFieldAttribute) input;
                 return new HeadingAttribute(attr.getId(), attr.getFormattedValues().get("value"));
             }
-            case PARTY_INFO: {
+            case PARTY_INFO -> {
                 OperationPartyInfoFieldAttribute attr = (OperationPartyInfoFieldAttribute) input;
                 return new PartyAttribute(attr.getId(), attr.getLabel(), fromPartyInfo(attr.getPartyInfo()));
             }
-            default: {
+            default -> {
                 return new KeyValueAttribute(input.getId(), input.getLabel(), null);
             }
         }

--- a/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/model/entity/OfflineSignatureQrCode.java
+++ b/powerauth-webflow-authentication-mtoken/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/mtoken/model/entity/OfflineSignatureQrCode.java
@@ -30,64 +30,30 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 /**
  * Signature and data for QR code in offline mode for mobile token.
+ *
+ * @param size  QR code size.
+ * @param data  QR code data.
+ * @param nonce Nonce.
  * @author Roman Strobl, roman.strobl@wultra.com
  */
-public class OfflineSignatureQrCode {
+public record OfflineSignatureQrCode(int size, String data, String nonce) {
 
     private static final Logger logger = LoggerFactory.getLogger(OfflineSignatureQrCode.class);
 
-    private final int size;
-    private final String data;
-    private final String nonce;
-
-    /**
-     * QR code constructor.
-     * @param size QR code size.
-     * @param data QR code data.
-     * @param nonce Nonce.
-     */
-    public OfflineSignatureQrCode(int size, String data, String nonce) {
-        this.size = size;
-        this.data = data;
-        this.nonce = nonce;
-    }
-
-    /**
-     * Get QR code size.
-     * @return QR code size.
-     */
-    public int getSize() {
-        return size;
-    }
-
-    /**
-     * Get QR code data.
-     * @return QR code data.
-     */
-    public String getData() {
-        return data;
-    }
-
-    /**
-     * Get nonce.
-     * @return Nonce.
-     */
-    public String getNonce() {
-        return nonce;
-    }
-
     /**
      * Encodes the QR code data into a String-based PNG image.
+     *
      * @return Generated QR code.
      */
     public String generateImage() {
         try {
             BitMatrix matrix = new MultiFormatWriter().encode(
-                    new String(data.getBytes("UTF-8"), "ISO-8859-1"),
+                    new String(data.getBytes(StandardCharsets.UTF_8), StandardCharsets.ISO_8859_1),
                     BarcodeFormat.QR_CODE,
                     size,
                     size);

--- a/powerauth-webflow-authentication-sms/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/sms/controller/SmsAuthorizationController.java
+++ b/powerauth-webflow-authentication-sms/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/sms/controller/SmsAuthorizationController.java
@@ -201,21 +201,19 @@ public class SmsAuthorizationController extends AuthMethodController<SmsAuthoriz
                 String cipherTransformation = configuration.getCipherTransformation();
                 io.getlime.security.powerauth.lib.webflow.authentication.encryption.PasswordProtection passwordProtection;
                 switch (passwordProtectionType) {
-                    case NO_PROTECTION:
+                    case NO_PROTECTION -> {
                         // Password is sent in plain text
                         passwordProtection = new NoPasswordProtection();
                         logger.info("No protection is used for protecting user password");
-                        break;
-
-                    case PASSWORD_ENCRYPTION_AES:
+                    }
+                    case PASSWORD_ENCRYPTION_AES -> {
                         // Encrypt user password in case password encryption is configured in Web Flow
                         passwordProtection = new AesEncryptionPasswordProtection(cipherTransformation, configuration.getPasswordEncryptionKey());
                         logger.info("User password is protected using transformation: {}", cipherTransformation);
-                        break;
-
-                    default:
+                    }
+                    default ->
                         // Unsupported authentication type
-                        throw new InvalidRequestException("Invalid authentication type");
+                            throw new InvalidRequestException("Invalid authentication type");
                 }
 
                 String protectedPassword = passwordProtection.protect(request.getPassword());
@@ -617,8 +615,7 @@ public class SmsAuthorizationController extends AuthMethodController<SmsAuthoriz
             logger.warn("Error occurred while verifying authorization code from SMS message: {}", e.getMessage());
             if (afsAction != null) {
                 final List<AfsAuthInstrument> authInstruments = authInstrumentConverter.fromAuthInstruments(request.getAuthInstruments());
-                if (e instanceof AuthenticationFailedException) {
-                    AuthenticationFailedException authEx = (AuthenticationFailedException) e;
+                if (e instanceof final AuthenticationFailedException authEx) {
                     if (authEx.getAccountStatus() != UserAccountStatus.ACTIVE) {
                         // notify AFS about failed authentication method due to the fact that user account is not active
                         afsIntegrationService.executeAuthAction(operation.getOperationId(), afsAction, username, authInstruments, AuthStepResult.AUTH_METHOD_FAILED);
@@ -732,13 +729,9 @@ public class SmsAuthorizationController extends AuthMethodController<SmsAuthoriz
     private AfsAction determineAfsActionInit(AuthMethod authMethod, String operationName) throws AuthStepException {
         AfsAction afsAction;
         switch (authMethod) {
-            case LOGIN_SCA:
-                afsAction = AfsAction.LOGIN_INIT;
-                break;
-            case APPROVAL_SCA:
-                afsAction = AfsAction.APPROVAL_INIT;
-                break;
-            case SMS_KEY:
+            case LOGIN_SCA -> afsAction = AfsAction.LOGIN_INIT;
+            case APPROVAL_SCA -> afsAction = AfsAction.APPROVAL_INIT;
+            case SMS_KEY -> {
                 GetOperationConfigDetailResponse config = getOperationConfig(operationName);
                 if (config == null) {
                     throw new OperationNotConfiguredException("Operation not configured, operation name: " + operationName);
@@ -751,9 +744,8 @@ public class SmsAuthorizationController extends AuthMethodController<SmsAuthoriz
                     // Unknown template, do not execute AFS action
                     afsAction = null;
                 }
-                break;
-            default:
-                afsAction = null;
+            }
+            default -> afsAction = null;
         }
         return afsAction;
     }
@@ -768,13 +760,9 @@ public class SmsAuthorizationController extends AuthMethodController<SmsAuthoriz
     private AfsAction determineAfsActionAuth(AuthMethod authMethod, String operationName) throws AuthStepException {
         AfsAction afsAction;
         switch (authMethod) {
-            case LOGIN_SCA:
-                afsAction = AfsAction.LOGIN_AUTH;
-                break;
-            case APPROVAL_SCA:
-                afsAction = AfsAction.APPROVAL_AUTH;
-                break;
-            case SMS_KEY:
+            case LOGIN_SCA -> afsAction = AfsAction.LOGIN_AUTH;
+            case APPROVAL_SCA -> afsAction = AfsAction.APPROVAL_AUTH;
+            case SMS_KEY -> {
                 GetOperationConfigDetailResponse config = getOperationConfig(operationName);
                 if (config == null) {
                     throw new OperationNotConfiguredException("Operation not configured, operation name: " + operationName);
@@ -787,9 +775,8 @@ public class SmsAuthorizationController extends AuthMethodController<SmsAuthoriz
                     // Unknown template, do not execute AFS action
                     afsAction = null;
                 }
-                break;
-            default:
-                afsAction = null;
+            }
+            default -> afsAction = null;
         }
         return afsAction;
     }

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/base/AuthStepResponse.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/base/AuthStepResponse.java
@@ -32,13 +32,9 @@ import java.util.List;
 public class AuthStepResponse {
 
     private AuthStepResult result;
-    private List<AuthStep> next;
+    private final List<AuthStep> next = new ArrayList<>();
     private String message;
     private Integer remainingAttempts;
-
-    public AuthStepResponse() {
-        this.next = new ArrayList<>();
-    }
 
     /**
      * Get the auth step result for the response - either success, or failure.

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/controller/AuthMethodController.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/controller/AuthMethodController.java
@@ -533,16 +533,16 @@ public abstract class AuthMethodController<T extends AuthStepRequest, R extends 
             }
             // TODO: Allow passing custom parameters
             switch (authOperationResponse.getAuthResult()) {
-                case DONE: {
+                case DONE -> {
                     return provider.doneAuthentication(userId);
                 }
-                case FAILED: {
+                case FAILED -> {
                     return provider.failedAuthentication(userId, authOperationResponse.getResultDescription());
                 }
-                case CONTINUE: {
+                case CONTINUE -> {
                     return provider.continueAuthentication(authOperationResponse.getOperationId(), userId, authOperationResponse.getSteps());
                 }
-                default: {
+                default -> {
                     return provider.failedAuthentication(userId, "error.unknown");
                 }
             }
@@ -550,15 +550,15 @@ public abstract class AuthMethodController<T extends AuthStepRequest, R extends 
             Error nextStepError = ex.getError();
             if (nextStepError != null) {
                 switch (nextStepError.getCode()) {
-                    case OperationAlreadyFinishedException.CODE:
-                        // Translate Next Step exception for update of a finished operation
-                        throw new OperationIsAlreadyFinished(ex.getMessage());
-                    case OperationAlreadyCanceledException.CODE:
-                        // Translate Next Step exception for update of a canceled operation
-                        throw new OperationIsAlreadyCanceledException(ex.getMessage());
-                    case OperationAlreadyFailedException.CODE:
-                        // Translate Next Step exception for update of a failed operation
-                        throw new OperationIsAlreadyFailedException(ex.getMessage());
+                    case OperationAlreadyFinishedException.CODE ->
+                            // Translate Next Step exception for update of a finished operation
+                            throw new OperationIsAlreadyFinished(ex.getMessage());
+                    case OperationAlreadyCanceledException.CODE ->
+                            // Translate Next Step exception for update of a canceled operation
+                            throw new OperationIsAlreadyCanceledException(ex.getMessage());
+                    case OperationAlreadyFailedException.CODE ->
+                            // Translate Next Step exception for update of a failed operation
+                            throw new OperationIsAlreadyFailedException(ex.getMessage());
                 }
             }
             // Generic Next Step error

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/encryption/AesEncryptionPasswordProtection.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/encryption/AesEncryptionPasswordProtection.java
@@ -37,11 +37,11 @@ public class AesEncryptionPasswordProtection implements PasswordProtection {
     private static final Logger logger = LoggerFactory.getLogger(AesEncryptionPasswordProtection.class);
 
     private final AESEncryptionUtils aes = new AESEncryptionUtils();
-    private KeyGenerator keyGenerator = new KeyGenerator();
-    private KeyConvertor keyConvertor = new KeyConvertor();
+    private final KeyGenerator keyGenerator = new KeyGenerator();
+    private final KeyConvertor keyConvertor = new KeyConvertor();
 
-    private String cipherTransformation;
-    private String secretKeyBase64;
+    private final String cipherTransformation;
+    private final String secretKeyBase64;
 
     /**
      * Class constructor.

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/model/converter/AuthInstrumentConverter.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/model/converter/AuthInstrumentConverter.java
@@ -34,18 +34,10 @@ public class AuthInstrumentConverter {
         List<AfsAuthInstrument> authInstrumentsAfs = new ArrayList<>();
         for (AuthInstrument instrument: authInstruments) {
             switch (instrument) {
-                case CREDENTIAL:
-                    authInstrumentsAfs.add(AfsAuthInstrument.CREDENTIAL);
-                    break;
-                case OTP_KEY:
-                    authInstrumentsAfs.add(AfsAuthInstrument.OTP_KEY);
-                    break;
-                case POWERAUTH_TOKEN:
-                    authInstrumentsAfs.add(AfsAuthInstrument.POWERAUTH_TOKEN);
-                    break;
-                case HW_TOKEN:
-                    authInstrumentsAfs.add(AfsAuthInstrument.HW_TOKEN);
-                    break;
+                case CREDENTIAL -> authInstrumentsAfs.add(AfsAuthInstrument.CREDENTIAL);
+                case OTP_KEY -> authInstrumentsAfs.add(AfsAuthInstrument.OTP_KEY);
+                case POWERAUTH_TOKEN -> authInstrumentsAfs.add(AfsAuthInstrument.POWERAUTH_TOKEN);
+                case HW_TOKEN -> authInstrumentsAfs.add(AfsAuthInstrument.HW_TOKEN);
             }
         }
         return authInstrumentsAfs;

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/model/converter/OperationCancellationConverter.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/model/converter/OperationCancellationConverter.java
@@ -34,14 +34,11 @@ public class OperationCancellationConverter {
         if (cancelReason == null) {
             return OperationTerminationReason.FAILED;
         }
-        switch (cancelReason) {
-            case INTERRUPTED_OPERATION:
-                return OperationTerminationReason.INTERRUPTED;
-            case TIMED_OUT_OPERATION:
-                return OperationTerminationReason.TIMED_OUT;
-            default:
-                return OperationTerminationReason.FAILED;
-        }
+        return switch (cancelReason) {
+            case INTERRUPTED_OPERATION -> OperationTerminationReason.INTERRUPTED;
+            case TIMED_OUT_OPERATION -> OperationTerminationReason.TIMED_OUT;
+            default -> OperationTerminationReason.FAILED;
+        };
     }
 
 }

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/repository/model/entity/AfsConfigEntity.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/repository/model/entity/AfsConfigEntity.java
@@ -22,6 +22,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -34,6 +35,7 @@ import java.util.Objects;
 @Table(name = "wf_afs_config")
 public class AfsConfigEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = -3077689235187445743L;
 
     @Id

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/repository/model/entity/CertificateVerificationEntity.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/repository/model/entity/CertificateVerificationEntity.java
@@ -20,6 +20,7 @@ package io.getlime.security.powerauth.lib.webflow.authentication.repository.mode
 import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthMethod;
 import jakarta.persistence.*;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.Objects;
@@ -33,6 +34,7 @@ import java.util.Objects;
 @Table(name = "wf_certificate_verification")
 public class CertificateVerificationEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 6993451807635603808L;
 
     @EmbeddedId
@@ -151,6 +153,7 @@ public class CertificateVerificationEntity implements Serializable {
     @Embeddable
     public static class CertificateVerificationKey implements Serializable {
 
+        @Serial
         private static final long serialVersionUID = -8783963465967422879L;
 
         @Column(name = "operation_id", nullable = false)

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/repository/model/entity/OperationSessionEntity.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/repository/model/entity/OperationSessionEntity.java
@@ -20,6 +20,7 @@ package io.getlime.security.powerauth.lib.webflow.authentication.repository.mode
 import io.getlime.security.powerauth.lib.nextstep.model.enumeration.AuthResult;
 import jakarta.persistence.*;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.Objects;
@@ -33,6 +34,7 @@ import java.util.Objects;
 @Table(name = "wf_operation_session")
 public class OperationSessionEntity implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = -5370629764971469306L;
 
     @Id

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/security/UserOperationAuthentication.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/security/UserOperationAuthentication.java
@@ -22,11 +22,9 @@ import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
+import java.io.Serial;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Locale;
+import java.util.*;
 
 /**
  * Object representing a user authentication.
@@ -35,6 +33,7 @@ import java.util.Locale;
  */
 public class UserOperationAuthentication extends AbstractAuthenticationToken implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 4514448849365459373L;
 
     private String userId;
@@ -76,9 +75,7 @@ public class UserOperationAuthentication extends AbstractAuthenticationToken imp
 
     @Override
     public Collection<GrantedAuthority> getAuthorities() {
-        ArrayList<GrantedAuthority> authorities = new ArrayList<>(1);
-        authorities.add(new SimpleGrantedAuthority("USER"));
-        return Collections.unmodifiableList(authorities);
+        return List.of(new SimpleGrantedAuthority("USER"));
     }
 
     @Override

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/MessageTranslationService.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/MessageTranslationService.java
@@ -119,9 +119,8 @@ public class MessageTranslationService {
         }
         for (OperationFormFieldAttribute attribute : attributes) {
             // Formatting of attributes with specified format
-            if (attribute instanceof OperationFormFieldAttributeFormatted) {
-                OperationFormFieldAttributeFormatted formattedAttribute = (OperationFormFieldAttributeFormatted) attribute;
-                ValueFormatType valueFormatType = formattedAttribute.getValueFormatType();
+            if (attribute instanceof final OperationFormFieldAttributeFormatted formattedAttribute) {
+                final ValueFormatType valueFormatType = formattedAttribute.getValueFormatType();
                 if (valueFormatType == ValueFormatType.LOCALIZED_TEXT) {
                     String formattedValue = localize(valueFormatterService.getValue(attribute));
                     formattedAttribute.addFormattedValue("value", formattedValue);
@@ -168,33 +167,31 @@ public class MessageTranslationService {
         for (OperationFormFieldAttribute attribute: formData.getParameters()) {
             String value = null;
             switch (attribute.getType()) {
-                case AMOUNT:
+                case AMOUNT -> {
                     OperationAmountFieldAttribute amountAttribute = (OperationAmountFieldAttribute) attribute;
                     value = amountAttribute.getAmount().toPlainString();
                     // special handling for translation of currency value
                     idValueMap.put(amountAttribute.getCurrencyId(), amountAttribute.getCurrency());
-                    break;
-                case NOTE:
+                }
+                case NOTE -> {
                     OperationNoteFieldAttribute messageAttribute = (OperationNoteFieldAttribute) attribute;
                     value = messageAttribute.getNote();
-                    break;
-                case BANK_ACCOUNT_CHOICE:
-                    value = formData.getUserInput().get(CHOSEN_BANK_ACCOUNT_NUMBER_INPUT);
-                    break;
-                case KEY_VALUE:
+                }
+                case BANK_ACCOUNT_CHOICE -> value = formData.getUserInput().get(CHOSEN_BANK_ACCOUNT_NUMBER_INPUT);
+                case KEY_VALUE -> {
                     OperationKeyValueFieldAttribute keyValueAttribute = (OperationKeyValueFieldAttribute) attribute;
                     value = keyValueAttribute.getValue();
-                    break;
-                case HEADING:
+                }
+                case HEADING -> {
                     OperationHeadingFieldAttribute headingAttribute = (OperationHeadingFieldAttribute) attribute;
                     value = headingAttribute.getValue();
-                    break;
-                case PARTY_INFO:
+                }
+                case PARTY_INFO -> {
                     OperationPartyInfoFieldAttribute partyInfoAttribute = (OperationPartyInfoFieldAttribute) attribute;
                     if (partyInfoAttribute.getPartyInfo() != null) {
                         value = partyInfoAttribute.getPartyInfo().getName();
                     }
-                    break;
+                }
             }
             idValueMap.put(attribute.getId(), value);
         }

--- a/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/ValueFormatterService.java
+++ b/powerauth-webflow-authentication/src/main/java/io/getlime/security/powerauth/lib/webflow/authentication/service/ValueFormatterService.java
@@ -69,38 +69,26 @@ public class ValueFormatterService {
         ValueFormatType valueFormatType = attribute.getValueFormatType();
 
         switch (valueFormatType) {
-
-            case TEXT: {
+            case TEXT -> {
                 attribute.addFormattedValue("value", getValue(attribute));
-                return;
             }
-
-            case AMOUNT: {
-                if (attribute instanceof OperationAmountFieldAttribute) {
-                    OperationAmountFieldAttribute amountAttribute = (OperationAmountFieldAttribute) attribute;
+            case AMOUNT -> {
+                if (attribute instanceof final OperationAmountFieldAttribute amountAttribute) {
                     addFormattedAmount(amountAttribute, locale);
                     return;
                 }
                 addNumericValue(attribute, locale);
-                return;
             }
-
-            case NUMBER: {
+            case NUMBER -> {
                 addNumericValue(attribute, locale);
-                return;
             }
-
-            case DATE:
+            case DATE -> {
                 attribute.addFormattedValue("value", formatDate(getValue(attribute), locale));
-                return;
-
-            case ACCOUNT:
+            }
+            case ACCOUNT -> {
                 attribute.addFormattedValue("value", formatAccount(getValue(attribute), locale));
-                return;
-
-            default:
-                throw new IllegalStateException("Unexpected value format type: "+attribute.getValueFormatType());
-
+            }
+            default -> throw new IllegalStateException("Unexpected value format type: " + attribute.getValueFormatType());
         }
     }
 
@@ -114,11 +102,9 @@ public class ValueFormatterService {
         try {
             BigDecimal numericValue = new BigDecimal(value);
             attribute.addFormattedValue("value", formatNumber(numericValue, locale));
-            return;
         } catch (NumberFormatException ex) {
             // do not interrupt operation by exception due to broken formatting
             attribute.addFormattedValue("value", value);
-            return;
         }
     }
 
@@ -131,14 +117,11 @@ public class ValueFormatterService {
         if (attribute == null) {
             return "";
         }
-        if (attribute instanceof OperationKeyValueFieldAttribute) {
-            OperationKeyValueFieldAttribute keyValueAttribute = (OperationKeyValueFieldAttribute) attribute;
+        if (attribute instanceof final OperationKeyValueFieldAttribute keyValueAttribute) {
             return keyValueAttribute.getValue();
-        } else if (attribute instanceof OperationNoteFieldAttribute) {
-            OperationNoteFieldAttribute noteAttribute = (OperationNoteFieldAttribute) attribute;
+        } else if (attribute instanceof final OperationNoteFieldAttribute noteAttribute) {
             return noteAttribute.getNote();
-        } else if (attribute instanceof OperationAmountFieldAttribute) {
-            OperationAmountFieldAttribute amountAttribute = (OperationAmountFieldAttribute) attribute;
+        } else if (attribute instanceof final OperationAmountFieldAttribute amountAttribute) {
             return amountAttribute.getAmount().toPlainString() + " " + amountAttribute.getCurrency();
         }
         throw new IllegalArgumentException("Attribute does not support formatting: "+attribute.getClass().getName());

--- a/powerauth-webflow-client/src/main/java/io/getlime/security/powerauth/app/webflow/demo/model/AvailableOperation.java
+++ b/powerauth-webflow-client/src/main/java/io/getlime/security/powerauth/app/webflow/demo/model/AvailableOperation.java
@@ -30,10 +30,10 @@ public class AvailableOperation {
         AUTHORIZATION
     }
 
-    private String name;
+    private final String name;
 
     private boolean isDefault;
-    private Type type;
+    private final Type type;
 
     public AvailableOperation(Type type, String name) {
         this.name = name;

--- a/powerauth-webflow-client/src/main/java/io/getlime/security/powerauth/app/webflow/demo/model/UserResponse.java
+++ b/powerauth-webflow-client/src/main/java/io/getlime/security/powerauth/app/webflow/demo/model/UserResponse.java
@@ -28,7 +28,7 @@ public class UserResponse {
     /**
      * Information about the user.
      */
-    public class User {
+    public static class User {
 
         private String id;
         private String givenName;
@@ -63,7 +63,7 @@ public class UserResponse {
     /**
      * Information about the connection.
      */
-    public class Connection {
+    public static class Connection {
 
         private String language;
         private boolean sca;

--- a/powerauth-webflow-i18n/src/main/java/io/getlime/security/powerauth/app/webflow/i18n/I18NService.java
+++ b/powerauth-webflow-i18n/src/main/java/io/getlime/security/powerauth/app/webflow/i18n/I18NService.java
@@ -33,7 +33,7 @@ import java.util.Locale;
 @Service
 public class I18NService {
 
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
 
     @Resource
     private ReloadableResourceBundleMessageSourceWithListing messageSource;

--- a/powerauth-webflow-resources/src/main/java/io/getlime/security/powerauth/lib/webflow/resource/model/UserInfoResponse.java
+++ b/powerauth-webflow-resources/src/main/java/io/getlime/security/powerauth/lib/webflow/resource/model/UserInfoResponse.java
@@ -25,8 +25,8 @@ import java.util.Map;
 
 /**
  * Minimal OIDC UserInfo response, as defined in OpenID Connect specification.
- * See https://openid.net/specs/openid-connect-core-1_0.html#UserInfo for details.
- *
+ * See <a href="https://openid.net/specs/openid-connect-core-1_0.html#UserInfo">OpenID Connect User Info</a> for details.
+ * <p>
  * TODO: implement support for generic parameters in extras
  *
  * @author Petr Dvorak, petr@wultra.com

--- a/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/configuration/PowerAuthWebServiceConfiguration.java
+++ b/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/configuration/PowerAuthWebServiceConfiguration.java
@@ -23,10 +23,8 @@ import com.wultra.security.powerauth.rest.client.PowerAuthRestClient;
 import com.wultra.security.powerauth.rest.client.PowerAuthRestClientConfiguration;
 import io.getlime.push.client.PushServerClient;
 import io.getlime.push.client.PushServerClientException;
-import io.getlime.security.powerauth.lib.webflow.authentication.service.SSLConfigurationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -43,11 +41,6 @@ public class PowerAuthWebServiceConfiguration {
 
     private static final Logger logger = LoggerFactory.getLogger(PowerAuthWebServiceConfiguration.class);
 
-    private SSLConfigurationService sslConfigurationService;
-
-    @Autowired
-    private com.fasterxml.jackson.databind.ObjectMapper mapper;
-
     @Value("${powerauth.service.url}")
     private String powerAuthRestUrl;
 
@@ -62,15 +55,6 @@ public class PowerAuthWebServiceConfiguration {
 
     @Value("${powerauth.service.ssl.acceptInvalidSslCertificate}")
     private boolean acceptInvalidSslCertificate;
-
-    /**
-     * Configuration constructor.
-     * @param sslConfigurationService SSL configuration service.
-     */
-    @Autowired
-    public PowerAuthWebServiceConfiguration(SSLConfigurationService sslConfigurationService) {
-        this.sslConfigurationService = sslConfigurationService;
-    }
 
     /**
      * Initialize PowerAuth REST client.

--- a/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/configuration/WebMvcConfiguration.java
+++ b/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/configuration/WebMvcConfiguration.java
@@ -102,9 +102,7 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
      */
     @Bean
     public LocaleResolver localeResolver() {
-        CookieLocaleResolver resolver = new CookieLocaleResolver();
-        resolver.setCookieName("lang");
-        return resolver;
+        return new CookieLocaleResolver("lang");
     }
 
     /**

--- a/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/exception/InvalidTokenException.java
+++ b/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/exception/InvalidTokenException.java
@@ -17,6 +17,8 @@
  */
 package io.getlime.security.powerauth.app.webflow.exception;
 
+import java.io.Serial;
+
 /**
  * Exception used when access token or refresh token is invalid.
  *
@@ -24,6 +26,7 @@ package io.getlime.security.powerauth.app.webflow.exception;
  */
 public class InvalidTokenException extends Exception {
 
+    @Serial
     private static final long serialVersionUID = 8669519506272141604L;
 
     public InvalidTokenException(String message) {

--- a/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/exception/TlsClientAuthenticationException.java
+++ b/powerauth-webflow/src/main/java/io/getlime/security/powerauth/app/webflow/exception/TlsClientAuthenticationException.java
@@ -19,6 +19,8 @@ package io.getlime.security.powerauth.app.webflow.exception;
 
 import io.getlime.security.powerauth.lib.webflow.authentication.exception.AuthStepException;
 
+import java.io.Serial;
+
 /**
  * Authentication exception used when TLS client authentication fails.
  *
@@ -26,6 +28,7 @@ import io.getlime.security.powerauth.lib.webflow.authentication.exception.AuthSt
  */
 public class TlsClientAuthenticationException extends AuthStepException {
 
+    @Serial
     private static final long serialVersionUID = 210138878105518589L;
 
     /**


### PR DESCRIPTION
- Remove redundant throws clause
- Add final modifier
- Use @serial annotation
- Use getSubjectX500Principal instead of deprecated getSubjectDN
- Replace deprecated resolver.setCookieName() by constructor call
- Remove unnecessary return as the last statement
- Replace .collect(Collectors.toList()) by toList()
- Use standard charsets constants
- Micro-optimalisation of containsAll
- Make inner class static
- Simplify optional call chain
- Replace explicit type by diamond operator <>
- Use List.sort instead of Collections.sort
- Use expression lambda instead of statement
- Use List.of
- Use text block
- Use patter variable
- Enhance switch
- Convert AuthorizationCode, OfflineSignatureQrCode, Violation and CertInfo to record