### PR TITLE
Fix #1954: Refactor LDAP configuration

### DIFF
--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/configuration/NextStepLdapConfiguration.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/configuration/NextStepLdapConfiguration.java
@@ -1,0 +1,77 @@
+/*
+ * PowerAuth Web Flow and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.app.nextstep.configuration;
+
+import io.getlime.security.powerauth.app.nextstep.service.DefaultLdapVerifierService;
+import io.getlime.security.powerauth.app.nextstep.service.LdapVerifierService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.ldap.core.LdapTemplate;
+import org.springframework.ldap.core.support.LdapContextSource;
+import org.springframework.util.StringUtils;
+
+import java.util.Map;
+
+/**
+ * LDAP configuration for Next Step server.
+ *
+ * @author Lubos Racansky, lubos.racansky@wultra.com
+ */
+@Configuration
+@ConditionalOnProperty(name = "powerauth.nextstep.ldap.enabled", havingValue = "true")
+@EnableConfigurationProperties(NextStepLdapConfigurationProperties.class)
+@Slf4j
+public class NextStepLdapConfiguration {
+
+    @Bean
+    public LdapVerifierService ldapVerifierService(final NextStepLdapConfigurationProperties configuration, final LdapTemplate ldapTemplate) {
+        logger.info("Initializing DefaultLdapVerifierService");
+        return new DefaultLdapVerifierService(configuration, ldapTemplate);
+    }
+
+    @Bean
+    public LdapContextSource contextSource(final NextStepLdapConfigurationProperties configuration) {
+        final LdapContextSource cs = new LdapContextSource();
+        cs.setUrl(configuration.getUrl());
+        cs.setBase(configuration.getBase());
+        if (StringUtils.hasText(configuration.getManagerDn())) {
+            cs.setUserDn(configuration.getManagerDn());
+        }
+        if (StringUtils.hasText(configuration.getManagerPassword())) {
+            cs.setPassword(configuration.getManagerPassword());
+        }
+        cs.setPooled(configuration.isPooled());
+        cs.setAnonymousReadOnly(configuration.isAnonymousReadOnly());
+
+        final Map<String, Object> env = Map.of(
+            "com.sun.jndi.ldap.connect.timeout", String.valueOf(configuration.getConnectTimeout().toMillis()),
+            "com.sun.jndi.ldap.read.timeout", String.valueOf(configuration.getReadTimeout().toMillis()));
+        cs.setBaseEnvironmentProperties(env);
+
+        cs.afterPropertiesSet();
+        return cs;
+    }
+
+    @Bean
+    public LdapTemplate ldapTemplate(final LdapContextSource cs) {
+        return new LdapTemplate(cs);
+    }
+}

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/configuration/NextStepLdapConfigurationProperties.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/configuration/NextStepLdapConfigurationProperties.java
@@ -1,0 +1,55 @@
+/*
+ * PowerAuth Web Flow and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.app.nextstep.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+/**
+ * LDAP configuration properties.
+ *
+ * @author Lubos Racansky, lubos.racansky@wultra.com
+ */
+@ConfigurationProperties(prefix = "powerauth.nextstep.ldap")
+@Getter
+@Setter
+public class NextStepLdapConfigurationProperties {
+
+    private String url;
+
+    private String base;
+
+    private String managerDn;
+
+    private String managerPassword;
+
+    private boolean pooled;
+
+    private boolean anonymousReadOnly;
+
+    private String userSearchBase;
+
+    private String userSearchFilter;
+
+    private Duration connectTimeout;
+
+    private Duration readTimeout;
+}

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/configuration/NextStepServerConfiguration.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/configuration/NextStepServerConfiguration.java
@@ -27,23 +27,22 @@ import com.wultra.security.powerauth.client.PowerAuthClient;
 import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
 import com.wultra.security.powerauth.rest.client.PowerAuthRestClient;
 import com.wultra.security.powerauth.rest.client.PowerAuthRestClientConfiguration;
+import io.getlime.security.powerauth.app.nextstep.repository.model.entity.CredentialEntity;
+import io.getlime.security.powerauth.app.nextstep.service.LdapVerifierService;
 import io.getlime.security.powerauth.lib.dataadapter.client.DataAdapterClient;
 import io.getlime.security.powerauth.lib.dataadapter.client.DataAdapterClientErrorException;
+import io.getlime.security.powerauth.lib.nextstep.model.entity.ExternalCredentialDetail;
+import io.getlime.security.powerauth.lib.nextstep.model.entity.enumeration.AuthenticationResult;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.ldap.core.LdapTemplate;
-import org.springframework.ldap.core.support.LdapContextSource;
-import org.springframework.util.StringUtils;
 
 import java.time.Duration;
-import java.util.Hashtable;
-import java.util.Map;
 
 /**
  * Configuration of Next Step server.
@@ -102,39 +101,6 @@ public class NextStepServerConfiguration {
 
     @Value("${powerauth.nextstep.db.master.encryption.key}")
     private String masterDbEncryptionKey;
-
-    /**
-     * Connection to LDAP setting.
-     */
-    @Value("${powerauth.nextstep.ldap.url}")
-    private String ldapUrl;
-
-    @Value("${powerauth.nextstep.ldap.base}")
-    private String ldapBase;
-
-    @Value("${powerauth.nextstep.ldap.managerDn}")
-    private String managerDn;
-
-    @Value("${powerauth.nextstep.ldap.managerPassword}")
-    private String managerPassword;
-
-    @Value("${powerauth.nextstep.ldap.pooled:false}")
-    private boolean ldapPooled;
-
-    @Value("${powerauth.nextstep.ldap.anonymousReadOnly:false}")
-    private boolean ldapAnonymousReadOnly;
-
-    @Value("${powerauth.nextstep.ldap.userSearchBase}")
-    private String userSearchBase;
-
-    @Value("${powerauth.nextstep.ldap.userSearchFilter}")
-    private String userSearchFilter;
-
-    @Value("${powerauth.nextstep.ldap.connectTimeout:5000}")
-    private int ldapConnectTimeoutMs;
-
-    @Value("${powerauth.nextstep.ldap.readTimeout:5000}")
-    private int ldapReadTimeoutMs;
 
     /**
      * Application name.
@@ -237,22 +203,6 @@ public class NextStepServerConfiguration {
     }
 
     /**
-     * Get configured base filter for finding user in LDAP.
-     * @return userSearchBase .
-     */
-    public String getUserSearchBase() {
-        return userSearchBase;
-    }
-
-    /**
-     * Get configured filter for finding user in LDAP.
-     * @return userSearchFilter
-     */
-    public String getUserSearchFilter() {
-        return userSearchFilter;
-    }
-
-    /**
      * Default data adapter client.
      *
      * @return Data adapter client.
@@ -307,38 +257,20 @@ public class NextStepServerConfiguration {
         return auditFactory.getAudit();
     }
 
-    /**
-     * Configure LDAP context source
-     * @return LDAP context source.
-     */
-    @ConditionalOnProperty(prefix = "powerauth.nextstep.ldap", name = "enabled", havingValue = "true")
     @Bean
-    public LdapContextSource contextSource() {
-        final LdapContextSource cs = new LdapContextSource();
-        cs.setUrl(ldapUrl);
-        cs.setBase(ldapBase);
-        if (StringUtils.hasText(managerDn)) {
-            cs.setUserDn(managerDn);
-        }
-        if (StringUtils.hasText(managerPassword)) {
-            cs.setPassword(managerPassword);
-        }
-        cs.setPooled(ldapPooled);
-        cs.setAnonymousReadOnly(ldapAnonymousReadOnly);
+    @ConditionalOnMissingBean(LdapVerifierService.class)
+    public LdapVerifierService emptyLdapVerifierService() {
+        logger.info("Initializing EmptyLdapVerifierService");
+        return new LdapVerifierService() {
+            @Override
+            public AuthenticationResult verifyCredential(final CredentialEntity credential, final String credentialValue) {
+                throw new IllegalStateException("LDAP is disabled.");
+            }
 
-        final Map<String, Object> env = new Hashtable<>();
-        env.put("com.sun.jndi.ldap.connect.timeout", String.valueOf(ldapConnectTimeoutMs));
-        env.put("com.sun.jndi.ldap.read.timeout", String.valueOf(ldapReadTimeoutMs));
-        cs.setBaseEnvironmentProperties(env);
-
-        cs.afterPropertiesSet();
-        return cs;
+            @Override
+            public ExternalCredentialDetail readCredentialExternalStatus(final CredentialEntity credential) {
+                throw new IllegalStateException("LDAP is disabled.");
+            }
+        };
     }
-
-    @ConditionalOnProperty(prefix = "powerauth.nextstep.ldap", name = "enabled", havingValue = "true")
-    @Bean
-    public LdapTemplate ldapTemplate(LdapContextSource cs) {
-        return new LdapTemplate(cs);
-    }
-
 }

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/DefaultLdapVerifierService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/DefaultLdapVerifierService.java
@@ -1,0 +1,151 @@
+/*
+ * PowerAuth Web Flow and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.app.nextstep.service;
+
+import io.getlime.security.powerauth.app.nextstep.configuration.NextStepLdapConfigurationProperties;
+import io.getlime.security.powerauth.app.nextstep.repository.model.entity.CredentialEntity;
+import io.getlime.security.powerauth.lib.nextstep.model.entity.ExternalCredentialDetail;
+import io.getlime.security.powerauth.lib.nextstep.model.entity.enumeration.AuthenticationResult;
+import io.getlime.security.powerauth.lib.nextstep.model.entity.enumeration.CredentialStatus;
+import io.getlime.security.powerauth.lib.nextstep.model.exception.InvalidRequestException;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.ldap.NamingException;
+import org.springframework.ldap.core.AttributesMapper;
+import org.springframework.ldap.core.LdapTemplate;
+import org.springframework.ldap.query.LdapQuery;
+import org.springframework.ldap.query.LdapQueryBuilder;
+import org.springframework.ldap.query.SearchScope;
+
+import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
+
+import static org.springframework.ldap.query.LdapQueryBuilder.query;
+
+/**
+ * Specialization of {@link LdapVerifierService} which uses Next Step configuration for LDAP.
+ *
+ * @author Zdenek Cerny, zdenek.cerny@wultra.com
+ */
+@Slf4j
+@AllArgsConstructor
+public class DefaultLdapVerifierService implements LdapVerifierService {
+
+    private static final String CONFIG_ERROR = "LDAP_NOT_CONFIGURED";
+    private static final String ACCOUNT_LOCK_ATTRIBUTE = "nsAccountLock";
+    private static final String PASSWORD_RETRY_COUNT_ATTRIBUTE = "passwordRetryCount";
+    private static final String PASSWORD_EXPIRATION_TIME = "passwordExpirationTime";
+
+    private final NextStepLdapConfigurationProperties configuration;
+
+    private final LdapTemplate ldapTemplate;
+
+    private String resolveUserSearchBase(CredentialEntity credential) {
+
+        final String userSearchBase;
+        // base search for user can be configured per customer or on server level
+        if (credential.getExternalReference() != null) {
+            userSearchBase = credential.getExternalReference();
+        } else {
+            userSearchBase = configuration.getUserSearchBase();
+        }
+        return userSearchBase;
+    }
+
+    @Override
+    public AuthenticationResult verifyCredential(CredentialEntity credential, String credentialValue) throws InvalidRequestException {
+        try {
+            final String userSearchBase = resolveUserSearchBase(credential);
+            if (userSearchBase == null) {
+                logger.error("action: verifyCredential, state: failed, reason: {}", CONFIG_ERROR);
+                throw new InvalidRequestException(CONFIG_ERROR);
+            }
+
+            // Build a search query to find the user entry
+            final LdapQuery query = query()
+                    .base(userSearchBase)
+                    .searchScope(SearchScope.SUBTREE)
+                    .filter(configuration.getUserSearchFilter(), credential.getUser().getUserId());
+            // Spring LDAP will do: search -> resolve DN -> attempt bind with that DN+password
+            ldapTemplate.authenticate(query, credentialValue);
+            return AuthenticationResult.SUCCEEDED;
+        } catch (EmptyResultDataAccessException | NamingException e) {
+            logger.warn("action: verifyCredential, state: failed, reason: {}", e.getMessage(), e);
+            return AuthenticationResult.FAILED;
+        }
+    }
+
+    private static Boolean getBoolAttrSafe(Attributes attrs, String name)  {
+        try {
+            final Attribute a = attrs.get(name);
+            if (a == null) {
+                return null;
+            }
+            return Boolean.parseBoolean(a.get().toString());
+        } catch (javax.naming.NamingException e) {
+            return null;
+        }
+    }
+
+    private static Integer getIntAttrSafe(Attributes attrs, String name)  {
+        try {
+            final Attribute a = attrs.get(name);
+            if (a == null) {
+                return null;
+            }
+            return Integer.valueOf(a.get().toString());
+        } catch (javax.naming.NamingException | NumberFormatException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public ExternalCredentialDetail readCredentialExternalStatus(CredentialEntity credential) throws InvalidRequestException {
+        final String userSearchBase = resolveUserSearchBase(credential);
+
+        if (userSearchBase == null) {
+            logger.error("action: readCredentialExternalStatus, state: failed, reason: {}", CONFIG_ERROR);
+            throw new InvalidRequestException(CONFIG_ERROR);
+        }
+        final var query = LdapQueryBuilder.query()
+                .base(userSearchBase)
+                .attributes(PASSWORD_RETRY_COUNT_ATTRIBUTE, ACCOUNT_LOCK_ATTRIBUTE, PASSWORD_EXPIRATION_TIME)
+                .filter(configuration.getUserSearchFilter(), credential.getUser().getUserId());
+
+        return ldapTemplate.search(query, attributeMapper()).stream()
+                .findFirst()
+                .orElse(new ExternalCredentialDetail());
+    }
+
+    private static AttributesMapper<ExternalCredentialDetail> attributeMapper() {
+        return attrs -> {
+            final ExternalCredentialDetail externalCredentialDetail = new ExternalCredentialDetail();
+
+            final Boolean blocked = getBoolAttrSafe(attrs, ACCOUNT_LOCK_ATTRIBUTE);
+            if (blocked != null) {
+                externalCredentialDetail.setCredentialStatus(blocked ? CredentialStatus.BLOCKED_TEMPORARY : CredentialStatus.ACTIVE);
+            }
+
+            final Integer attemptCounter = getIntAttrSafe(attrs, PASSWORD_RETRY_COUNT_ATTRIBUTE);
+            externalCredentialDetail.setFailedAttempts(attemptCounter);
+
+            return externalCredentialDetail;
+        };
+    }
+}

--- a/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/LdapVerifierService.java
+++ b/powerauth-nextstep/src/main/java/io/getlime/security/powerauth/app/nextstep/service/LdapVerifierService.java
@@ -17,64 +17,17 @@
  */
 package io.getlime.security.powerauth.app.nextstep.service;
 
-import io.getlime.security.powerauth.app.nextstep.configuration.NextStepServerConfiguration;
 import io.getlime.security.powerauth.app.nextstep.repository.model.entity.CredentialEntity;
 import io.getlime.security.powerauth.lib.nextstep.model.entity.ExternalCredentialDetail;
 import io.getlime.security.powerauth.lib.nextstep.model.entity.enumeration.AuthenticationResult;
-import io.getlime.security.powerauth.lib.nextstep.model.entity.enumeration.CredentialStatus;
 import io.getlime.security.powerauth.lib.nextstep.model.exception.InvalidRequestException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.ldap.NamingException;
-import org.springframework.ldap.core.LdapTemplate;
-import org.springframework.ldap.query.LdapQuery;
-import org.springframework.ldap.query.LdapQueryBuilder;
-import org.springframework.ldap.query.SearchScope;
-import org.springframework.ldap.core.AttributesMapper;
-import org.springframework.stereotype.Service;
-
-import javax.naming.directory.Attribute;
-import javax.naming.directory.Attributes;
-
-import static org.springframework.ldap.query.LdapQueryBuilder.query;
 
 /**
  * Service for verifying credentials and reading external credential status using LDAP.
  *
- * @author Zdenek Cerny, zdenek.cerny@wultra.com
+ * @author Lubos Racansky, lubos.racansky@wultra.com
  */
-@Service
-public class LdapVerifierService {
-
-    private final Logger logger = LoggerFactory.getLogger(LdapVerifierService.class);
-    private static final String CONFIG_ERROR = "LDAP_NOT_CONFIGURED";
-    private static final String ACCOUNT_LOCK_ATTRIBUTE = "nsAccountLock";
-    private static final String PASSWORD_RETRY_COUNT_ATTRIBUTE = "passwordRetryCount";
-    private static final String PASSWORD_EXPIRATION_TIME = "passwordExpirationTime";
-
-    private final NextStepServerConfiguration nextStepServerConfiguration;
-
-    private final LdapTemplate ldapTemplate;
-
-    @Autowired
-    public LdapVerifierService(NextStepServerConfiguration nextStepServerConfiguration, LdapTemplate ldapTemplate) {
-        this.nextStepServerConfiguration = nextStepServerConfiguration;
-        this.ldapTemplate = ldapTemplate;
-    }
-
-    private String resolveUserSearchBase(CredentialEntity credential) {
-
-        final String userSearchBase;
-        // base search for user can be configured per customer or on server level
-        if (credential.getExternalReference() != null) {
-            userSearchBase = credential.getExternalReference();
-        } else {
-            userSearchBase = nextStepServerConfiguration.getUserSearchBase();
-        }
-        return userSearchBase;
-    }
+public interface LdapVerifierService {
 
     /**
      * Verifies credential in configured LDAP.
@@ -83,51 +36,7 @@ public class LdapVerifierService {
      * @param credentialValue credential value to verify.
      * @return result of authentication, i.e. FAILED or SUCCEEDED
      */
-    public AuthenticationResult verifyCredential(CredentialEntity credential, String credentialValue) throws InvalidRequestException {
-        try {
-            final String userSearchBase = resolveUserSearchBase(credential);
-            if (userSearchBase == null) {
-                logger.error("action: verifyCredential, state: failed, reason: {}", CONFIG_ERROR);
-                throw new InvalidRequestException(CONFIG_ERROR);
-            }
-
-            // Build a search query to find the user entry
-            LdapQuery query = query()
-                    .base(userSearchBase)
-                    .searchScope(SearchScope.SUBTREE)
-                    .filter(nextStepServerConfiguration.getUserSearchFilter(), credential.getUser().getUserId());
-            // Spring LDAP will do: search -> resolve DN -> attempt bind with that DN+password
-            ldapTemplate.authenticate(query, credentialValue);
-            return AuthenticationResult.SUCCEEDED;
-        } catch (EmptyResultDataAccessException | NamingException e) {
-            logger.warn("action: verifyCredential, state: failed, reason: {}", e.getMessage(), e);
-            return AuthenticationResult.FAILED;
-        }
-    }
-
-    private static Boolean getBoolAttrSafe(Attributes attrs, String name)  {
-        try {
-            Attribute a = attrs.get(name);
-            if (a == null) {
-                return null;
-            }
-            return Boolean.parseBoolean(a.get().toString());
-        } catch (javax.naming.NamingException e) {
-            return null;
-        }
-    }
-
-    private static Integer getIntAttrSafe(Attributes attrs, String name)  {
-        try {
-            Attribute a = attrs.get(name);
-            if (a == null) {
-                return null;
-            }
-            return Integer.valueOf(a.get().toString());
-        } catch (javax.naming.NamingException | NumberFormatException e) {
-            return null;
-        }
-    }
+    AuthenticationResult verifyCredential(CredentialEntity credential, String credentialValue) throws InvalidRequestException;
 
     /**
      * Get attempt counter from LDAP
@@ -135,30 +44,5 @@ public class LdapVerifierService {
      * @param credential credentials to get attributes for - credentials can have set up special base search to override server configuration.
      * @return number of attempts.
      */
-    public ExternalCredentialDetail readCredentialExternalStatus(CredentialEntity credential) throws InvalidRequestException {
-        final String userSearchBase = resolveUserSearchBase(credential);
-
-        if (userSearchBase == null) {
-            logger.error("action: readCredentialExternalStatus, state: failed, reason: {}", CONFIG_ERROR);
-            throw new InvalidRequestException(CONFIG_ERROR);
-        }
-        var query = LdapQueryBuilder.query()
-                .base(userSearchBase)
-                .attributes(PASSWORD_RETRY_COUNT_ATTRIBUTE, ACCOUNT_LOCK_ATTRIBUTE, PASSWORD_EXPIRATION_TIME)
-                .filter(nextStepServerConfiguration.getUserSearchFilter(), credential.getUser().getUserId());
-
-        return ldapTemplate.search(query, (AttributesMapper<ExternalCredentialDetail>) attrs -> {
-            ExternalCredentialDetail externalCredentialDetail = new ExternalCredentialDetail();
-
-            final Boolean blocked = getBoolAttrSafe(attrs, ACCOUNT_LOCK_ATTRIBUTE);
-            if (blocked != null) {
-                externalCredentialDetail.setCredentialStatus(blocked ? CredentialStatus.BLOCKED_TEMPORARY : CredentialStatus.ACTIVE);
-            }
-
-            final Integer attemptCounter = getIntAttrSafe(attrs, PASSWORD_RETRY_COUNT_ATTRIBUTE);
-            externalCredentialDetail.setFailedAttempts(attemptCounter);
-
-            return externalCredentialDetail;
-        }).stream().findFirst().orElse(new ExternalCredentialDetail());
-    }
+    ExternalCredentialDetail readCredentialExternalStatus(CredentialEntity credential) throws InvalidRequestException;
 }

--- a/powerauth-nextstep/src/main/resources/application.properties
+++ b/powerauth-nextstep/src/main/resources/application.properties
@@ -100,4 +100,4 @@ powerauth.nextstep.ldap.readTimeout=${NEXTSTEP_LDAP_READTIMEOUT:5000}
 
 spring.autoconfigure.exclude=\
   org.springframework.boot.actuate.autoconfigure.metrics.jersey.JerseyServerMetricsAutoConfiguration, \
-  org.springframework.boot.actuate.autoconfigure.ldap.LdapHealthContributorAutoConfiguration
+  org.springframework.boot.autoconfigure.ldap.LdapAutoConfiguration


### PR DESCRIPTION
Even though `powerauth.nextstep.ldap.enabled` is set to `false`, Spring Boot autoconfigures the LDAP.
Refactor to configure LDAP only if the feature is enabled, and also allow health check monitoring in that case.
Last, but not least, providing an empty implementation of `LdapVerifierService`.