### PR TITLE
fix #2077: register lombok annotation processor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -329,6 +329,19 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <executions>
                     <execution>


### PR DESCRIPTION
## Description

Registered Lombok as an explicit annotation processor in the root Maven compiler plugin configuration.

## Motivation and Context

Java 25 no longer enables implicit annotation processor discovery by default, so Lombok-generated members may be unavailable during compilation. Explicitly configuring Lombok in `annotationProcessorPaths` keeps local Java 25 builds working.

## Closes

Closes #2077