### PR TITLE
Fix #1762: NextStep: Swagger update for validationFailures error handling

### DIFF
--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/entity/error/response/CredentialValidationErrorResponse.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/entity/error/response/CredentialValidationErrorResponse.java
@@ -1,0 +1,36 @@
+/*
+ * PowerAuth Web Flow and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.getlime.security.powerauth.lib.nextstep.model.entity.error.response;
+
+import io.getlime.core.rest.model.base.response.ObjectResponse;
+import io.getlime.security.powerauth.lib.nextstep.model.entity.error.CredentialValidationError;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Error response wrapping the {@link CredentialValidationError}.
+ *
+ * @author Jan Pesek, jan.pesek@wultra.com
+ */
+public class CredentialValidationErrorResponse extends ObjectResponse<CredentialValidationError> {
+
+    public CredentialValidationErrorResponse(@NotNull final CredentialValidationError responseObject) {
+        super("ERROR", responseObject);
+    }
+
+}

--- a/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/entity/error/response/ExtendedErrorResponse.java
+++ b/powerauth-nextstep-model/src/main/java/io/getlime/security/powerauth/lib/nextstep/model/entity/error/response/ExtendedErrorResponse.java
@@ -1,0 +1,36 @@
+/*
+ * PowerAuth Web Flow and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.getlime.security.powerauth.lib.nextstep.model.entity.error.response;
+
+import io.getlime.core.rest.model.base.response.ObjectResponse;
+import io.getlime.security.powerauth.lib.nextstep.model.entity.error.ExtendedError;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Error response wrapping the {@link ExtendedError}.
+ *
+ * @author Jan Pesek, jan.pesek@wultra.com
+ */
+public class ExtendedErrorResponse extends ObjectResponse<ExtendedError> {
+
+    public ExtendedErrorResponse(@NotNull final ExtendedError responseObject) {
+        super("ERROR", responseObject);
+    }
+
+}

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/exception/DefaultExceptionResolver.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/exception/DefaultExceptionResolver.java
@@ -25,6 +25,8 @@ import io.getlime.core.rest.model.base.response.ErrorResponse;
 import io.getlime.security.powerauth.lib.nextstep.model.entity.error.CredentialValidationError;
 import io.getlime.security.powerauth.lib.nextstep.model.entity.error.ExtendedError;
 import io.getlime.security.powerauth.lib.nextstep.model.entity.error.Violation;
+import io.getlime.security.powerauth.lib.nextstep.model.entity.error.response.CredentialValidationErrorResponse;
+import io.getlime.security.powerauth.lib.nextstep.model.entity.error.response.ExtendedErrorResponse;
 import io.getlime.security.powerauth.lib.nextstep.model.exception.*;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
@@ -798,12 +800,12 @@ public class DefaultExceptionResolver {
      */
     @ExceptionHandler(CredentialValidationFailedException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public @ResponseBody ErrorResponse handleCredentialValidationFailedException(CredentialValidationFailedException ex) {
+    public @ResponseBody CredentialValidationErrorResponse handleCredentialValidationFailedException(CredentialValidationFailedException ex) {
         logger.warn("Error occurred in Next Step server: {}", ex.getMessage());
         logger.warn("Validation errors: {}", ex.getError().getValidationFailures());
         audit.warn("Error occurred in Next Step server", AUDIT_DETAIL_BAD_REQUEST, ex);
         final CredentialValidationError error = new CredentialValidationError(CredentialValidationFailedException.CODE, "Credential validation failed.", ex.getError().getValidationFailures());
-        return new ErrorResponse(error);
+        return new CredentialValidationErrorResponse(error);
     }
 
     /**
@@ -813,14 +815,14 @@ public class DefaultExceptionResolver {
      */
     @ExceptionHandler(MissingServletRequestParameterException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public @ResponseBody ErrorResponse handleMissingServletRequestParameterException(MissingServletRequestParameterException ex) {
+    public @ResponseBody ExtendedErrorResponse handleMissingServletRequestParameterException(MissingServletRequestParameterException ex) {
         logger.warn("Error occurred in Next Step server: {}", ex.getMessage());
         audit.warn("Error occurred in Next Step server", AUDIT_DETAIL_BAD_REQUEST, ex);
         final ExtendedError error = new ExtendedError(RequestValidationFailedException.CODE, "Request validation failed.");
         error.getViolations().add(
                 new Violation(ex.getParameterName(), null, ex.getMessage())
         );
-        return new ErrorResponse(error);
+        return new ExtendedErrorResponse(error);
     }
 
     /**
@@ -831,7 +833,7 @@ public class DefaultExceptionResolver {
      */
     @ExceptionHandler(ConstraintViolationException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public @ResponseBody ErrorResponse handleConstraintViolationException(ConstraintViolationException ex) {
+    public @ResponseBody ExtendedErrorResponse handleConstraintViolationException(ConstraintViolationException ex) {
         logger.warn("Error occurred in Next Step server: {}", ex.getMessage());
         audit.warn("Error occurred in Next Step server", AUDIT_DETAIL_BAD_REQUEST, ex);
         final ExtendedError error = new ExtendedError(RequestValidationFailedException.CODE, "Request validation failed.");
@@ -840,7 +842,7 @@ public class DefaultExceptionResolver {
                     new Violation(violation.getPropertyPath().toString(), violation.getInvalidValue(), violation.getMessage())
             );
         }
-        return new ErrorResponse(error);
+        return new ExtendedErrorResponse(error);
     }
 
     /**
@@ -851,7 +853,7 @@ public class DefaultExceptionResolver {
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public @ResponseBody ErrorResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+    public @ResponseBody ExtendedErrorResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
         logger.warn("Error occurred in Next Step server: {}", ex.getMessage());
         audit.warn("Error occurred in Next Step server", AUDIT_DETAIL_BAD_REQUEST, ex);
         final ExtendedError error = new ExtendedError(RequestValidationFailedException.CODE, "Request validation failed.");
@@ -860,7 +862,7 @@ public class DefaultExceptionResolver {
                     new Violation(fieldError.getField(), fieldError.getRejectedValue(), fieldError.getDefaultMessage())
             );
         }
-        return new ErrorResponse(error);
+        return new ExtendedErrorResponse(error);
     }
 
     /**


### PR DESCRIPTION
Instead of propagating generic error response only:

```yml
"400":
    description: "Invalid request, error codes: REQUEST_VALIDATION_FAILED, OPERATION_NOT_FOUND, OPERATION_NOT_VALID"
    content:
        application/json:
            schema:
                $ref: "#/components/schemas/ErrorResponse"
```

We now get following struture:
```yml
"400":
    description: "Invalid request, error codes: REQUEST_VALIDATION_FAILED, OPERATION_NOT_FOUND, OPERATION_NOT_VALID"
    content:
        application/json:
            schema:
                oneOf:
                    - $ref: "#/components/schemas/ExtendedErrorResponse"
                    - $ref: "#/components/schemas/ErrorResponse"
                    - $ref: "#/components/schemas/CredentialValidationErrorResponse"
```
Which propagets also the `CredentialValidationError` itself, together with the enum `validationFailures`, as requested.
