### PR TITLE
Fix #2059: JSON Logging Foundation

### DIFF
--- a/powerauth-nextstep/docker/conf/logback/ns-logback.xml
+++ b/powerauth-nextstep/docker/conf/logback/ns-logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <springProperty scope="context" name="appname" source="spring.application.name"/>
+    <springProperty scope="context" name="appname" source="spring.application.name" defaultValue="unknown"/>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <includeMdc>true</includeMdc>

--- a/powerauth-nextstep/docker/conf/logback/ns-logback.xml
+++ b/powerauth-nextstep/docker/conf/logback/ns-logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <springProperty scope="context" name="appname" source="spring.application.name"/>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeMdc>true</includeMdc>
+            <omitEmptyFields>true</omitEmptyFields>
+            <customFields>{"appname":"${appname}"}</customFields>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/powerauth-tpp-engine/docker/conf/logback/tpp-logback.xml
+++ b/powerauth-tpp-engine/docker/conf/logback/tpp-logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <springProperty scope="context" name="appname" source="spring.application.name"/>
+    <springProperty scope="context" name="appname" source="spring.application.name" defaultValue="unknown"/>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <includeMdc>true</includeMdc>

--- a/powerauth-tpp-engine/docker/conf/logback/tpp-logback.xml
+++ b/powerauth-tpp-engine/docker/conf/logback/tpp-logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <springProperty scope="context" name="appname" source="spring.application.name"/>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeMdc>true</includeMdc>
+            <omitEmptyFields>true</omitEmptyFields>
+            <customFields>{"appname":"${appname}"}</customFields>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/powerauth-webflow-client/docker/conf/logback/pwfc-logback.xml
+++ b/powerauth-webflow-client/docker/conf/logback/pwfc-logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <springProperty scope="context" name="appname" source="spring.application.name"/>
+    <springProperty scope="context" name="appname" source="spring.application.name" defaultValue="unknown"/>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <includeMdc>true</includeMdc>

--- a/powerauth-webflow-client/docker/conf/logback/pwfc-logback.xml
+++ b/powerauth-webflow-client/docker/conf/logback/pwfc-logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <springProperty scope="context" name="appname" source="spring.application.name"/>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeMdc>true</includeMdc>
+            <omitEmptyFields>true</omitEmptyFields>
+            <customFields>{"appname":"${appname}"}</customFields>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/powerauth-webflow/docker/conf/logback/pwf-logback.xml
+++ b/powerauth-webflow/docker/conf/logback/pwf-logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <springProperty scope="context" name="appname" source="spring.application.name"/>
+    <springProperty scope="context" name="appname" source="spring.application.name" defaultValue="unknown"/>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <includeMdc>true</includeMdc>

--- a/powerauth-webflow/docker/conf/logback/pwf-logback.xml
+++ b/powerauth-webflow/docker/conf/logback/pwf-logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <springProperty scope="context" name="appname" source="spring.application.name"/>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeMdc>true</includeMdc>
+            <omitEmptyFields>true</omitEmptyFields>
+            <customFields>{"appname":"${appname}"}</customFields>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary

Fixes #2059 — JSON Logging Foundation for `powerauth-webflow`.

### Changes

- **L2**: Create logback JSON configs for all 4 deployable modules — each using `<springProperty>` sourced from `spring.application.name` and `<omitEmptyFields>true</omitEmptyFields>`

### Affected files

- `powerauth-nextstep/docker/conf/logback/ns-logback.xml` *(new)*
- `powerauth-webflow/docker/conf/logback/pwf-logback.xml` *(new)*
- `powerauth-tpp-engine/docker/conf/logback/tpp-logback.xml` *(new)*
- `powerauth-webflow-client/docker/conf/logback/pwfc-logback.xml` *(new)*

### Notes

- All 4 modules already have `spring.application.name` and `logging.config` configured — no L1 changes needed ✅
- `logstash-logback-encoder` version `8.1` is already the latest — no version bump needed ✅

### References

- Issue: #2059
- Epic: wultra/tasklist#863 (JSON Logging Foundation)
- Logging Guideline: https://github.com/wultra/development-internal/wiki/Logging-Guideline

---

### Follow-up: defaultValue for springProperty

Added `defaultValue="unknown"` to `<springProperty>` in all logback configs.

`<springProperty>` is fully supported when the config is loaded via Spring Boot's Logback configurator (standard production path via `logging.config`). The `defaultValue` is a safety net for the edge case where the file is loaded as a plain Logback config outside of Spring Boot — in that scenario `spring.application.name` cannot be resolved and the fallback prevents `appname_IS_UNDEFINED` appearing in log output.