### PR TITLE
Fix #1535: Remove Guava dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -257,6 +257,19 @@
                 <version>${bcprov-jdk18on.version}</version>
             </dependency>
 
+            <!-- TODO (racansky, 2024-01-05) overriding vulnerable transitive dependency of owasp-java-html-sanitizer, https://github.com/OWASP/java-html-sanitizer/pull/295 -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+                <artifactId>owasp-java-html-sanitizer</artifactId>
+                <version>${owasp-java-html-sanitizer.version}</version>
+            </dependency>
+
             <!-- Library for formatting monetary amounts -->
             <dependency>
                 <groupId>org.javamoney.moneta</groupId>

--- a/powerauth-nextstep/pom.xml
+++ b/powerauth-nextstep/pom.xml
@@ -119,13 +119,6 @@
             <version>${springdoc-openapi-starter-webmvc-ui.version}</version>
         </dependency>
 
-        <!-- Upgrade Swagger Guava dependency due to CVE-2018-10237 -->
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-        </dependency>
-
         <!-- Testing -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/powerauth-tpp-engine/pom.xml
+++ b/powerauth-tpp-engine/pom.xml
@@ -96,13 +96,6 @@
             <version>${springdoc-openapi-starter-webmvc-ui.version}</version>
         </dependency>
 
-        <!-- Upgrade Swagger Guava dependency due to CVE-2018-10237 -->
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-        </dependency>
-
         <!-- Testing -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/powerauth-webflow-authentication-consent/pom.xml
+++ b/powerauth-webflow-authentication-consent/pom.xml
@@ -48,7 +48,6 @@
         <dependency>
             <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
             <artifactId>owasp-java-html-sanitizer</artifactId>
-            <version>${owasp-java-html-sanitizer.version}</version>
         </dependency>
     </dependencies>
 

--- a/powerauth-webflow-authentication/src/test/java/io/getlime/security/powerauth/lib/webflow/authentication/interceptor/WebSocketHandshakeInterceptorTest.java
+++ b/powerauth-webflow-authentication/src/test/java/io/getlime/security/powerauth/lib/webflow/authentication/interceptor/WebSocketHandshakeInterceptorTest.java
@@ -1,0 +1,54 @@
+/*
+ * PowerAuth Web Flow and related software components
+ * Copyright (C) 2024 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.lib.webflow.authentication.interceptor;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test for {@link WebSocketHandshakeInterceptor}.
+ *
+ * @author Lubos Racansky, lubos.racansky@wultra.com
+ */
+class WebSocketHandshakeInterceptorTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "192.168.0.1",
+            "255.255.255.255",
+            "10.0.0.255"
+    })
+    void testIsIpv4Address_valid(final String address) {
+        assertTrue(WebSocketHandshakeInterceptor.IpAddressValidator.isIpv4Address(address));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "192.168.0.256", // value above 255
+            "192.168.0", // only 3 octets
+            ".192.168.0.1", // starts with a '.'
+            "192.168.0.01", // leading zero
+    })
+    void testIsIpv4Address_invalid(final String address) {
+        assertFalse(WebSocketHandshakeInterceptor.IpAddressValidator.isIpv4Address(address));
+    }
+
+}

--- a/powerauth-webflow/pom.xml
+++ b/powerauth-webflow/pom.xml
@@ -68,12 +68,6 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
-        <!-- Other Dependencies -->
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>


### PR DESCRIPTION
Guava dependency remains because of owasp-java-html-sanitizer, but the API not directly used anymore.