### PR TITLE
Fix #1765: NextStep: Missing securitySchemes in swagger

### DIFF
--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/configuration/OpenApiConfiguration.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/configuration/OpenApiConfiguration.java
@@ -22,9 +22,16 @@ import io.swagger.v3.oas.annotations.info.Contact;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 import io.swagger.v3.oas.annotations.servers.Server;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import jakarta.servlet.ServletContext;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 /**
  * Configuration class used for setting up Open API documentation.
@@ -58,6 +65,29 @@ public class OpenApiConfiguration {
                 .group("nextstep")
                 .packagesToScan(packages)
                 .build();
+    }
+
+    @Bean
+    public OpenAPI openAPI(final ServletContext servletContext, final SecurityConfig securityConfig) {
+        final io.swagger.v3.oas.models.servers.Server server = new io.swagger.v3.oas.models.servers.Server()
+                .url(servletContext.getContextPath())
+                .description("Default Server URL");
+
+        final OpenAPI openAPI = new OpenAPI()
+                .servers(List.of(server));
+
+        if (SecurityConfig.AuthType.OIDC == securityConfig.getAuthType()) {
+            final Components components = new Components()
+                    .addSecuritySchemes("bearerAuth", new SecurityScheme()
+                    .type(SecurityScheme.Type.HTTP)
+                    .scheme("bearer")
+                    .bearerFormat("JWT"));
+
+            openAPI.components(components);
+            openAPI.addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
+        }
+
+        return openAPI;
     }
 
 }

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/configuration/SecurityConfig.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/configuration/SecurityConfig.java
@@ -68,13 +68,17 @@ public class SecurityConfig {
                 .build();
     }
 
-    enum AuthType {
+    public enum AuthType {
         NONE,
 
         /**
          * OpenID Connect.
          */
         OIDC
+    }
+
+    public AuthType getAuthType() {
+        return this.authType;
     }
 
 }

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/ServiceController.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/controller/ServiceController.java
@@ -24,6 +24,7 @@ import io.getlime.security.powerauth.lib.nextstep.model.response.ServiceStatusRe
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -72,6 +73,7 @@ public class ServiceController {
      * Controller resource with system information.
      * @return System status info.
      */
+    @SecurityRequirements
     @Operation(summary = "Get service status")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Service status sent in response"),


### PR DESCRIPTION
When the Next Step is configured with `powerauth.nextstep.security.auth.type=OIDC`, it is expected an access token is included in the request header. This PR enhances the generated swagger, when the auth type is set to OIDC as follows:

```yaml
security:
    - bearerAuth: []
    
components:
    securitySchemes:
        bearerAuth:
            type: http
            scheme: bearer
            bearerFormat: JWT
```



In case of `powerauth.nextstep.security.auth.type=NONE` (by default), no change is visible.