### PR TITLE
Fix #1879: Request processing failed: java.lang.IllegalArgumentException: argument "content" is null

### DIFF
--- a/powerauth-nextstep-client/src/main/java/io/getlime/security/powerauth/lib/nextstep/client/NextStepClientException.java
+++ b/powerauth-nextstep-client/src/main/java/io/getlime/security/powerauth/lib/nextstep/client/NextStepClientException.java
@@ -99,6 +99,10 @@ public class NextStepClientException extends Exception {
             logger.trace("Wultra Java Core lib did not parse ErrorResponse for {}", ex.getResponse());
             try {
                 // TODO (racansky, 2022-12-06) workaround until https://github.com/wultra/lime-java-core/issues/32
+                if (ex.getResponse() == null) {
+                    logger.warn("No response received during REST client call");
+                    return null;
+                }
                 ErrorResponse errorResponse = objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES).readValue(ex.getResponse(), ErrorResponse.class);
                 if (errorResponse != null && errorResponse.getResponseObject() != null) {
                     switch (errorResponse.getResponseObject().getCode()) {


### PR DESCRIPTION
The deserialization error is fixed and original exception is logged, e.g. 

```
Caused by: com.wultra.core.rest.client.base.RestClientException: HTTP GET request failed
	at com.wultra.core.rest.client.base.DefaultRestClient.get(DefaultRestClient.java:317) ~[rest-client-base-1.12.0.jar:na]
	at com.wultra.core.rest.client.base.DefaultRestClient.getObject(DefaultRestClient.java:361) ~[rest-client-base-1.12.0.jar:na]
	at io.getlime.security.powerauth.lib.nextstep.client.NextStepClient.getObjectImpl(NextStepClient.java:3249) ~[powerauth-nextstep-client-1.10.1-SNAPSHOT.jar:1.10.1-SNAPSHOT]
	... 202 common frames omitted
Caused by: org.springframework.web.reactive.function.client.WebClientRequestException: Failed to resolve '...' [A(1)] after 2 queries 
```