### PR TITLE
Fix #1462: Update documentation regarding AS support

### DIFF
--- a/docs/Web-Flow-Installation-Manual.md
+++ b/docs/Web-Flow-Installation-Manual.md
@@ -42,7 +42,7 @@ A recent version of the Bouncy Castle library is bundled with Web Flow and Next 
 
 Unzip Tomcat to "/opt/tomcat" folder. You can download Tomcat here:
 
-[https://tomcat.apache.org/download-90.cgi](https://tomcat.apache.org/download-90.cgi)
+[https://tomcat.apache.org/download-10.cgi](https://tomcat.apache.org/download-10.cgi)
 
 Change owner of the files to "tomcat" user:
 


### PR DESCRIPTION
Fix #1462
In the manual, there is download link to Tomcat 9. The link was changed to point to Tomcat 10.